### PR TITLE
feat: Add optional binary CIGAR column for BAM/CRAM

### DIFF
--- a/benchmarks/runner/src/main.rs
+++ b/benchmarks/runner/src/main.rs
@@ -233,7 +233,7 @@ async fn register_table(
         }
         "bam" => {
             use datafusion_bio_format_bam::table_provider::BamTableProvider;
-            let provider = BamTableProvider::new(file_path.to_string(), None, true, None)
+            let provider = BamTableProvider::new(file_path.to_string(), None, true, None, false)
                 .await
                 .context("Failed to create BAM table provider")?;
             ctx.register_table(table_name, std::sync::Arc::new(provider))

--- a/datafusion/bio-format-bam/examples/benchmark_read.rs
+++ b/datafusion/bio-format-bam/examples/benchmark_read.rs
@@ -20,7 +20,7 @@ async fn count_rows(
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let table = BamTableProvider::new(BAM_PATH.to_string(), None, true, None).await?;
+    let table = BamTableProvider::new(BAM_PATH.to_string(), None, true, None, false).await?;
 
     let ctx = SessionContext::new();
     ctx.register_table("bam", Arc::new(table))?;

--- a/datafusion/bio-format-bam/examples/describe_bam_schema.rs
+++ b/datafusion/bio-format-bam/examples/describe_bam_schema.rs
@@ -14,8 +14,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let provider = BamTableProvider::new(
         "tests/rev_reads.bam".to_string(),
         None,
-        true, // 0-based coordinates
-        None, // No pre-specified tags
+        true,  // 0-based coordinates
+        None,  // No pre-specified tags
+        false, // String CIGAR (default)
     )
     .await?;
 

--- a/datafusion/bio-format-bam/examples/test_bam_reader.rs
+++ b/datafusion/bio-format-bam/examples/test_bam_reader.rs
@@ -18,7 +18,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         file_path.clone(),
         Some(object_storage_options),
         true,
-        None, // No tag fields
+        None,  // No tag fields
+        false, // String CIGAR (default)
     )
     .await
     .unwrap();

--- a/datafusion/bio-format-bam/examples/test_bam_with_tags.rs
+++ b/datafusion/bio-format-bam/examples/test_bam_with_tags.rs
@@ -10,6 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         true, // 0-based coordinates
         Some(vec!["NM".to_string(), "MD".to_string(), "AS".to_string()]),
+        false, // String CIGAR (default)
     )
     .await?;
 

--- a/datafusion/bio-format-bam/examples/write_bam.rs
+++ b/datafusion/bio-format-bam/examples/write_bam.rs
@@ -18,9 +18,10 @@ async fn main() -> datafusion::error::Result<()> {
     let input_path = "test_data/sample.bam";
     let input_table = BamTableProvider::new(
         input_path.to_string(),
-        None, // object storage options
-        true, // 0-based coordinates
-        None, // tag fields
+        None,  // object storage options
+        true,  // 0-based coordinates
+        None,  // tag fields
+        false, // String CIGAR (default)
     )
     .await?;
     ctx.register_table("input_bam", Arc::new(input_table))?;
@@ -72,9 +73,10 @@ async fn main() -> datafusion::error::Result<()> {
     // Register SAM input
     let sam_input = BamTableProvider::new(
         "input.sam".to_string(),
-        None, // object storage options
-        true, // 0-based coordinates
-        None, // tag fields
+        None,  // object storage options
+        true,  // 0-based coordinates
+        None,  // tag fields
+        false, // String CIGAR (default)
     )
     .await?;
     ctx.register_table("input_sam", Arc::new(sam_input))?;

--- a/datafusion/bio-format-bam/src/lib.rs
+++ b/datafusion/bio-format-bam/src/lib.rs
@@ -23,7 +23,7 @@
 //! let ctx = SessionContext::new();
 //!
 //! // Register a BAM file as a table
-//! let table = BamTableProvider::new("data/alignments.bam".to_string(), None, true, None).await?;
+//! let table = BamTableProvider::new("data/alignments.bam".to_string(), None, true, None, false).await?;
 //! ctx.register_table("alignments", Arc::new(table.clone()))?;
 //!
 //! // Discover and describe available columns by sampling records

--- a/datafusion/bio-format-bam/tests/indexed_read_large_test.rs
+++ b/datafusion/bio-format-bam/tests/indexed_read_large_test.rs
@@ -35,8 +35,14 @@ async fn collect_distinct_chroms(ctx: &SessionContext, sql: &str) -> HashSet<Str
 
 async fn setup_bam_ctx() -> datafusion::error::Result<SessionContext> {
     let ctx = SessionContext::new();
-    let provider =
-        BamTableProvider::new("tests/multi_chrom_large.bam".to_string(), None, true, None).await?;
+    let provider = BamTableProvider::new(
+        "tests/multi_chrom_large.bam".to_string(),
+        None,
+        true,
+        None,
+        false,
+    )
+    .await?;
     ctx.register_table("bam", Arc::new(provider))?;
     Ok(ctx)
 }

--- a/datafusion/bio-format-bam/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-bam/tests/indexed_read_test.rs
@@ -48,9 +48,10 @@ async fn setup_bam_ctx() -> datafusion::error::Result<SessionContext> {
     let ctx = SessionContext::new();
     let provider = BamTableProvider::new(
         "tests/multi_chrom.bam".to_string(),
-        None, // object_storage_options
-        true, // zero-based coordinates
-        None, // tag_fields
+        None,  // object_storage_options
+        true,  // zero-based coordinates
+        None,  // tag_fields
+        false, // String CIGAR (default)
     )
     .await?;
     ctx.register_table("bam", Arc::new(provider))?;
@@ -256,6 +257,7 @@ async fn setup_bam_ctx_with_partitions(
         None,
         true, // zero-based coordinates
         None,
+        false, // String CIGAR (default)
     )
     .await?;
     ctx.register_table("bam", Arc::new(provider))?;

--- a/datafusion/bio-format-bam/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-bam/tests/projection_pushdown_test.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 const BAM_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/multi_chrom.bam");
 
 async fn setup_bam_ctx(table_name: &str) -> Result<SessionContext, Box<dyn std::error::Error>> {
-    let table = BamTableProvider::new(BAM_PATH.to_string(), None, true, None).await?;
+    let table = BamTableProvider::new(BAM_PATH.to_string(), None, true, None, false).await?;
     let ctx = SessionContext::new();
     ctx.register_table(table_name, Arc::new(table))?;
     Ok(ctx)
@@ -209,7 +209,7 @@ async fn write_sam_file() -> Result<(tempfile::TempDir, String), Box<dyn std::er
 #[tokio::test]
 async fn test_sam_plan_projection() -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp, sam_path) = write_sam_file().await?;
-    let table = BamTableProvider::new(sam_path, None, true, None).await?;
+    let table = BamTableProvider::new(sam_path, None, true, None, false).await?;
     let ctx = SessionContext::new();
     ctx.register_table("t", Arc::new(table))?;
     let df = ctx.sql("SELECT name, chrom FROM t").await?;
@@ -221,7 +221,7 @@ async fn test_sam_plan_projection() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn test_sam_projection_single_column() -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp, sam_path) = write_sam_file().await?;
-    let table = BamTableProvider::new(sam_path, None, true, None).await?;
+    let table = BamTableProvider::new(sam_path, None, true, None, false).await?;
     let ctx = SessionContext::new();
     ctx.register_table("t", Arc::new(table))?;
     let df = ctx.sql("SELECT name FROM t").await?;
@@ -242,7 +242,7 @@ async fn test_sam_projection_single_column() -> Result<(), Box<dyn std::error::E
 #[tokio::test]
 async fn test_sam_projection_reordered() -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp, sam_path) = write_sam_file().await?;
-    let table = BamTableProvider::new(sam_path, None, true, None).await?;
+    let table = BamTableProvider::new(sam_path, None, true, None, false).await?;
     let ctx = SessionContext::new();
     ctx.register_table("t", Arc::new(table))?;
     let df = ctx.sql("SELECT mapping_quality, name FROM t").await?;

--- a/datafusion/bio-format-bam/tests/tag_tests.rs
+++ b/datafusion/bio-format-bam/tests/tag_tests.rs
@@ -10,7 +10,8 @@ async fn test_bam_without_tags() {
         "tests/rev_reads.bam".to_string(),
         None,
         true,
-        None, // No tags
+        None,  // No tags
+        false, // String CIGAR (default)
     )
     .await
     .unwrap();
@@ -36,6 +37,7 @@ async fn test_bam_with_specified_tags() {
         None,
         true,
         Some(vec!["NM".to_string(), "MD".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -71,6 +73,7 @@ async fn test_query_with_tag_projection() {
         None,
         true,
         Some(vec!["NM".to_string(), "MD".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -102,6 +105,7 @@ async fn test_query_without_tag_projection() {
         None,
         true,
         Some(vec!["NM".to_string(), "MD".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -133,6 +137,7 @@ async fn test_count_query() {
         None,
         true,
         Some(vec!["NM".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -155,6 +160,7 @@ async fn test_unknown_tag_accepted() {
         None,
         true,
         Some(vec!["UNKNOWN_TAG".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -199,6 +205,7 @@ async fn test_multiple_tags() {
             "AS".to_string(),
             "RG".to_string(),
         ]),
+        false,
     )
     .await
     .unwrap();
@@ -220,10 +227,15 @@ async fn test_multiple_tags() {
 #[tokio::test]
 async fn test_empty_tag_list() {
     // Test that Some(vec![]) behaves like None (no tags)
-    let provider =
-        BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, Some(vec![]))
-            .await
-            .unwrap();
+    let provider = BamTableProvider::new(
+        "tests/rev_reads.bam".to_string(),
+        None,
+        true,
+        Some(vec![]),
+        false,
+    )
+    .await
+    .unwrap();
 
     let ctx = SessionContext::new();
     ctx.register_table("bam", Arc::new(provider)).unwrap();
@@ -256,6 +268,7 @@ async fn test_read_all_13_tags() {
         None,
         true, // 0-based coordinates
         Some(tag_fields),
+        false,
     )
     .await
     .unwrap();
@@ -304,6 +317,7 @@ async fn test_xt_tag_character_values() {
         None,
         true,
         Some(vec!["XT".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -361,6 +375,7 @@ async fn test_integer_tags_from_int8_encoding() {
         None,
         true,
         Some(vec!["NM".to_string(), "MQ".to_string(), "UQ".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -412,6 +427,7 @@ async fn test_nullable_tags_with_mixed_presence() {
             "XN".to_string(),
             "OC".to_string(),
         ]),
+        false,
     )
     .await
     .unwrap();
@@ -503,9 +519,10 @@ async fn test_nullable_tags_with_mixed_presence() {
 async fn test_describe_discovers_tags() {
     use datafusion::prelude::*;
 
-    let provider = BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, None)
-        .await
-        .unwrap();
+    let provider =
+        BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, None, false)
+            .await
+            .unwrap();
 
     let ctx = SessionContext::new();
 
@@ -558,9 +575,10 @@ async fn test_describe_discovers_tags() {
 async fn test_describe_with_display() {
     use datafusion::prelude::*;
 
-    let provider = BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, None)
-        .await
-        .unwrap();
+    let provider =
+        BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, None, false)
+            .await
+            .unwrap();
 
     let ctx = SessionContext::new();
     let schema_df = provider.describe(&ctx, Some(100)).await.unwrap();
@@ -575,9 +593,10 @@ async fn test_describe_method_signature() {
     // Test that describe method exists with correct signature
     use datafusion::prelude::*;
 
-    let provider = BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, None)
-        .await
-        .unwrap();
+    let provider =
+        BamTableProvider::new("tests/rev_reads.bam".to_string(), None, true, None, false)
+            .await
+            .unwrap();
 
     let ctx = SessionContext::new();
     let result = provider.describe(&ctx, Some(10)).await;

--- a/datafusion/bio-format-bam/tests/write_test.rs
+++ b/datafusion/bio-format-bam/tests/write_test.rs
@@ -127,6 +127,7 @@ async fn test_tags_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         None, // storage options
         true, // 0-based coordinates
         Some(tag_fields.clone()),
+        false, // String CIGAR (default)
     )
     .await?;
 
@@ -260,6 +261,7 @@ async fn test_character_tags_round_trip() -> Result<(), Box<dyn std::error::Erro
         true,
         Some(tag_fields.clone()),
         Some(10), // Sample 10 records
+        false,    // String CIGAR (default)
     )
     .await?;
 
@@ -373,6 +375,7 @@ async fn test_integer_array_tags_round_trip() -> Result<(), Box<dyn std::error::
         true,
         Some(tag_fields.clone()),
         Some(10), // Sample 10 records
+        false,    // String CIGAR (default)
     )
     .await?;
 
@@ -501,6 +504,7 @@ async fn test_byte_array_tags_round_trip() -> Result<(), Box<dyn std::error::Err
         true,
         Some(tag_fields.clone()),
         Some(10), // Sample 10 records
+        false,    // String CIGAR (default)
     )
     .await?;
 
@@ -616,6 +620,7 @@ async fn test_float_tags_round_trip() -> Result<(), Box<dyn std::error::Error>> 
         true,
         Some(tag_fields.clone()),
         Some(10), // Sample 10 records
+        false,    // String CIGAR (default)
     )
     .await?;
 
@@ -778,8 +783,14 @@ async fn test_sort_on_write_coordinate_order() -> Result<(), Box<dyn std::error:
         .await?;
 
     // Read back and verify order: chr1:100, chr1:200, chr2:300
-    let read_provider =
-        BamTableProvider::new(output_path.to_str().unwrap().to_string(), None, true, None).await?;
+    let read_provider = BamTableProvider::new(
+        output_path.to_str().unwrap().to_string(),
+        None,
+        true,
+        None,
+        false,
+    )
+    .await?;
 
     // Verify header has SO:coordinate
     let read_schema = read_provider.schema();
@@ -897,8 +908,14 @@ async fn test_sort_on_write_false_sets_unsorted() -> Result<(), Box<dyn std::err
         .await?;
 
     // Read back and verify header has SO:unsorted
-    let read_provider =
-        BamTableProvider::new(output_path.to_str().unwrap().to_string(), None, true, None).await?;
+    let read_provider = BamTableProvider::new(
+        output_path.to_str().unwrap().to_string(),
+        None,
+        true,
+        None,
+        false,
+    )
+    .await?;
 
     let read_schema = read_provider.schema();
     let sort_order = read_schema.metadata().get(BAM_SORT_ORDER_KEY);

--- a/datafusion/bio-format-core/src/lib.rs
+++ b/datafusion/bio-format-core/src/lib.rs
@@ -52,10 +52,11 @@ pub mod metadata;
 
 // Re-export commonly used metadata keys, types, and utilities
 pub use metadata::{
-    BAM_COMMENTS_KEY, BAM_FILE_FORMAT_VERSION_KEY, BAM_GROUP_ORDER_KEY, BAM_PROGRAM_INFO_KEY,
-    BAM_READ_GROUPS_KEY, BAM_REFERENCE_SEQUENCES_KEY, BAM_SORT_ORDER_KEY, BAM_SUBSORT_ORDER_KEY,
-    BAM_TAG_DESCRIPTION_KEY, BAM_TAG_TAG_KEY, BAM_TAG_TYPE_KEY, ProgramMetadata, ReadGroupMetadata,
-    ReferenceSequenceMetadata, extract_header_metadata, from_json_string, to_json_string,
+    BAM_BINARY_CIGAR_KEY, BAM_COMMENTS_KEY, BAM_FILE_FORMAT_VERSION_KEY, BAM_GROUP_ORDER_KEY,
+    BAM_PROGRAM_INFO_KEY, BAM_READ_GROUPS_KEY, BAM_REFERENCE_SEQUENCES_KEY, BAM_SORT_ORDER_KEY,
+    BAM_SUBSORT_ORDER_KEY, BAM_TAG_DESCRIPTION_KEY, BAM_TAG_TAG_KEY, BAM_TAG_TYPE_KEY,
+    ProgramMetadata, ReadGroupMetadata, ReferenceSequenceMetadata, extract_header_metadata,
+    from_json_string, to_json_string,
 };
 /// Alignment utilities shared between BAM and CRAM formats
 pub mod alignment_utils;

--- a/datafusion/bio-format-core/src/metadata.rs
+++ b/datafusion/bio-format-core/src/metadata.rs
@@ -97,6 +97,9 @@ pub const BAM_TAG_TYPE_KEY: &str = "bio.bam.tag.type";
 /// BAM optional tag description stored in field metadata
 pub const BAM_TAG_DESCRIPTION_KEY: &str = "bio.bam.tag.description";
 
+/// Whether the CIGAR column uses binary encoding (raw LE u32 ops) instead of string
+pub const BAM_BINARY_CIGAR_KEY: &str = "bio.bam.binary_cigar";
+
 // ============================================================================
 // GFF-Specific Metadata Keys (For Future Use)
 // ============================================================================

--- a/datafusion/bio-format-cram/examples/test_md_tag.rs
+++ b/datafusion/bio-format-cram/examples/test_md_tag.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         true,
         Some(vec!["MD".to_string(), "NM".to_string()]),
+        false,
     )
     .await?;
 
@@ -50,6 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         true,
         Some(10),
+        false,
     )
     .await?;
 

--- a/datafusion/bio-format-cram/examples/test_tag_discovery.rs
+++ b/datafusion/bio-format-cram/examples/test_tag_discovery.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         true,
         Some(10),
+        false,
     )
     .await?;
 
@@ -48,6 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         true,
         None, // No tags specified
+        false,
     )
     .await?;
 

--- a/datafusion/bio-format-cram/examples/write_cram.rs
+++ b/datafusion/bio-format-cram/examples/write_cram.rs
@@ -25,6 +25,7 @@ async fn main() -> datafusion::error::Result<()> {
         None,      // object storage options
         true,      // 0-based coordinates
         Some(100), // Sample 100 records to discover tags
+        false,     // binary_cigar
     )
     .await?;
     ctx.register_table("input_cram", Arc::new(input_table))?;
@@ -101,6 +102,7 @@ async fn main() -> datafusion::error::Result<()> {
         true,      // 0-based coordinates
         None,      // tag_fields (None to discover all)
         Some(100), // Sample 100 records to discover tags
+        false,     // String CIGAR (default)
     )
     .await?;
     ctx.register_table("input_bam", Arc::new(bam_input))?;

--- a/datafusion/bio-format-cram/src/lib.rs
+++ b/datafusion/bio-format-cram/src/lib.rs
@@ -29,6 +29,7 @@
 //!     None,
 //!     true,
 //!     Some(vec!["MD".to_string(), "NM".to_string(), "RG".to_string()]),
+//!     false,
 //! ).await?;
 //! ctx.register_table("alignments", Arc::new(table))?;
 //!
@@ -57,6 +58,7 @@
 //!     None,
 //!     true,
 //!     Some(100),  // Sample 100 records
+//!     false,
 //! ).await?;
 //! ctx.register_table("alignments", Arc::new(table))?;
 //!

--- a/datafusion/bio-format-cram/src/serializer.rs
+++ b/datafusion/bio-format-cram/src/serializer.rs
@@ -4,8 +4,10 @@
 //! to CRAM format for writing to files.
 
 use datafusion::arrow::array::{
-    Array, Float32Array, Int32Array, ListArray, RecordBatch, StringArray, UInt8Array, UInt32Array,
+    Array, BinaryArray, Float32Array, Int32Array, ListArray, RecordBatch, StringArray, UInt8Array,
+    UInt32Array,
 };
+use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{DataFusionError, Result};
 use datafusion_bio_format_core::{BAM_TAG_TAG_KEY, BAM_TAG_TYPE_KEY};
 use noodles_sam as sam;
@@ -14,6 +16,34 @@ use noodles_sam::alignment::record_buf::{
     Cigar, QualityScores, Sequence, data::field::Value as TagValue,
 };
 use std::collections::HashMap;
+
+/// Cigar column data: either string or binary
+enum CigarColumn<'a> {
+    String(&'a StringArray),
+    Binary(&'a BinaryArray),
+}
+
+/// Look up the cigar column, handling both Utf8 and Binary types
+fn get_cigar_column(batch: &RecordBatch) -> Result<CigarColumn<'_>> {
+    let idx = batch.schema().index_of("cigar").map_err(|_| {
+        DataFusionError::Execution("Required column 'cigar' not found in batch".to_string())
+    })?;
+    let col = batch.column(idx);
+    match col.data_type() {
+        DataType::Binary => {
+            let arr = col.as_any().downcast_ref::<BinaryArray>().ok_or_else(|| {
+                DataFusionError::Execution("Column 'cigar' downcast to BinaryArray failed".into())
+            })?;
+            Ok(CigarColumn::Binary(arr))
+        }
+        _ => {
+            let arr = col.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+                DataFusionError::Execution("Column 'cigar' must be String or Binary type".into())
+            })?;
+            Ok(CigarColumn::String(arr))
+        }
+    }
+}
 
 /// Converts an Arrow RecordBatch to a vector of CRAM records.
 ///
@@ -53,7 +83,7 @@ pub fn batch_to_cram_records(
     let chroms = get_string_column_by_name(batch, "chrom")?;
     let starts = get_u32_column_by_name(batch, "start")?;
     let flags = get_u32_column_by_name(batch, "flags")?;
-    let cigars = get_string_column_by_name(batch, "cigar")?;
+    let cigar_col = get_cigar_column(batch)?;
     let mapping_qualities = get_u32_column_by_name(batch, "mapping_quality")?;
     let mate_chroms = get_string_column_by_name(batch, "mate_chrom")?;
     let mate_starts = get_u32_column_by_name(batch, "mate_start")?;
@@ -73,7 +103,7 @@ pub fn batch_to_cram_records(
             chroms,
             starts,
             flags,
-            cigars,
+            &cigar_col,
             mapping_qualities,
             mate_chroms,
             mate_starts,
@@ -100,7 +130,7 @@ fn build_single_record(
     chroms: &StringArray,
     starts: &UInt32Array,
     flags: &UInt32Array,
-    cigars: &StringArray,
+    cigar_col: &CigarColumn<'_>,
     mapping_qualities: &UInt32Array,
     mate_chroms: &StringArray,
     mate_starts: &UInt32Array,
@@ -159,8 +189,21 @@ fn build_single_record(
     *record.mapping_quality_mut() = mapq;
 
     // 6. CIGAR
-    let cigar_str = cigars.value(row);
-    let cigar = parse_cigar_string(cigar_str)?;
+    let cigar = match cigar_col {
+        CigarColumn::String(arr) => {
+            let cigar_str = arr.value(row);
+            parse_cigar_string(cigar_str)?
+        }
+        CigarColumn::Binary(arr) => {
+            let bytes = arr.value(row);
+            let ops =
+                datafusion_bio_format_core::alignment_utils::decode_binary_cigar_to_ops(bytes)
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!("Failed to decode binary CIGAR: {}", e))
+                    })?;
+            Cigar::from(ops)
+        }
+    };
     *record.cigar_mut() = cigar;
 
     // 7. RNEXT (mate reference sequence ID)

--- a/datafusion/bio-format-cram/tests/indexed_read_large_test.rs
+++ b/datafusion/bio-format-cram/tests/indexed_read_large_test.rs
@@ -41,6 +41,7 @@ async fn setup_cram_ctx() -> datafusion::error::Result<SessionContext> {
         None,
         true,
         None,
+        false,
     )
     .await?;
     ctx.register_table("cram", Arc::new(provider))?;

--- a/datafusion/bio-format-cram/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-cram/tests/indexed_read_test.rs
@@ -50,10 +50,11 @@ async fn setup_cram_ctx() -> datafusion::error::Result<SessionContext> {
     let ctx = SessionContext::new();
     let provider = CramTableProvider::new(
         "tests/multi_chrom.cram".to_string(),
-        None, // reference_path: None for no_ref CRAM
-        None, // object_storage_options
-        true, // zero-based coordinates
-        None, // tag_fields
+        None,  // reference_path: None for no_ref CRAM
+        None,  // object_storage_options
+        true,  // zero-based coordinates
+        None,  // tag_fields
+        false, // binary_cigar
     )
     .await?;
     ctx.register_table("cram", Arc::new(provider))?;

--- a/datafusion/bio-format-cram/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-cram/tests/projection_pushdown_test.rs
@@ -18,6 +18,7 @@ async fn setup_cram_ctx(table_name: &str) -> Result<SessionContext, Box<dyn std:
         None,
         true,
         None,
+        false,
     )
     .await?;
     let ctx = SessionContext::new();

--- a/datafusion/bio-format-cram/tests/tag_tests.rs
+++ b/datafusion/bio-format-cram/tests/tag_tests.rs
@@ -26,6 +26,7 @@ async fn test_cram_read_with_tags() {
             "MQ".to_string(),
             "RG".to_string(),
         ]),
+        false,
     )
     .await
     .unwrap();
@@ -128,6 +129,7 @@ async fn test_cram_nullable_tags_with_mixed_presence() {
         None,
         true,
         Some(vec!["NM".to_string(), "MQ".to_string(), "E2".to_string()]),
+        false,
     )
     .await
     .unwrap();
@@ -173,6 +175,7 @@ async fn test_cram_tag_projection_pushdown() {
             "MQ".to_string(),
             "RG".to_string(),
         ]),
+        false,
     )
     .await
     .unwrap();
@@ -202,6 +205,7 @@ async fn test_cram_tag_with_filter() {
         None,
         true,
         Some(vec!["NM".to_string()]),
+        false,
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Summary

- Add `binary_cigar: bool` flag to `BamTableProvider` and `CramTableProvider` (default `false`) that stores CIGAR data as raw little-endian `u32` bytes in an Arrow `BinaryArray` instead of decoded string format
- BAM read path achieves true zero-copy via `record.cigar().as_ref()` — no decoding or string formatting
- CRAM/SAM read paths encode ops to binary format, still avoiding string formatting overhead
- Write path transparently handles both `BinaryArray` and `StringArray` CIGAR columns via a `CigarColumn` enum
- Core encode/decode helpers (`encode_cigar_ops_to_binary`, `decode_binary_cigar_to_ops`) with unit tests in `alignment_utils.rs`
- Feature state stored in Arrow schema metadata (`bio.bam.binary_cigar`) for round-trip preservation

## Test plan

- [x] All existing tests pass unchanged (`binary_cigar` defaults to `false`)
- [x] New unit tests for encode/decode round-trip, all 9 CIGAR op kinds, empty CIGAR, invalid inputs
- [x] `cargo build` — clean, no warnings
- [x] `cargo test` — all 72 test suites pass, 0 failures
- [x] `cargo clippy` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)