### PR TITLE
fix: Preserve case sensitivity for VCF INFO and FORMAT fields

### DIFF
--- a/datafusion/bio-format-vcf/src/table_provider.rs
+++ b/datafusion/bio-format-vcf/src/table_provider.rs
@@ -50,7 +50,8 @@ async fn determine_schema_from_header(
                 let dtype = info_to_arrow_type(&header_infos, &tag);
                 let info = header_infos.get(tag.as_str()).unwrap();
                 let nullable = is_nullable(&info.ty());
-                fields.push(Field::new(tag.to_lowercase(), dtype, nullable));
+                // Preserve case sensitivity for INFO fields to avoid conflicts
+                fields.push(Field::new(tag.clone(), dtype, nullable));
             }
         }
         _ => {}
@@ -60,11 +61,8 @@ async fn determine_schema_from_header(
         Some(formats) => {
             for tag in formats {
                 let dtype = format_to_arrow_type(&header_formats, &tag);
-                fields.push(Field::new(
-                    format!("format_{}", tag.to_lowercase()),
-                    dtype,
-                    true,
-                ));
+                // Preserve case sensitivity for FORMAT fields
+                fields.push(Field::new(format!("format_{}", tag), dtype, true));
             }
         }
         _ => {}


### PR DESCRIPTION
This change preserves the original case of INFO and FORMAT field names in VCF files instead of converting them to lowercase. This fixes a critical issue where INFO fields with uppercase names (e.g., "END") would conflict with standard VCF columns (e.g., "end") after being converted to lowercase, causing schema errors.

Changes:
- Remove .to_lowercase() calls for INFO field names
- Remove .to_lowercase() calls for FORMAT field names
- Add comments explaining the case preservation

This ensures that field names maintain their original case as specified in the VCF header, preventing name collisions and maintaining VCF spec compliance.

Fixes issue #248 in polars-bio where DeepVariant VCF files with END INFO field could not be read due to duplicate "end" field names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)