### PR TITLE
fix: Preserve MAPQ 255, QNAME *, and add template_length column

### DIFF
--- a/datafusion/bio-format-bam/src/serializer.rs
+++ b/datafusion/bio-format-bam/src/serializer.rs
@@ -59,6 +59,7 @@ pub fn batch_to_bam_records(
     let mate_starts = get_u32_column_by_name(batch, "mate_start")?;
     let sequences = get_string_column_by_name(batch, "sequence")?;
     let quality_scores = get_string_column_by_name(batch, "quality_scores")?;
+    let template_lengths = get_i32_column_by_name(batch, "template_length")?;
 
     // Build tag column map
     let tag_columns = build_tag_column_map(batch, tag_fields);
@@ -78,6 +79,7 @@ pub fn batch_to_bam_records(
             mate_starts,
             sequences,
             quality_scores,
+            template_lengths,
             &ref_map,
             batch,
             tag_fields,
@@ -104,6 +106,7 @@ fn build_single_record(
     mate_starts: &UInt32Array,
     sequences: &StringArray,
     quality_scores: &StringArray,
+    template_lengths: &Int32Array,
     ref_map: &HashMap<String, usize>,
     batch: &RecordBatch,
     tag_fields: &[String],
@@ -113,8 +116,8 @@ fn build_single_record(
     // Create a new mutable BAM record
     let mut record = RecordBuf::default();
 
-    // 1. QNAME (read name)
-    let name = if names.is_null(row) {
+    // 1. QNAME (read name) - "*" means unavailable; convert back to None for noodles
+    let name = if names.is_null(row) || names.value(row) == "*" {
         None
     } else {
         Some(names.value(row).as_bytes().to_vec().into())
@@ -151,12 +154,8 @@ fn build_single_record(
     };
     *record.alignment_start_mut() = alignment_start;
 
-    // 5. MAPQ (mapping quality)
-    let mapq = if mapping_qualities.is_null(row) {
-        sam::alignment::record::MappingQuality::new(255) // Unknown
-    } else {
-        sam::alignment::record::MappingQuality::new(mapping_qualities.value(row) as u8)
-    };
+    // 5. MAPQ (mapping quality) - non-nullable, 255 means unavailable per SAM spec
+    let mapq = sam::alignment::record::MappingQuality::new(mapping_qualities.value(row) as u8);
     *record.mapping_quality_mut() = mapq;
 
     // 6. CIGAR
@@ -193,8 +192,8 @@ fn build_single_record(
     };
     *record.mate_alignment_start_mut() = mate_alignment_start;
 
-    // 9. TLEN (template length) - not stored in our schema, default to 0
-    *record.template_length_mut() = 0;
+    // 9. TLEN (template length)
+    *record.template_length_mut() = template_lengths.value(row);
 
     // 10. SEQ (sequence)
     let seq_str = sequences.value(row);
@@ -436,6 +435,18 @@ fn get_u32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a 
         .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be UInt32 type", name)))
 }
 
+/// Gets an i32 column from the batch by name
+fn get_i32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int32Array> {
+    let idx = batch.schema().index_of(name).map_err(|_| {
+        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+    })?;
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be Int32 type", name)))
+}
+
 /// Builds a map from tag name to column index
 fn build_tag_column_map(batch: &RecordBatch, tag_fields: &[String]) -> HashMap<String, usize> {
     let mut map = HashMap::new();
@@ -522,6 +533,7 @@ mod tests {
             Field::new("mate_start", DataType::UInt32, true),
             Field::new("sequence", DataType::Utf8, false),
             Field::new("quality_scores", DataType::Utf8, false),
+            Field::new("template_length", DataType::Int32, false),
         ]));
 
         // Create test data
@@ -549,6 +561,7 @@ mod tests {
                 Arc::new(mate_starts),
                 Arc::new(sequences),
                 Arc::new(quality_scores),
+                Arc::new(Int32Array::from(vec![0i32])),
             ],
         )
         .unwrap();

--- a/datafusion/bio-format-bam/src/table_provider.rs
+++ b/datafusion/bio-format-bam/src/table_provider.rs
@@ -42,11 +42,12 @@ fn determine_schema(
         Field::new("end", DataType::UInt32, true),
         Field::new("flags", DataType::UInt32, false), //FIXME:: optimize storage
         Field::new("cigar", DataType::Utf8, false),
-        Field::new("mapping_quality", DataType::UInt32, true),
+        Field::new("mapping_quality", DataType::UInt32, false),
         Field::new("mate_chrom", DataType::Utf8, true),
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
     ];
 
     // Add tag fields if specified
@@ -108,11 +109,12 @@ async fn determine_schema_from_file(
         Field::new("end", DataType::UInt32, true),
         Field::new("flags", DataType::UInt32, false),
         Field::new("cigar", DataType::Utf8, false),
-        Field::new("mapping_quality", DataType::UInt32, true),
+        Field::new("mapping_quality", DataType::UInt32, false),
         Field::new("mate_chrom", DataType::Utf8, true),
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
     ];
 
     use crate::storage::{SamReader, is_sam_file};
@@ -317,7 +319,7 @@ impl BamTableProvider {
     /// * `coordinate_system_zero_based` - If true (default), output 0-based half-open coordinates;
     ///   if false, output 1-based closed coordinates
     /// * `tag_fields` - Optional list of BAM alignment tag names to include as columns.
-    ///   `None` = no tags included (only 11 core fields),
+    ///   `None` = no tags included (only 12 core fields),
     ///   `Some(vec!["NM", "MD", "AS"])` = include specified tags as columns
     ///
     /// # Returns
@@ -691,7 +693,7 @@ impl BamTableProvider {
             }
         }
 
-        // Add 11 core fields
+        // Add 12 core fields
         let core_fields = vec![
             (
                 "name",
@@ -707,7 +709,7 @@ impl BamTableProvider {
             (
                 "mapping_quality",
                 DataType::UInt32,
-                true,
+                false,
                 "Mapping quality (0-255)",
             ),
             (
@@ -723,6 +725,12 @@ impl BamTableProvider {
                 DataType::Utf8,
                 false,
                 "Base quality scores",
+            ),
+            (
+                "template_length",
+                DataType::Int32,
+                false,
+                "Template length (TLEN)",
             ),
         ];
 

--- a/datafusion/bio-format-bam/src/write_exec.rs
+++ b/datafusion/bio-format-bam/src/write_exec.rs
@@ -342,7 +342,7 @@ async fn write_bam_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{StringArray, UInt32Array};
+    use datafusion::arrow::array::{Int32Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::datasource::{MemTable, TableProvider};
     use datafusion::prelude::*;
@@ -363,6 +363,7 @@ mod tests {
             Field::new("mate_start", DataType::UInt32, true),
             Field::new("sequence", DataType::Utf8, false),
             Field::new("quality_scores", DataType::Utf8, false),
+            Field::new("template_length", DataType::Int32, false),
         ]));
 
         // Create test data
@@ -376,6 +377,7 @@ mod tests {
         let mate_starts = UInt32Array::from(vec![Option::<u32>::None, Option::<u32>::None]);
         let sequences = StringArray::from(vec!["ACGTACGTAC", "TGCATGCATG"]);
         let quality_scores = StringArray::from(vec!["!!!!!!!!!!", "!!!!!!!!!!"]);
+        let template_lengths = Int32Array::from(vec![0i32, 0i32]);
 
         let batch = RecordBatch::try_new(
             schema.clone(),
@@ -390,6 +392,7 @@ mod tests {
                 Arc::new(mate_starts),
                 Arc::new(sequences),
                 Arc::new(quality_scores),
+                Arc::new(template_lengths),
             ],
         )
         .unwrap();

--- a/datafusion/bio-format-bam/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-bam/tests/projection_pushdown_test.rs
@@ -45,8 +45,8 @@ async fn test_bam_plan_no_projection_select_star() -> Result<(), Box<dyn std::er
     let plan = df.create_physical_plan().await?;
     let leaf = find_leaf_exec(&plan);
     assert_eq!(leaf.name(), "BamExec");
-    // SELECT * should have all 11 core columns
-    assert_eq!(leaf.schema().fields().len(), 11);
+    // SELECT * should have all 12 core columns
+    assert_eq!(leaf.schema().fields().len(), 12);
     Ok(())
 }
 

--- a/datafusion/bio-format-bam/tests/tag_tests.rs
+++ b/datafusion/bio-format-bam/tests/tag_tests.rs
@@ -21,8 +21,8 @@ async fn test_bam_without_tags() {
     let df = ctx.table("bam").await.unwrap();
     let schema = df.schema();
 
-    // Should have 11 core fields only
-    assert_eq!(schema.fields().len(), 11);
+    // Should have 12 core fields only
+    assert_eq!(schema.fields().len(), 12);
     assert!(schema.field_with_name(None, "name").is_ok());
     assert!(schema.field_with_name(None, "chrom").is_ok());
     assert!(schema.field_with_name(None, "start").is_ok());
@@ -46,8 +46,8 @@ async fn test_bam_with_specified_tags() {
     let df = ctx.table("bam").await.unwrap();
     let schema = df.schema();
 
-    // Should have 11 core fields + 2 tag fields = 13
-    assert_eq!(schema.fields().len(), 13);
+    // Should have 12 core fields + 2 tag fields = 14
+    assert_eq!(schema.fields().len(), 14);
 
     // Verify tag fields are present
     assert!(schema.field_with_name(None, "NM").is_ok());
@@ -165,8 +165,8 @@ async fn test_unknown_tag_accepted() {
     let df = ctx.table("bam").await.unwrap();
     let schema = df.schema();
 
-    // Should have 11 core + 1 unknown tag = 12 fields
-    assert_eq!(schema.fields().len(), 12);
+    // Should have 12 core + 1 unknown tag = 13 fields
+    assert_eq!(schema.fields().len(), 13);
 
     // Verify unknown tag field is present with Utf8 type
     let unknown_field = schema.field_with_name(None, "UNKNOWN_TAG").unwrap();
@@ -209,8 +209,8 @@ async fn test_multiple_tags() {
     let df = ctx.table("bam").await.unwrap();
     let schema = df.schema();
 
-    // Should have 11 core + 4 tag fields = 15
-    assert_eq!(schema.fields().len(), 15);
+    // Should have 12 core + 4 tag fields = 16
+    assert_eq!(schema.fields().len(), 16);
     assert!(schema.field_with_name(None, "NM").is_ok());
     assert!(schema.field_with_name(None, "MD").is_ok());
     assert!(schema.field_with_name(None, "AS").is_ok());
@@ -231,8 +231,8 @@ async fn test_empty_tag_list() {
     let df = ctx.table("bam").await.unwrap();
     let schema = df.schema();
 
-    // Should have 11 core fields only
-    assert_eq!(schema.fields().len(), 11);
+    // Should have 12 core fields only
+    assert_eq!(schema.fields().len(), 12);
 }
 
 /// All 13 tags present in the bam_with_tags.bam test file
@@ -263,10 +263,10 @@ async fn test_read_all_13_tags() {
     let ctx = SessionContext::new();
     ctx.register_table("bam", Arc::new(provider)).unwrap();
 
-    // Verify schema: 11 core + 13 tags = 24 fields
+    // Verify schema: 12 core + 13 tags = 25 fields
     let df = ctx.table("bam").await.unwrap();
     let schema = df.schema();
-    assert_eq!(schema.fields().len(), 24);
+    assert_eq!(schema.fields().len(), 25);
 
     // Verify all tag fields are in schema with expected types
     use datafusion::arrow::datatypes::DataType;

--- a/datafusion/bio-format-bam/tests/write_test.rs
+++ b/datafusion/bio-format-bam/tests/write_test.rs
@@ -60,6 +60,7 @@ async fn test_tags_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
         Field::new("NM", DataType::Int32, true).with_metadata(tag_nm_metadata),
         Field::new("MD", DataType::Utf8, true).with_metadata(tag_md_metadata),
         Field::new("AS", DataType::Int32, true).with_metadata(tag_as_metadata),
@@ -87,6 +88,7 @@ async fn test_tags_round_trip() -> Result<(), Box<dyn std::error::Error>> {
                 "IIIIIIIIII",
                 "IIIIIIIIII",
             ])),
+            Arc::new(Int32Array::from(vec![0i32; 3])),
             // Tags
             Arc::new(Int32Array::from(vec![Some(2), Some(1), Some(0)])), // NM
             Arc::new(StringArray::from(vec![
@@ -207,6 +209,7 @@ async fn test_character_tags_round_trip() -> Result<(), Box<dyn std::error::Erro
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
         Field::new("XT", DataType::Utf8, true).with_metadata(tag_xt_metadata),
     ]));
 
@@ -224,6 +227,7 @@ async fn test_character_tags_round_trip() -> Result<(), Box<dyn std::error::Erro
             Arc::new(UInt32Array::from(vec![None::<u32>, None])),
             Arc::new(StringArray::from(vec!["ACGTACGTAC", "ACGTACGTAC"])),
             Arc::new(StringArray::from(vec!["IIIIIIIIII", "IIIIIIIIII"])),
+            Arc::new(Int32Array::from(vec![0i32; 2])),
             Arc::new(StringArray::from(vec![Some("U"), Some("R")])), // XT character tag
         ],
     )?;
@@ -308,6 +312,7 @@ async fn test_integer_array_tags_round_trip() -> Result<(), Box<dyn std::error::
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
         Field::new(
             "ZB",
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
@@ -335,6 +340,7 @@ async fn test_integer_array_tags_round_trip() -> Result<(), Box<dyn std::error::
             Arc::new(UInt32Array::from(vec![None::<u32>, None])),
             Arc::new(StringArray::from(vec!["ACGTACGTAC", "ACGTACGTAC"])),
             Arc::new(StringArray::from(vec!["IIIIIIIIII", "IIIIIIIIII"])),
+            Arc::new(Int32Array::from(vec![0i32; 2])),
             Arc::new(list_array),
         ],
     )?;
@@ -434,6 +440,7 @@ async fn test_byte_array_tags_round_trip() -> Result<(), Box<dyn std::error::Err
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
         Field::new(
             "ZC",
             DataType::List(Arc::new(Field::new("item", DataType::UInt8, true))),
@@ -461,6 +468,7 @@ async fn test_byte_array_tags_round_trip() -> Result<(), Box<dyn std::error::Err
             Arc::new(UInt32Array::from(vec![None::<u32>, None])),
             Arc::new(StringArray::from(vec!["ACGTACGTAC", "ACGTACGTAC"])),
             Arc::new(StringArray::from(vec!["IIIIIIIIII", "IIIIIIIIII"])),
+            Arc::new(Int32Array::from(vec![0i32; 2])),
             Arc::new(list_array),
         ],
     )?;
@@ -557,6 +565,7 @@ async fn test_float_tags_round_trip() -> Result<(), Box<dyn std::error::Error>> 
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
         Field::new("XS", DataType::Float32, true).with_metadata(tag_xs_metadata),
     ]));
 
@@ -574,6 +583,7 @@ async fn test_float_tags_round_trip() -> Result<(), Box<dyn std::error::Error>> 
             Arc::new(UInt32Array::from(vec![None::<u32>, None])),
             Arc::new(StringArray::from(vec!["ACGTACGTAC", "ACGTACGTAC"])),
             Arc::new(StringArray::from(vec!["IIIIIIIIII", "IIIIIIIIII"])),
+            Arc::new(Int32Array::from(vec![0i32; 2])),
             Arc::new(Float32Array::from(vec![Some(45.5), Some(38.2)])), // XS float tag
         ],
     )?;
@@ -649,6 +659,7 @@ async fn test_write_without_tags() -> Result<(), Box<dyn std::error::Error>> {
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
     ]));
 
     let batch = RecordBatch::try_new(
@@ -664,6 +675,7 @@ async fn test_write_without_tags() -> Result<(), Box<dyn std::error::Error>> {
             Arc::new(UInt32Array::from(vec![None::<u32>])),
             Arc::new(StringArray::from(vec!["ACGTACGTAC"])),
             Arc::new(StringArray::from(vec!["IIIIIIIIII"])),
+            Arc::new(Int32Array::from(vec![0i32; 1])),
         ],
     )?;
 
@@ -716,6 +728,7 @@ async fn test_sort_on_write_coordinate_order() -> Result<(), Box<dyn std::error:
             Field::new("mate_start", DataType::UInt32, true),
             Field::new("sequence", DataType::Utf8, false),
             Field::new("quality_scores", DataType::Utf8, false),
+            Field::new("template_length", DataType::Int32, false),
         ],
         schema_metadata,
     ));
@@ -742,6 +755,7 @@ async fn test_sort_on_write_coordinate_order() -> Result<(), Box<dyn std::error:
                 "IIIIIIIIII",
                 "IIIIIIIIII",
             ])),
+            Arc::new(Int32Array::from(vec![0i32; 3])),
         ],
     )?;
 
@@ -842,6 +856,7 @@ async fn test_sort_on_write_false_sets_unsorted() -> Result<(), Box<dyn std::err
             Field::new("mate_start", DataType::UInt32, true),
             Field::new("sequence", DataType::Utf8, false),
             Field::new("quality_scores", DataType::Utf8, false),
+            Field::new("template_length", DataType::Int32, false),
         ],
         schema_metadata,
     ));
@@ -859,6 +874,7 @@ async fn test_sort_on_write_false_sets_unsorted() -> Result<(), Box<dyn std::err
             Arc::new(UInt32Array::from(vec![None::<u32>])),
             Arc::new(StringArray::from(vec!["ACGTACGTAC"])),
             Arc::new(StringArray::from(vec!["IIIIIIIIII"])),
+            Arc::new(Int32Array::from(vec![0i32; 1])),
         ],
     )?;
 

--- a/datafusion/bio-format-cram/src/table_provider.rs
+++ b/datafusion/bio-format-cram/src/table_provider.rs
@@ -39,11 +39,12 @@ fn determine_schema(
         Field::new("end", DataType::UInt32, true),
         Field::new("flags", DataType::UInt32, false),
         Field::new("cigar", DataType::Utf8, false),
-        Field::new("mapping_quality", DataType::UInt32, true),
+        Field::new("mapping_quality", DataType::UInt32, false),
         Field::new("mate_chrom", DataType::Utf8, true),
         Field::new("mate_start", DataType::UInt32, true),
         Field::new("sequence", DataType::Utf8, false),
         Field::new("quality_scores", DataType::Utf8, false),
+        Field::new("template_length", DataType::Int32, false),
     ];
 
     // Add tag fields if specified
@@ -455,11 +456,12 @@ impl CramTableProvider {
             ("end", "UInt32", true, "Alignment end position"),
             ("flags", "UInt32", false, "SAM flags"),
             ("cigar", "Utf8", false, "CIGAR string"),
-            ("mapping_quality", "UInt32", true, "Mapping quality"),
+            ("mapping_quality", "UInt32", false, "Mapping quality"),
             ("mate_chrom", "Utf8", true, "Mate chromosome"),
             ("mate_start", "UInt32", true, "Mate start position"),
             ("sequence", "Utf8", false, "Read sequence"),
             ("quality_scores", "Utf8", false, "Quality scores"),
+            ("template_length", "Int32", false, "Template length (TLEN)"),
         ];
 
         for (name, dtype, is_null, desc) in core_fields {

--- a/datafusion/bio-format-cram/src/write_exec.rs
+++ b/datafusion/bio-format-cram/src/write_exec.rs
@@ -349,7 +349,7 @@ async fn write_cram_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{StringArray, UInt32Array};
+    use datafusion::arrow::array::{Int32Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::datasource::{MemTable, TableProvider};
     use datafusion::prelude::*;
@@ -370,6 +370,7 @@ mod tests {
             Field::new("mate_start", DataType::UInt32, true),
             Field::new("sequence", DataType::Utf8, false),
             Field::new("quality_scores", DataType::Utf8, false),
+            Field::new("template_length", DataType::Int32, false),
         ]));
 
         // Create test data with unmapped reads (no reference needed)
@@ -378,11 +379,12 @@ mod tests {
         let starts = UInt32Array::from(vec![Option::<u32>::None, Option::<u32>::None]);
         let flags = UInt32Array::from(vec![4u32, 4u32]); // 0x4 = unmapped
         let cigars = StringArray::from(vec!["*", "*"]);
-        let mapping_qualities = UInt32Array::from(vec![Option::<u32>::None, Option::<u32>::None]);
+        let mapping_qualities = UInt32Array::from(vec![0u32, 0u32]);
         let mate_chroms = StringArray::from(vec![Option::<&str>::None, Option::<&str>::None]);
         let mate_starts = UInt32Array::from(vec![Option::<u32>::None, Option::<u32>::None]);
         let sequences = StringArray::from(vec!["ACGTACGTAC", "TGCATGCATG"]);
         let quality_scores = StringArray::from(vec!["!!!!!!!!!!", "!!!!!!!!!!"]);
+        let template_lengths = Int32Array::from(vec![0i32, 0i32]);
 
         let batch = RecordBatch::try_new(
             schema.clone(),
@@ -397,6 +399,7 @@ mod tests {
                 Arc::new(mate_starts),
                 Arc::new(sequences),
                 Arc::new(quality_scores),
+                Arc::new(template_lengths),
             ],
         )
         .unwrap();

--- a/datafusion/bio-format-cram/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-cram/tests/projection_pushdown_test.rs
@@ -52,7 +52,7 @@ async fn test_cram_plan_no_projection_select_star() -> Result<(), Box<dyn std::e
     let plan = df.create_physical_plan().await?;
     let leaf = find_leaf_exec(&plan);
     assert_eq!(leaf.name(), "CramExec");
-    assert_eq!(leaf.schema().fields().len(), 11);
+    assert_eq!(leaf.schema().fields().len(), 12);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- **MAPQ 255 → stored as `255`** instead of `null`. Fixes [polars-bio#293](https://github.com/biodatageeks/polars-bio/issues/293). noodles' `MappingQuality::new(255)` returns `None` per SAM spec, but the raw byte is always present in BAM/CRAM/SAM. Tools like STAR use 255 legitimately. The `mapping_quality` column is now non-nullable `UInt32`.
- **QNAME `*` → stored as `"*"` string** instead of `null`. On write-back, `"*"` is converted back to `None` for noodles compatibility.
- **Added `template_length` (TLEN) column** as a non-nullable `Int32` field at index 11, shifting tag columns from index 11+ to 12+. Previously hardcoded to 0 on write; now round-trips correctly.

### Files changed (14 files, +444 −81)

| Area | Files |
|------|-------|
| Core | `alignment_utils.rs` — `RecordFields` struct, batch builder |
| BAM read | `physical_exec.rs` — BAM/SAM macros + indexed reader |
| CRAM read | `physical_exec.rs` — remote, local, indexed readers |
| BAM write | `serializer.rs`, `write_exec.rs` |
| CRAM write | `serializer.rs`, `write_exec.rs` |
| Schema | `table_provider.rs` (BAM + CRAM) |
| Tests | `sam_read_test.rs`, `write_test.rs`, `tag_tests.rs`, `projection_pushdown_test.rs` (BAM + CRAM) |

## Test plan

- [x] `cargo build` — passes
- [x] `cargo test` — all tests pass (0 failures across entire workspace)
- [x] `cargo clippy` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New test: `test_mapq_255_preserved` — SAM round-trip with MAPQ=255
- [x] New test: `test_name_star_preserved` — SAM round-trip with QNAME=*
- [x] New test: `test_template_length_round_trip` — SAM round-trip with positive/negative TLEN values

🤖 Generated with [Claude Code](https://claude.com/claude-code)