### PR TITLE
feat: Upgrade DataFusion 50.3.0 → 52.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -119,14 +119,23 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "arrayref"
@@ -142,9 +151,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -163,23 +172,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -189,29 +198,33 @@ dependencies = [
  "chrono-tz",
  "half",
  "hashbrown 0.16.1",
- "num",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -220,15 +233,15 @@ dependencies = [
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
+checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -241,21 +254,22 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
+checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -264,14 +278,13 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
- "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
+checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -281,19 +294,21 @@ dependencies = [
  "chrono",
  "half",
  "indexmap",
+ "itoa",
  "lexical-core",
  "memchr",
- "num",
- "serde",
+ "num-traits",
+ "ryu",
+ "serde_core",
  "serde_json",
  "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -304,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -317,33 +332,33 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_json",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -351,26 +366,21 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.19"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
 dependencies = [
- "bzip2 0.5.2",
- "flate2",
- "futures-core",
- "memchr",
+ "compression-codecs",
+ "compression-core",
  "pin-project-lite",
  "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -471,9 +481,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake2"
@@ -549,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -604,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -668,14 +678,30 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.2"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "strum",
- "strum_macros",
+ "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
@@ -727,6 +753,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -852,22 +888,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af15bb3c6ffa33011ef579f6b0bcbe7c26584688bd6c994f548e44df67f011a"
+checksum = "d12ee9fdc6cdb5898c7691bb994f0ba606c4acc93a2258d78bb9f26ff8158bb3"
 dependencies = [
  "arrow",
- "arrow-ipc",
  "arrow-schema",
  "async-trait",
  "bytes",
- "bzip2 0.6.1",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
+ "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
  "datafusion-datasource-parquet",
@@ -887,7 +922,6 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "datafusion-sql",
- "flate2",
  "futures",
  "itertools",
  "log",
@@ -901,8 +935,6 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
- "xz2",
- "zstd",
 ]
 
 [[package]]
@@ -1176,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187622262ad8f7d16d3be9202b4c1e0116f1c9aa387e5074245538b755261621"
+checksum = "462dc9ef45e5d688aeaae49a7e310587e81b6016b9d03bace5626ad0043e5a9e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1191,7 +1223,6 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-session",
- "datafusion-sql",
  "futures",
  "itertools",
  "log",
@@ -1202,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9657314f0a32efd0382b9a46fdeb2d233273ece64baa68a7c45f5a192daf0f83"
+checksum = "1b96dbf1d728fc321817b744eb5080cdd75312faa6980b338817f68f3caa4208"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1214,28 +1245,27 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "datafusion-session",
  "futures",
+ "itertools",
  "log",
  "object_store",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
+checksum = "3237a6ff0d2149af4631290074289cae548c9863c885d821315d54c6673a074a"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-ipc",
- "base64",
  "chrono",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "libc",
  "log",
@@ -1250,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6234a6c7173fe5db1c6c35c01a12b2aa0f803a3007feee53483218817f8b1e"
+checksum = "70b5e34026af55a1bfccb1ef0a763cf1f64e77c696ffcf5a128a278c31236528"
 dependencies = [
  "futures",
  "log",
@@ -1261,15 +1291,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7256c9cb27a78709dd42d0c80f0178494637209cac6e29d5c93edd09b6721b86"
+checksum = "1b2a6be734cc3785e18bbf2a7f2b22537f6b9fb960d79617775a51568c281842"
 dependencies = [
  "arrow",
- "async-compression",
  "async-trait",
  "bytes",
- "bzip2 0.6.1",
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1280,38 +1308,54 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
- "flate2",
  "futures",
  "glob",
  "itertools",
  "log",
  "object_store",
- "parquet",
  "rand 0.9.2",
- "tempfile",
  "tokio",
- "tokio-util",
  "url",
- "xz2",
- "zstd",
 ]
 
 [[package]]
-name = "datafusion-datasource-csv"
-version = "50.3.0"
+name = "datafusion-datasource-arrow"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64533a90f78e1684bfb113d200b540f18f268134622d7c96bbebc91354d04825"
+checksum = "1739b9b07c9236389e09c74f770e88aff7055250774e9def7d3f4f56b3dcc7be"
 dependencies = [
  "arrow",
+ "arrow-ipc",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "52.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c73bc54b518bbba7c7650299d07d58730293cfba4356f6f428cc94c20b7600"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
@@ -1323,49 +1367,44 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ebeb12c77df0aacad26f21b0d033aeede423a64b2b352f53048a75bf1d6e6"
+checksum = "37812c8494c698c4d889374ecfabbff780f1f26d9ec095dd1bddfc2a8ca12559"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e783c4c7d7faa1199af2df4761c68530634521b176a8d1331ddbc5a5c75133"
+checksum = "2210937ecd9f0e824c397e73f4b5385c97cd1aff43ab2b5836fcfd2d321523fb"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-pruning",
  "datafusion-session",
@@ -1375,24 +1414,24 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-doc"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ee6b1d9a80d13f9deb2291f45c07044b8e62fb540dbde2453a18be17a36429"
+checksum = "2c825f969126bc2ef6a6a02d94b3c07abff871acf4d6dd759ce1255edb7923ce"
 
 [[package]]
 name = "datafusion-execution"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cec0a57653bec7b933fb248d3ffa3fa3ab3bd33bd140dc917f714ac036f531"
+checksum = "fa03ef05a2c2f90dd6c743e3e111078e322f4b395d20d4b4d431a245d79521ae"
 dependencies = [
  "arrow",
  "async-trait",
+ "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1407,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef76910bdca909722586389156d0aa4da4020e1631994d50fadd8ad4b1aa05fe"
+checksum = "ef33934c1f98ee695cc51192cc5f9ed3a8febee84fdbcd9131bf9d3a9a78276f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1421,6 +1460,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
+ "itertools",
  "paste",
  "recursive",
  "serde_json",
@@ -1429,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d155ccbda29591ca71a1344dd6bed26c65a4438072b400df9db59447f590bb6"
+checksum = "000c98206e3dd47d2939a94b6c67af4bfa6732dd668ac4fafdbde408fd9134ea"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1442,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de2782136bd6014670fd84fe3b0ca3b3e4106c96403c3ae05c0598577139977"
+checksum = "379b01418ab95ca947014066248c22139fe9af9289354de10b445bd000d5d276"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1452,6 +1492,7 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
+ "chrono-tz",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -1462,6 +1503,7 @@ dependencies = [
  "itertools",
  "log",
  "md-5",
+ "num-traits",
  "rand 0.9.2",
  "regex",
  "sha2",
@@ -1471,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07331fc13603a9da97b74fd8a273f4238222943dffdbbed1c4c6f862a30105bf"
+checksum = "fd00d5454ba4c3f8ebbd04bd6a6a9dc7ced7c56d883f70f2076c188be8459e4c"
 dependencies = [
  "ahash",
  "arrow",
@@ -1492,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5951e572a8610b89968a09b5420515a121fbc305c0258651f318dc07c97ab17"
+checksum = "aec06b380729a87210a4e11f555ec2d729a328142253f8d557b87593622ecc9f"
 dependencies = [
  "ahash",
  "arrow",
@@ -1505,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdacca9302c3d8fc03f3e94f338767e786a88a33f5ebad6ffc0e7b50364b9ea3"
+checksum = "904f48d45e0f1eb7d0eb5c0f80f2b5c6046a85454364a6b16a2e0b46f62e7dff"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1515,6 +1557,7 @@ dependencies = [
  "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
@@ -1527,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37ff8a99434fbbad604a7e0669717c58c7c4f14c472d45067c4b016621d981"
+checksum = "e9a0d20e2b887e11bee24f7734d780a2588b925796ac741c3118dd06d5aa77f0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1543,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e2aea7c79c926cffabb13dc27309d4eaeb130f4a21c8ba91cdd241c813652b"
+checksum = "d3414b0a07e39b6979fe3a69c7aa79a9f1369f1d5c8e52146e66058be1b285ee"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1561,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fead257ab5fd2ffc3b40fda64da307e20de0040fe43d49197241d9de82a487f"
+checksum = "5bf2feae63cd4754e31add64ce75cae07d015bce4bb41cd09872f93add32523a"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1571,20 +1614,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6f637bce95efac05cdfb9b6c19579ed4aa5f6b94d951cfa5bb054b7bb4f730"
+checksum = "c4fe888aeb6a095c4bcbe8ac1874c4b9a4c7ffa2ba849db7922683ba20875aaf"
 dependencies = [
- "datafusion-expr",
+ "datafusion-doc",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6583ef666ae000a613a837e69e456681a9faa96347bf3877661e9e89e141d8a"
+checksum = "8a6527c063ae305c11be397a86d8193936f4b84d137fe40bd706dfc178cf733c"
 dependencies = [
  "arrow",
  "chrono",
@@ -1602,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8668103361a272cbbe3a61f72eca60c9b7c706e87cc3565bcf21e2b277b84f6"
+checksum = "0bb028323dd4efd049dd8a78d78fe81b2b969447b39c51424167f973ac5811d9"
 dependencies = [
  "ahash",
  "arrow",
@@ -1614,20 +1657,21 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "itertools",
- "log",
  "parking_lot",
  "paste",
  "petgraph",
+ "recursive",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815acced725d30601b397e39958e0e55630e0a10d66ef7769c14ae6597298bb0"
+checksum = "78fe0826aef7eab6b4b61533d811234a7a9e5e458331ebbf94152a51fc8ab433"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1640,23 +1684,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6652fe7b5bf87e85ed175f571745305565da2c0b599d98e697bcbedc7baa47c3"
+checksum = "cfccd388620734c661bd8b7ca93c44cdd59fecc9b550eea416a78ffcbb29475f"
 dependencies = [
  "ahash",
  "arrow",
+ "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "indexmap",
  "itertools",
+ "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b7d623eb6162a3332b564a0907ba00895c505d101b99af78345f1acf929b5c"
+checksum = "bde5fa10e73259a03b705d5fddc136516814ab5f441b939525618a4070f5a059"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1668,33 +1715,32 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "itertools",
- "log",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7f778a1a838dec124efb96eae6144237d546945587557c9e6936b3414558c"
+checksum = "0e1098760fb29127c24cc9ade3277051dc73c9ed0ac0131bd7bcd742e0ad7470"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "itertools",
  "log",
@@ -1705,12 +1751,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1e59e2ca14fe3c30f141600b10ad8815e2856caa59ebbd0e3e07cd3d127a65"
+checksum = "64d0fef4201777b52951edec086c21a5b246f3c82621569ddb4a26f488bc38a9"
 dependencies = [
  "arrow",
- "arrow-schema",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -1723,36 +1768,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ef8e2745583619bd7a49474e8f45fbe98ebb31a133f27802217125a7b3d58d"
+checksum = "f71f1e39e8f2acbf1c63b0e93756c2e970a64729dab70ac789587d6237c4fde0"
 dependencies = [
- "arrow",
  "async-trait",
- "dashmap",
  "datafusion-common",
- "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-plan",
- "datafusion-sql",
- "futures",
- "itertools",
- "log",
- "object_store",
  "parking_lot",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "50.3.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abd9868770386fede29e5a4b14f49c0bf48d652c3b9d7a8a0332329b87d50b"
+checksum = "f44693cfcaeb7a9f12d71d1c576c3a6dc025a12cef209375fa2d16fb3b5670ee"
 dependencies = [
  "arrow",
  "bigdecimal",
+ "chrono",
  "datafusion-common",
  "datafusion-expr",
  "indexmap",
@@ -1775,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba"
 dependencies = [
  "powerfmt",
 ]
@@ -1858,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -1868,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1892,7 +1928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1947,6 +1983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1987,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1997,15 +2039,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2014,15 +2056,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2031,21 +2073,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2055,7 +2097,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2094,6 +2135,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2150,10 +2204,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2161,7 +2211,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2169,6 +2219,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2199,11 +2254,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2437,6 +2492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2526,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2535,9 +2598,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
 dependencies = [
  "jiff-static",
  "log",
@@ -2548,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2569,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2600,6 +2663,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-core"
@@ -2666,24 +2735,24 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -2739,9 +2808,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
 dependencies = [
  "twox-hash",
 ]
@@ -2778,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -2811,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -3343,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -3356,21 +3425,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3410,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -3430,17 +3485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3470,6 +3514,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "object_store"
@@ -3565,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -3631,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
+checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3652,11 +3705,11 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "lz4_flex",
- "num",
  "num-bigint",
+ "num-integer",
+ "num-traits",
  "object_store",
  "paste",
- "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -3833,6 +3886,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,10 +3906,11 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
 dependencies = [
+ "ar_archive_writer",
  "cc",
 ]
 
@@ -4227,7 +4291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4273,9 +4337,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -4323,12 +4387,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4336,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4495,9 +4559,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -4557,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
  "recursive",
@@ -4585,34 +4649,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
 ]
 
 [[package]]
@@ -4623,9 +4668,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4673,7 +4718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -4689,15 +4734,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4762,30 +4807,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5013,9 +5058,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5028,6 +5073,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5067,11 +5118,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5122,18 +5173,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5144,9 +5204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5158,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5168,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5181,11 +5241,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5202,10 +5284,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5252,7 +5346,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5617,9 +5711,91 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5741,15 +5917,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,19 @@ edition = "2024"
 
 
 [workspace.dependencies]
-datafusion = {version = "50.3.0"}
-datafusion-execution = "50.3.0"
+datafusion = { version = "52.1.0", default-features = false, features = [
+    "nested_expressions",
+    "crypto_expressions",
+    "datetime_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "string_expressions",
+    "unicode_expressions",
+    "parquet",
+    "recursive_protection",
+    "sql",
+] }
+datafusion-execution = "52.1.0"
 async-trait = "0.1.85"
 opendal = { version = "0.53.3", features = ["services-gcs", "services-s3","layers-blocking", "services-azblob", "services-http"] }
 noodles = { version = "0.93.0",  features = ["bam", "vcf", "bgzf", "cram", "async"]}
@@ -33,7 +44,7 @@ bytes = "1.10.0"
 futures = "0.3.31"
 async-stream = "0.3.6"
 futures-util = "0.3.31"
-async-compression = "0.4.19"
+async-compression = "0.4.35"
 flate2 = { version = "1.0", features = ["zlib-rs"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/benchmarks/common/Cargo.toml
+++ b/benchmarks/common/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "datafusion-bio-benchmarks-common"
 version = "0.5.2"
-edition = "2021"
-rust-version = "1.86.0"
+edition = "2024"
+rust-version = "1.88.0"
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/benchmarks/common/src/data_downloader.rs
+++ b/benchmarks/common/src/data_downloader.rs
@@ -52,7 +52,7 @@ impl DataDownloader {
         if output_path.exists() && !force {
             // Validate cached file is not a stale HTML page from a previous failed download
             if let Err(e) = validate_not_html(&output_path, &file.filename) {
-                println!("✗ Cached file invalid ({}), re-downloading...", e);
+                println!("✗ Cached file invalid ({e}), re-downloading...");
                 // validate_not_html already removes the file on HTML detection
             } else {
                 println!("✓ Using cached file: {}", output_path.display());
@@ -75,10 +75,7 @@ impl DataDownloader {
 
         // Try direct download first
         if let Err(e) = self.download_direct(file, &output_path) {
-            println!(
-                "Direct download failed ({}), trying with confirmation...",
-                e
-            );
+            println!("Direct download failed ({e}), trying with confirmation...");
             self.download_with_confirmation(file, &output_path)?;
         }
 
@@ -93,9 +90,7 @@ impl DataDownloader {
             if &actual_checksum != expected_checksum {
                 std::fs::remove_file(&output_path)?;
                 return Err(anyhow!(
-                    "Checksum mismatch:\n  Expected: {}\n  Actual:   {}",
-                    expected_checksum,
-                    actual_checksum
+                    "Checksum mismatch:\n  Expected: {expected_checksum}\n  Actual:   {actual_checksum}"
                 ));
             }
             println!("✓ Checksum verified");
@@ -217,10 +212,7 @@ pub fn extract_drive_id(url: &str) -> Result<String> {
         }
     }
 
-    Err(anyhow!(
-        "Could not extract Google Drive ID from URL: {}",
-        url
-    ))
+    Err(anyhow!("Could not extract Google Drive ID from URL: {url}"))
 }
 
 /// Check that a downloaded file is not an HTML page.
@@ -232,8 +224,7 @@ fn validate_not_html(path: &Path, filename: &str) -> Result<()> {
     let bytes_read = file.read(&mut header)?;
     if bytes_read == 0 {
         anyhow::bail!(
-            "Downloaded file '{}' is empty — Google Drive may have returned an error page",
-            filename
+            "Downloaded file '{filename}' is empty — Google Drive may have returned an error page"
         );
     }
 

--- a/benchmarks/common/src/lib.rs
+++ b/benchmarks/common/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod data_downloader;
 pub mod harness;
 
-pub use data_downloader::{extract_drive_id, DataDownloader, TestDataFile};
+pub use data_downloader::{DataDownloader, TestDataFile, extract_drive_id};
 pub use harness::{
-    write_result, BenchmarkCategory, BenchmarkResult, BenchmarkResultBuilder, Metrics, SystemInfo,
+    BenchmarkCategory, BenchmarkResult, BenchmarkResultBuilder, Metrics, SystemInfo, write_result,
 };

--- a/benchmarks/runner/Cargo.toml
+++ b/benchmarks/runner/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "datafusion-bio-benchmarks-runner"
 version = "0.5.2"
-edition = "2021"
-rust-version = "1.86.0"
+edition = "2024"
+rust-version = "1.88.0"
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/benchmarks/runner/src/main.rs
+++ b/benchmarks/runner/src/main.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
 
     println!("📊 DataFusion Bio-Formats Benchmark Runner");
     println!("==========================================\n");
-    println!("Config: {}", config_path);
+    println!("Config: {config_path}");
     println!("Output: {}\n", output_dir.display());
 
     // Load YAML configuration
@@ -257,8 +257,7 @@ async fn register_table(
         }
         _ => {
             anyhow::bail!(
-                "Unsupported format: {}. Supported formats: gff, vcf, fastq, bam, bed, fasta",
-                format
+                "Unsupported format: {format}. Supported formats: gff, vcf, fastq, bam, bed, fasta"
             );
         }
     }
@@ -286,7 +285,7 @@ async fn run_parallelism_benchmarks(
             ThreadCount::Max(_) => num_cpus::get(),
         };
 
-        println!("  Testing with {} threads...", thread_count);
+        println!("  Testing with {thread_count} threads...");
 
         let mut total_records = 0u64;
         let mut total_time = 0.0;
@@ -313,7 +312,7 @@ async fn run_parallelism_benchmarks(
         }
 
         // Build and write result
-        let benchmark_name = format!("{}_parallelism_{}threads", format, thread_count);
+        let benchmark_name = format!("{format}_parallelism_{thread_count}threads");
         let config_json = serde_json::json!({
             "threads": thread_count,
             "repetitions": config.repetitions,
@@ -336,7 +335,7 @@ async fn run_parallelism_benchmarks(
             avg_time,
             config.repetitions,
             speedup
-                .map(|s| format!(", {:.2}x speedup", s))
+                .map(|s| format!(", {s:.2}x speedup"))
                 .unwrap_or_default()
         );
     }

--- a/datafusion/bio-format-bam/examples/benchmark_read.rs
+++ b/datafusion/bio-format-bam/examples/benchmark_read.rs
@@ -31,8 +31,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (sql, label) in &queries {
-        println!("\n--- {} ---", label);
-        println!("SQL: {}", sql);
+        println!("\n--- {label} ---");
+        println!("SQL: {sql}");
 
         let mut timings = Vec::with_capacity(NUM_RUNS);
         let mut rows = 0;
@@ -42,10 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             rows = r;
             let secs = elapsed.as_secs_f64();
             let rows_per_sec = rows as f64 / secs;
-            println!(
-                "  Run {}: {:.3}s  ({} rows, {:.0} rows/sec)",
-                run, secs, rows, rows_per_sec
-            );
+            println!("  Run {run}: {secs:.3}s  ({rows} rows, {rows_per_sec:.0} rows/sec)");
             timings.push(elapsed);
         }
 

--- a/datafusion/bio-format-bam/examples/describe_bam_schema.rs
+++ b/datafusion/bio-format-bam/examples/describe_bam_schema.rs
@@ -52,10 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for sample_size in [10, 50, 200] {
         let schema_df = provider.describe(&ctx, Some(sample_size)).await?;
         let count = schema_df.count().await?;
-        println!(
-            "Sample size {}: {} total columns discovered",
-            sample_size, count
-        );
+        println!("Sample size {sample_size}: {count} total columns discovered");
     }
 
     Ok(())

--- a/datafusion/bio-format-bam/examples/write_bam.rs
+++ b/datafusion/bio-format-bam/examples/write_bam.rs
@@ -98,8 +98,8 @@ async fn main() -> datafusion::error::Result<()> {
 
     println!("\n✓ BAM/SAM write examples completed successfully");
     println!("Output files:");
-    println!("  - {}", output_path_1);
-    println!("  - {}", output_path_2);
+    println!("  - {output_path_1}");
+    println!("  - {output_path_2}");
     println!("  - output/converted.bam");
 
     Ok(())

--- a/datafusion/bio-format-bam/src/serializer.rs
+++ b/datafusion/bio-format-bam/src/serializer.rs
@@ -202,7 +202,7 @@ fn build_single_record(
             let ops =
                 datafusion_bio_format_core::alignment_utils::decode_binary_cigar_to_ops(bytes)
                     .map_err(|e| {
-                        DataFusionError::Execution(format!("Failed to decode binary CIGAR: {}", e))
+                        DataFusionError::Execution(format!("Failed to decode binary CIGAR: {e}"))
                     })?;
             Cigar::from(ops)
         }
@@ -288,7 +288,7 @@ fn parse_cigar_string(cigar_str: &str) -> Result<Cigar> {
     // Collect operations from the iterator
     let ops: std::result::Result<Vec<_>, _> = record_cigar.iter().collect();
     let ops = ops.map_err(|e| {
-        DataFusionError::Execution(format!("Failed to parse CIGAR '{}': {}", cigar_str, e))
+        DataFusionError::Execution(format!("Failed to parse CIGAR '{cigar_str}': {e}"))
     })?;
 
     Ok(Cigar::from(ops))
@@ -460,37 +460,37 @@ fn arrow_to_sam_tag_value(
 /// Gets a string column from the batch by name
 fn get_string_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be String type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be String type")))
 }
 
 /// Gets a u32 column from the batch by name
 fn get_u32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a UInt32Array> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<UInt32Array>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be UInt32 type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be UInt32 type")))
 }
 
 /// Gets an i32 column from the batch by name
 fn get_i32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int32Array> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<Int32Array>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be Int32 type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be Int32 type")))
 }
 
 /// Builds a map from tag name to column index

--- a/datafusion/bio-format-bam/src/storage.rs
+++ b/datafusion/bio-format-bam/src/storage.rs
@@ -59,6 +59,7 @@ pub async fn get_local_bam_reader(file_path: String) -> Result<Reader<BgzfReader
 ///
 /// This type abstracts over the different reader implementations needed for local
 /// files with multithreaded decompression and remote files accessed via cloud storage.
+#[allow(clippy::large_enum_variant)]
 pub enum BamReader {
     /// Local BAM reader with single-threaded BGZF decompression
     Local(Reader<BgzfReader<File>>),
@@ -97,7 +98,7 @@ impl BamReader {
                     .unwrap();
                 BamReader::Remote(reader)
             }
-            _ => panic!("Unsupported storage type for BAM file: {:?}", storage_type),
+            _ => panic!("Unsupported storage type for BAM file: {storage_type:?}"),
         }
     }
     /// Reads BAM records from the file as an async stream.
@@ -274,7 +275,7 @@ impl IndexedBamReader {
         let mut reader = bam::io::indexed_reader::Builder::default()
             .set_index(bam::bai::fs::read(index_path)?)
             .build_from_path(file_path)
-            .map_err(|e| Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(Error::other)?;
         let header = reader.read_header()?;
         Ok(Self { reader, header })
     }
@@ -327,7 +328,7 @@ pub fn estimate_sizes_from_bai(
     let index = match bam::bai::fs::read(index_path) {
         Ok(idx) => idx,
         Err(e) => {
-            log::debug!("Failed to read BAI index for size estimation: {}", e);
+            log::debug!("Failed to read BAI index for size estimation: {e}");
             // Return uniform estimates as fallback
             return regions
                 .iter()

--- a/datafusion/bio-format-bam/src/write_exec.rs
+++ b/datafusion/bio-format-bam/src/write_exec.rs
@@ -285,7 +285,7 @@ async fn write_bam_stream(
     schema_metadata_overrides: HashMap<String, String>,
     output_schema: SchemaRef,
 ) -> Result<RecordBatch> {
-    debug!("Starting BAM write to: {}", output_path);
+    debug!("Starting BAM write to: {output_path}");
 
     // Create writer
     let mut writer = BamLocalWriter::with_compression(&output_path, compression)?;
@@ -315,7 +315,7 @@ async fn write_bam_stream(
         let batch = batch_result?;
         let num_rows = batch.num_rows();
 
-        debug!("Writing batch with {} rows", num_rows);
+        debug!("Writing batch with {num_rows} rows");
 
         // Convert batch to BAM records
         let records =
@@ -329,7 +329,7 @@ async fn write_bam_stream(
     // Finish writing
     writer.finish(&header)?;
 
-    debug!("Wrote {} records to {}", total_count, output_path);
+    debug!("Wrote {total_count} records to {output_path}");
 
     // Return count as RecordBatch
     let count_array = Arc::new(UInt64Array::from(vec![total_count]));

--- a/datafusion/bio-format-bam/src/writer.rs
+++ b/datafusion/bio-format-bam/src/writer.rs
@@ -98,7 +98,7 @@ impl BamLocalWriter {
         compression: BamCompressionType,
     ) -> Result<Self> {
         let file = File::create(path.as_ref()).map_err(|e| {
-            DataFusionError::Execution(format!("Failed to create output file: {}", e))
+            DataFusionError::Execution(format!("Failed to create output file: {e}"))
         })?;
         let buf_writer = BufWriter::new(file);
 
@@ -125,10 +125,10 @@ impl BamLocalWriter {
     pub fn write_header(&mut self, header: &sam::Header) -> Result<()> {
         match self {
             BamLocalWriter::Sam(writer) => writer.write_header(header).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write SAM header: {}", e))
+                DataFusionError::Execution(format!("Failed to write SAM header: {e}"))
             }),
             BamLocalWriter::Bam(writer) => writer.write_header(header).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write BAM header: {}", e))
+                DataFusionError::Execution(format!("Failed to write BAM header: {e}"))
             }),
         }
     }
@@ -151,12 +151,12 @@ impl BamLocalWriter {
         match self {
             BamLocalWriter::Sam(writer) => {
                 writer.write_alignment_record(header, record).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to write SAM record: {}", e))
+                    DataFusionError::Execution(format!("Failed to write SAM record: {e}"))
                 })
             }
             BamLocalWriter::Bam(writer) => {
                 writer.write_alignment_record(header, record).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to write BAM record: {}", e))
+                    DataFusionError::Execution(format!("Failed to write BAM record: {e}"))
                 })
             }
         }
@@ -200,14 +200,14 @@ impl BamLocalWriter {
             BamLocalWriter::Sam(ref mut writer) => {
                 // SAM writer needs header for finish
                 writer.finish(header).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to finish SAM stream: {}", e))
+                    DataFusionError::Execution(format!("Failed to finish SAM stream: {e}"))
                 })?;
                 Ok(())
             }
             BamLocalWriter::Bam(ref mut writer) => {
                 // BAM writer needs header for finish
                 writer.finish(header).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to finish BAM stream: {}", e))
+                    DataFusionError::Execution(format!("Failed to finish BAM stream: {e}"))
                 })?;
                 Ok(())
             }

--- a/datafusion/bio-format-bam/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-bam/tests/indexed_read_test.rs
@@ -90,13 +90,11 @@ async fn test_bam_multi_chromosome_query() -> datafusion::error::Result<()> {
 
     assert!(
         chroms.contains("chr1"),
-        "Expected chr1 in results: {:?}",
-        chroms
+        "Expected chr1 in results: {chroms:?}"
     );
     assert!(
         chroms.contains("chr2"),
-        "Expected chr2 in results: {:?}",
-        chroms
+        "Expected chr2 in results: {chroms:?}"
     );
 
     let count = count_rows(
@@ -126,11 +124,7 @@ async fn test_bam_full_scan_total_count() -> datafusion::error::Result<()> {
     assert_eq!(
         total,
         chr1 + chr2 + chrx,
-        "Full scan total ({}) should equal sum of per-chrom counts (chr1={}, chr2={}, chrX={})",
-        total,
-        chr1,
-        chr2,
-        chrx
+        "Full scan total ({total}) should equal sum of per-chrom counts (chr1={chr1}, chr2={chr2}, chrX={chrx})"
     );
 
     Ok(())
@@ -151,9 +145,7 @@ async fn test_bam_record_level_filter() -> datafusion::error::Result<()> {
     );
     assert!(
         filtered <= total,
-        "Filtered count ({}) should be <= total ({})",
-        filtered,
-        total
+        "Filtered count ({filtered}) should be <= total ({total})"
     );
 
     Ok(())
@@ -176,9 +168,7 @@ async fn test_bam_combined_genomic_and_record_filter() -> datafusion::error::Res
     assert!(combined > 0, "Expected some reads matching combined filter");
     assert!(
         combined <= chr1_total,
-        "Combined filter count ({}) should be <= chr1 total ({})",
-        combined,
-        chr1_total
+        "Combined filter count ({combined}) should be <= chr1 total ({chr1_total})"
     );
 
     Ok(())
@@ -202,9 +192,7 @@ async fn test_bam_region_with_start_end() -> datafusion::error::Result<()> {
     assert!(region_count > 0, "Expected reads in the specified region");
     assert!(
         region_count < chr1_total,
-        "Region count ({}) should be < chr1 total ({})",
-        region_count,
-        chr1_total
+        "Region count ({region_count}) should be < chr1 total ({chr1_total})"
     );
 
     Ok(())
@@ -239,8 +227,7 @@ async fn test_bam_indexed_vs_full_scan_correctness() -> datafusion::error::Resul
 
     assert_eq!(
         indexed_count, manual_count,
-        "Indexed chr1 count ({}) should equal manual count from full scan ({})",
-        indexed_count, manual_count
+        "Indexed chr1 count ({indexed_count}) should equal manual count from full scan ({manual_count})"
     );
 
     Ok(())

--- a/datafusion/bio-format-bam/tests/tag_tests.rs
+++ b/datafusion/bio-format-bam/tests/tag_tests.rs
@@ -352,16 +352,10 @@ async fn test_xt_tag_character_values() {
 
     // All XT values should be single ASCII characters
     for val in &xt_values {
-        assert_eq!(
-            val.len(),
-            1,
-            "XT value '{}' should be single character",
-            val
-        );
+        assert_eq!(val.len(), 1, "XT value '{val}' should be single character");
         assert!(
             val.chars().next().unwrap().is_ascii(),
-            "XT value '{}' should be ASCII",
-            val,
+            "XT value '{val}' should be ASCII",
         );
     }
 }
@@ -405,8 +399,7 @@ async fn test_integer_tags_from_int8_encoding() {
                 let nm = nm_col.value(i);
                 assert!(
                     (0..100).contains(&nm),
-                    "NM={} should be a small non-negative integer",
-                    nm
+                    "NM={nm} should be a small non-negative integer"
                 );
             }
         }
@@ -491,26 +484,22 @@ async fn test_nullable_tags_with_mixed_presence() {
     // NM is present in most reads (12 of 14 mapped reads have it)
     assert!(
         nm_count >= 10,
-        "NM should be present in most reads, got {}",
-        nm_count
+        "NM should be present in most reads, got {nm_count}"
     );
     // XT is present in fewer reads (5 of 14)
     assert!(
         (3..14).contains(&xt_count),
-        "XT should be present in some reads, got {}",
-        xt_count
+        "XT should be present in some reads, got {xt_count}"
     );
     // XN is rare (2 of 14)
     assert!(
         (1..=5).contains(&xn_count),
-        "XN should be present in few reads, got {}",
-        xn_count
+        "XN should be present in few reads, got {xn_count}"
     );
     // OC is rare (2 of 14)
     assert!(
         (1..=5).contains(&oc_count),
-        "OC should be present in few reads, got {}",
-        oc_count
+        "OC should be present in few reads, got {oc_count}"
     );
 }
 
@@ -566,7 +555,7 @@ async fn test_describe_discovers_tags() {
         .filter(|&i| categories.value(i) == "tag")
         .count();
 
-    println!("Discovered {} tags in sample", tag_count);
+    println!("Discovered {tag_count} tags in sample");
     // Should discover at least some tags if present in data
 }
 

--- a/datafusion/bio-format-bed/src/physical_exec.rs
+++ b/datafusion/bio-format-bed/src/physical_exec.rs
@@ -65,7 +65,7 @@ impl DisplayAs for BedExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "BedExec: projection=[{}]", proj_str)
+        write!(f, "BedExec: projection=[{proj_str}]")
     }
 }
 
@@ -203,7 +203,7 @@ async fn get_remote_bed_stream(
             record_num += 1;
             // Once the batch size is reached, build and yield a record batch.
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let batch = build_record_batch(
                     Arc::clone(&schema.clone()),
                     &chroms,
@@ -213,7 +213,7 @@ async fn get_remote_bed_stream(
                     projection.clone(),
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 chroms.clear();
@@ -294,7 +294,7 @@ async fn get_local_bed(
             record_num += 1;
             // Once the batch size is reached, build and yield a record batch.
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let batch = build_record_batch(
                     Arc::clone(&schema.clone()),
                     &chroms,
@@ -304,7 +304,7 @@ async fn get_local_bed(
                    projection.clone(),
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 chroms.clear();
@@ -380,7 +380,7 @@ fn build_record_batch(
         }
     };
     RecordBatch::try_new(schema.clone(), arrays)
-        .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+        .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
 }
 
 /// Routes to appropriate reader based on storage backend and creates a record batch stream

--- a/datafusion/bio-format-bed/src/table_provider.rs
+++ b/datafusion/bio-format-bed/src/table_provider.rs
@@ -56,7 +56,7 @@ fn determine_schema(coordinate_system_zero_based: bool) -> datafusion::common::R
         coordinate_system_zero_based.to_string(),
     );
     let schema = Schema::new_with_metadata(fields, metadata);
-    debug!("Schema: {:?}", schema);
+    debug!("Schema: {schema:?}");
     Ok(Arc::new(schema))
 }
 

--- a/datafusion/bio-format-core/src/alignment_utils.rs
+++ b/datafusion/bio-format-core/src/alignment_utils.rs
@@ -267,10 +267,10 @@ pub fn build_record_batch(
     if arrays.is_empty() {
         let options = RecordBatchOptions::new().with_row_count(Some(record_count));
         RecordBatch::try_new_with_options(schema.clone(), arrays, &options)
-            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
     } else {
         RecordBatch::try_new(schema.clone(), arrays)
-            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
     }
 }
 
@@ -332,10 +332,10 @@ pub fn build_record_batch_from_builders(
     if arrays.is_empty() {
         let options = RecordBatchOptions::new().with_row_count(Some(record_count));
         RecordBatch::try_new_with_options(schema.clone(), arrays, &options)
-            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
     } else {
         RecordBatch::try_new(schema.clone(), arrays)
-            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
     }
 }
 
@@ -754,7 +754,7 @@ fn code_to_op_kind(code: u8) -> io::Result<OpKind> {
         8 => Ok(OpKind::SequenceMismatch),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("invalid CIGAR op code: {}", code),
+            format!("invalid CIGAR op code: {code}"),
         )),
     }
 }

--- a/datafusion/bio-format-core/src/index_utils.rs
+++ b/datafusion/bio-format-core/src/index_utils.rs
@@ -32,8 +32,8 @@ pub fn discover_index_path(data_file: &str, format: IndexFormat) -> Option<Strin
     let candidates = get_index_candidates(data_file, format);
     let result = candidates.into_iter().find(|path| Path::new(path).exists());
     match &result {
-        Some(path) => debug!("Discovered {:?} index for {}: {}", format, data_file, path),
-        None => debug!("No {:?} index found for {}", format, data_file),
+        Some(path) => debug!("Discovered {format:?} index for {data_file}: {path}"),
+        None => debug!("No {format:?} index found for {data_file}"),
     }
     result
 }
@@ -47,7 +47,7 @@ fn get_index_candidates(data_file: &str, format: IndexFormat) -> Vec<String> {
             // Convention 2: file.bai (replacing .bam extension)
             let mut candidates = vec![format!("{}.bai", data_file)];
             if let Some(stripped) = data_file.strip_suffix(".bam") {
-                candidates.push(format!("{}.bai", stripped));
+                candidates.push(format!("{stripped}.bai"));
             }
             candidates
         }
@@ -102,12 +102,9 @@ pub fn discover_pairs_index(data_file: &str) -> Option<(String, IndexFormat)> {
         return Some((path, IndexFormat::CSI));
     }
     // Pairix (.px2) index is tabix-compatible
-    let px2_path = format!("{}.px2", data_file);
+    let px2_path = format!("{data_file}.px2");
     if Path::new(&px2_path).exists() {
-        debug!(
-            "Discovered pairix (.px2) index for {}: {}",
-            data_file, px2_path
-        );
+        debug!("Discovered pairix (.px2) index for {data_file}: {px2_path}");
         return Some((px2_path, IndexFormat::TBI));
     }
     None

--- a/datafusion/bio-format-core/src/object_storage.rs
+++ b/datafusion/bio-format-core/src/object_storage.rs
@@ -77,7 +77,7 @@ impl CompressionType {
             "bgz" => CompressionType::BGZF,
             "none" => CompressionType::NONE,
             "auto" => CompressionType::AUTO,
-            _ => panic!("Invalid compression type: {}", compression_type),
+            _ => panic!("Invalid compression type: {compression_type}"),
         }
     }
 }
@@ -168,8 +168,7 @@ pub async fn get_compression_type(
     object_storage_options: ObjectStorageOptions,
 ) -> Result<CompressionType, opendal::Error> {
     debug!(
-        "get_compression_type called with file_path: {}, compression_type: {:?}",
-        file_path, compression_type
+        "get_compression_type called with file_path: {file_path}, compression_type: {compression_type:?}"
     );
     if let Some(ct) = compression_type {
         if ct != CompressionType::AUTO {
@@ -208,10 +207,7 @@ pub async fn get_compression_type(
                 buffer
             }
             Err(e) => {
-                log::error!(
-                    "Failed to get remote stream for compression detection: {}",
-                    e
-                );
+                log::error!("Failed to get remote stream for compression detection: {e}");
                 return Ok(CompressionType::NONE);
             }
         }
@@ -357,7 +353,7 @@ fn extract_account_and_container(url_str: &str) -> BlobInfo {
     let host = url.host_str().ok_or("URL is missing a host").unwrap();
     // If there’s an explicit port (e.g. emulator), include it; otherwise, empty.
     let port = match url.port() {
-        Some(p) => format!("{}", p),
+        Some(p) => format!("{p}"),
         None => String::new(),
     };
     let mut segments = url
@@ -395,9 +391,9 @@ fn extract_account_and_container(url_str: &str) -> BlobInfo {
     };
     let endpoint = if !host.ends_with(".blob.core.windows.net") {
         // For Azure Blob Storage, the endpoint is the full URL without the path
-        format!("{}://{}:{}/{}", scheme, host, port, account)
+        format!("{scheme}://{host}:{port}/{account}")
     } else {
-        format!("{}://{}:{}", scheme, host, port)
+        format!("{scheme}://{host}:{port}")
     };
     let remaining: Vec<&str> = segments.collect();
     // Join by "/" (no leading slash). If empty, relative_path = ""
@@ -475,16 +471,11 @@ pub async fn get_remote_stream(
         StorageType::S3 => {
             log::info!(
                 "Using S3 storage type with parameters: \
-                bucket_name: {}, \
-                allow_anonymous: {}, \
-                enable_request_payer: {}, \
-                max_retries: {}, \
-                timeout: {}",
-                bucket_name,
-                allow_anonymous,
-                enable_request_payer,
-                max_retries,
-                timeout
+                bucket_name: {bucket_name}, \
+                allow_anonymous: {allow_anonymous}, \
+                enable_request_payer: {enable_request_payer}, \
+                max_retries: {max_retries}, \
+                timeout: {timeout}"
             );
             let mut builder = S3::default()
                 .region(
@@ -600,18 +591,12 @@ pub async fn get_remote_stream(
         StorageType::GCS => {
             log::info!(
                 "Using GCS storage type with parameters: \
-                bucket_name: {}, \
-                chunk_size: {}, \
-                concurrent_fetches: {}, \
-                allow_anonymous: {}, \
-                max_retries: {}, \
-                timeout: {}",
-                bucket_name,
-                chunk_size,
-                concurrent_fetches,
-                allow_anonymous,
-                max_retries,
-                timeout,
+                bucket_name: {bucket_name}, \
+                chunk_size: {chunk_size}, \
+                concurrent_fetches: {concurrent_fetches}, \
+                allow_anonymous: {allow_anonymous}, \
+                max_retries: {max_retries}, \
+                timeout: {timeout}",
             );
             let mut builder = Gcs::default().bucket(bucket_name.as_str());
             if allow_anonymous {

--- a/datafusion/bio-format-core/src/partition_balancer.rs
+++ b/datafusion/bio-format-core/src/partition_balancer.rs
@@ -399,8 +399,7 @@ mod tests {
         let total_regions: usize = result.iter().map(|b| b.regions.len()).sum();
         assert!(
             total_regions > 2,
-            "Expected splitting, got {} regions",
-            total_regions
+            "Expected splitting, got {total_regions} regions"
         );
         assert!(result.len() <= 4, "Should not exceed target_partitions");
     }
@@ -567,8 +566,7 @@ mod tests {
         let result_total: u64 = result.iter().map(|b| b.total_estimated_bytes).sum();
         assert_eq!(
             result_total, total,
-            "Total bytes should be exactly preserved: {} vs {}",
-            result_total, total
+            "Total bytes should be exactly preserved: {result_total} vs {total}"
         );
 
         // Linear scan guarantees near-perfect balance
@@ -585,9 +583,7 @@ mod tests {
         // With linear scan, max/min ratio should be very close to 1
         assert!(
             max_bytes <= min_bytes * 2,
-            "Partitions too imbalanced: max={} min={}",
-            max_bytes,
-            min_bytes
+            "Partitions too imbalanced: max={max_bytes} min={min_bytes}"
         );
     }
 
@@ -728,8 +724,7 @@ mod tests {
             let result_total: u64 = result.iter().map(|b| b.total_estimated_bytes).sum();
             assert_eq!(
                 result_total, total,
-                "Total bytes not preserved for target={}: {} vs {}",
-                target, result_total, total
+                "Total bytes not preserved for target={target}: {result_total} vs {total}"
             );
         }
     }
@@ -778,8 +773,7 @@ mod tests {
             if let Some(end) = region.end {
                 assert!(
                     end < 2_000_000,
-                    "Split end {} should be near data (< 2M), not spread across full contig",
-                    end
+                    "Split end {end} should be near data (< 2M), not spread across full contig"
                 );
             }
         }
@@ -803,8 +797,7 @@ mod tests {
             let result_total: u64 = result.iter().map(|b| b.total_estimated_bytes).sum();
             assert_eq!(
                 result_total, total,
-                "Bin-aware: total bytes not preserved for target={}: {} vs {}",
-                target, result_total, total
+                "Bin-aware: total bytes not preserved for target={target}: {result_total} vs {total}"
             );
         }
     }
@@ -877,8 +870,7 @@ mod tests {
                 || (200_000_000..=201_000_000).contains(&end);
             assert!(
                 near_cluster,
-                "Split at {} should be near a data cluster, not in empty genomic space",
-                end
+                "Split at {end} should be near a data cluster, not in empty genomic space"
             );
         }
     }
@@ -916,7 +908,7 @@ mod tests {
         ];
         // Add 60 zero-estimate alt/decoy contigs (like chrUn_*, chr*_random, HLA-*)
         for i in 0..60 {
-            estimates.push(estimate(&format!("alt_contig_{}", i), 0, None));
+            estimates.push(estimate(&format!("alt_contig_{i}"), 0, None));
         }
 
         let result = balance_partitions(estimates, 8);
@@ -925,8 +917,7 @@ mod tests {
         let total_regions: usize = result.iter().map(|b| b.regions.len()).sum();
         assert!(
             total_regions >= 84,
-            "Expected at least 84 regions (24 chroms + 60 alts), got {}",
-            total_regions
+            "Expected at least 84 regions (24 chroms + 60 alts), got {total_regions}"
         );
 
         // Total estimated bytes preserved
@@ -949,17 +940,14 @@ mod tests {
         // Allow up to 15 (< 2x ideal share) to account for uneven data-region counts.
         assert!(
             max_zero <= 15,
-            "Max zero-est regions on one partition = {}, expected <= 15. Distribution: {:?}",
-            max_zero,
-            zero_est_per_partition
+            "Max zero-est regions on one partition = {max_zero}, expected <= 15. Distribution: {zero_est_per_partition:?}"
         );
 
         // No partition should have 0 zero-estimate regions (all should get some)
         let min_zero = *zero_est_per_partition.iter().min().unwrap();
         assert!(
             min_zero >= 1,
-            "Every partition should get at least 1 zero-est region. Distribution: {:?}",
-            zero_est_per_partition
+            "Every partition should get at least 1 zero-est region. Distribution: {zero_est_per_partition:?}"
         );
     }
 
@@ -973,7 +961,7 @@ mod tests {
             estimate("chr3", 60, Some(198_000_000)),
         ];
         for i in 0..20 {
-            estimates.push(estimate(&format!("scaffold_{}", i), 0, None));
+            estimates.push(estimate(&format!("scaffold_{i}"), 0, None));
         }
 
         let result = balance_partitions(estimates, 4);
@@ -982,8 +970,7 @@ mod tests {
         let total_regions: usize = result.iter().map(|b| b.regions.len()).sum();
         assert!(
             total_regions >= 23,
-            "Expected at least 23 regions, got {}",
-            total_regions
+            "Expected at least 23 regions, got {total_regions}"
         );
 
         // Total bytes preserved
@@ -1005,17 +992,13 @@ mod tests {
         let max_scaffolds = *scaffold_per_partition.iter().max().unwrap();
         assert!(
             max_scaffolds < 20,
-            "One partition got all {} scaffolds — not distributed! {:?}",
-            max_scaffolds,
-            scaffold_per_partition
+            "One partition got all {max_scaffolds} scaffolds — not distributed! {scaffold_per_partition:?}"
         );
 
         // With 20 scaffolds across 4 partitions, max should be <= 8 (generous threshold)
         assert!(
             max_scaffolds <= 8,
-            "Max scaffolds on one partition = {}, expected <= 8. Distribution: {:?}",
-            max_scaffolds,
-            scaffold_per_partition
+            "Max scaffolds on one partition = {max_scaffolds}, expected <= 8. Distribution: {scaffold_per_partition:?}"
         );
     }
 }

--- a/datafusion/bio-format-core/src/table_utils.rs
+++ b/datafusion/bio-format-core/src/table_utils.rs
@@ -157,8 +157,7 @@ impl OptionalField {
                 Ok(())
             }
             other => Err(ArrowError::SchemaError(format!(
-                "Expected ArrayStructBuilder, found {:?}",
-                other
+                "Expected ArrayStructBuilder, found {other:?}"
             ))),
         }
     }

--- a/datafusion/bio-format-cram/examples/test_tag_discovery.rs
+++ b/datafusion/bio-format-cram/examples/test_tag_discovery.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let test_file = "/Users/mwiewior/research/git/polars-bio/tests/data/io/cram/test.cram";
 
-    println!("Testing CRAM tag discovery with file: {}", test_file);
+    println!("Testing CRAM tag discovery with file: {test_file}");
     println!("{}", "=".repeat(80));
 
     // Test 1: Using try_new_with_inferred_schema (should discover tags)
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             df.show().await?;
         }
         Err(e) => {
-            println!("Query failed as expected: {}", e);
+            println!("Query failed as expected: {e}");
         }
     }
 

--- a/datafusion/bio-format-cram/examples/write_cram.rs
+++ b/datafusion/bio-format-cram/examples/write_cram.rs
@@ -124,9 +124,9 @@ async fn main() -> datafusion::error::Result<()> {
 
     println!("\n✓ CRAM write examples completed successfully");
     println!("Output files:");
-    println!("  - {}", output_path_1);
-    println!("  - {}", output_path_2);
-    println!("  - {}", output_path_3);
+    println!("  - {output_path_1}");
+    println!("  - {output_path_2}");
+    println!("  - {output_path_3}");
     println!("  - output/converted.cram");
     println!("\nNote: Create .fai index for reference with: samtools faidx reference/genome.fasta");
 

--- a/datafusion/bio-format-cram/src/physical_exec.rs
+++ b/datafusion/bio-format-cram/src/physical_exec.rs
@@ -76,7 +76,7 @@ impl DisplayAs for CramExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "CramExec: projection=[{}]", proj_str)
+        write!(f, "CramExec: projection=[{proj_str}]")
     }
 }
 
@@ -201,7 +201,7 @@ fn set_tag_builders(
                 }
             };
 
-            debug!("Creating builder for tag {}: {:?}", tag, arrow_type);
+            debug!("Creating builder for tag {tag}: {arrow_type:?}");
 
             if let Ok(builder) = OptionalField::new(&arrow_type, batch_size) {
                 let tag_bytes = tag.as_bytes();
@@ -211,12 +211,12 @@ fn set_tag_builders(
                     tag_builders.1.push(arrow_type.clone());
                     tag_builders.2.push(builder);
                     tag_builders.3.push(parsed_tag);
-                    debug!("Successfully created builder for tag {}", tag);
+                    debug!("Successfully created builder for tag {tag}");
                 } else {
-                    debug!("Invalid tag name length for {}", tag);
+                    debug!("Invalid tag name length for {tag}");
                 }
             } else {
-                debug!("Failed to create builder for tag {}: {:?}", tag, arrow_type);
+                debug!("Failed to create builder for tag {tag}: {arrow_type:?}");
             }
         }
     }
@@ -619,7 +619,7 @@ async fn get_remote_cram_stream(
 
             record_num += 1;
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let tag_arrays = if num_tag_fields > 0 {
                     Some(builders_to_arrays(&mut tag_builders.2)?)
                 } else {
@@ -646,7 +646,7 @@ async fn get_remote_cram_stream(
                     batch_size,
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 name.clear();
                 chrom.clear();
@@ -892,7 +892,7 @@ async fn get_local_cram(
 
             record_num += 1;
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let tag_arrays = if num_tag_fields > 0 {
                     Some(builders_to_arrays(&mut tag_builders.2)?)
                 } else {
@@ -919,7 +919,7 @@ async fn get_local_cram(
                     batch_size,
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 name.clear();
@@ -1027,7 +1027,7 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
     region_str
         .parse::<noodles_core::Region>()
-        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{}': {}", region_str, e)))
+        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{region_str}': {e}")))
 }
 
 /// Get a streaming RecordBatch stream from an indexed CRAM file for one or more regions.
@@ -1056,7 +1056,7 @@ async fn get_indexed_stream(
             let mut indexed_reader =
                 IndexedCramReader::new(&file_path, &index_path, reference_path.as_deref())
                     .map_err(|e| {
-                        DataFusionError::Execution(format!("Failed to open indexed CRAM: {}", e))
+                        DataFusionError::Execution(format!("Failed to open indexed CRAM: {e}"))
                     })?;
 
             let names = indexed_reader.reference_names();
@@ -1120,12 +1120,12 @@ async fn get_indexed_stream(
 
                 let noodles_region = build_noodles_region(region)?;
                 let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("CRAM region query failed: {}", e))
+                    DataFusionError::Execution(format!("CRAM region query failed: {e}"))
                 })?;
 
                 for result in records {
                     let record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("CRAM record read error: {}", e))
+                        DataFusionError::Execution(format!("CRAM record read error: {e}"))
                     })?;
 
                     let chrom_name =

--- a/datafusion/bio-format-cram/src/serializer.rs
+++ b/datafusion/bio-format-cram/src/serializer.rs
@@ -199,7 +199,7 @@ fn build_single_record(
             let ops =
                 datafusion_bio_format_core::alignment_utils::decode_binary_cigar_to_ops(bytes)
                     .map_err(|e| {
-                        DataFusionError::Execution(format!("Failed to decode binary CIGAR: {}", e))
+                        DataFusionError::Execution(format!("Failed to decode binary CIGAR: {e}"))
                     })?;
             Cigar::from(ops)
         }
@@ -285,7 +285,7 @@ fn parse_cigar_string(cigar_str: &str) -> Result<Cigar> {
     // Collect operations from the iterator
     let ops: std::result::Result<Vec<_>, _> = record_cigar.iter().collect();
     let ops = ops.map_err(|e| {
-        DataFusionError::Execution(format!("Failed to parse CIGAR '{}': {}", cigar_str, e))
+        DataFusionError::Execution(format!("Failed to parse CIGAR '{cigar_str}': {e}"))
     })?;
 
     Ok(Cigar::from(ops))
@@ -457,37 +457,37 @@ fn arrow_to_sam_tag_value(
 /// Gets a string column from the batch by name
 fn get_string_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be String type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be String type")))
 }
 
 /// Gets a u32 column from the batch by name
 fn get_u32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a UInt32Array> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<UInt32Array>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be UInt32 type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be UInt32 type")))
 }
 
 /// Gets an i32 column from the batch by name
 fn get_i32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int32Array> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<Int32Array>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be Int32 type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be Int32 type")))
 }
 
 /// Builds a map from tag name to column index

--- a/datafusion/bio-format-cram/src/write_exec.rs
+++ b/datafusion/bio-format-cram/src/write_exec.rs
@@ -281,7 +281,7 @@ async fn write_cram_stream(
     schema_metadata_overrides: HashMap<String, String>,
     output_schema: SchemaRef,
 ) -> Result<RecordBatch> {
-    debug!("Starting CRAM write to: {}", output_path);
+    debug!("Starting CRAM write to: {output_path}");
 
     // Create writer with reference
     let reference_path_ref = reference_path.as_ref();
@@ -322,7 +322,7 @@ async fn write_cram_stream(
         let batch = batch_result?;
         let num_rows = batch.num_rows();
 
-        debug!("Writing batch with {} rows", num_rows);
+        debug!("Writing batch with {num_rows} rows");
 
         // Convert batch to CRAM records
         let records =
@@ -336,7 +336,7 @@ async fn write_cram_stream(
     // Finish writing
     writer.finish(&header)?;
 
-    debug!("Wrote {} records to {}", total_count, output_path);
+    debug!("Wrote {total_count} records to {output_path}");
 
     // Return count as RecordBatch
     let count_array = Arc::new(UInt64Array::from(vec![total_count]));

--- a/datafusion/bio-format-cram/src/writer.rs
+++ b/datafusion/bio-format-cram/src/writer.rs
@@ -63,9 +63,8 @@ impl CramLocalWriter {
             }
         }
 
-        let file = File::create(path.as_ref()).map_err(|e| {
-            DataFusionError::Execution(format!("Failed to create CRAM file: {}", e))
-        })?;
+        let file = File::create(path.as_ref())
+            .map_err(|e| DataFusionError::Execution(format!("Failed to create CRAM file: {e}")))?;
         let buf_writer = BufWriter::new(file);
 
         // Build writer with reference repository if available
@@ -82,13 +81,12 @@ impl CramLocalWriter {
             let fai_path = format!("{}.fai", ref_path.display());
             let index_file = File::open(&fai_path).map_err(|e| {
                 DataFusionError::Execution(format!(
-                    "Failed to open reference index {}: {}",
-                    fai_path, e
+                    "Failed to open reference index {fai_path}: {e}"
                 ))
             })?;
             let mut index_reader = fasta::fai::io::Reader::new(std::io::BufReader::new(index_file));
             let index = index_reader.read_index().map_err(|e| {
-                DataFusionError::Execution(format!("Failed to read FASTA index: {}", e))
+                DataFusionError::Execution(format!("Failed to read FASTA index: {e}"))
             })?;
 
             let indexed_reader = fasta::io::IndexedReader::new(fasta_reader, index);
@@ -127,7 +125,7 @@ impl CramLocalWriter {
     pub fn write_header(&mut self, header: &sam::Header) -> Result<()> {
         self.writer
             .write_header(header)
-            .map_err(|e| DataFusionError::Execution(format!("Failed to write CRAM header: {}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Failed to write CRAM header: {e}")))
     }
 
     /// Writes a single alignment record to the file
@@ -147,7 +145,7 @@ impl CramLocalWriter {
     ) -> Result<()> {
         self.writer
             .write_alignment_record(header, record)
-            .map_err(|e| DataFusionError::Execution(format!("Failed to write CRAM record: {}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Failed to write CRAM record: {e}")))
     }
 
     /// Writes multiple alignment records to the file
@@ -184,11 +182,12 @@ impl CramLocalWriter {
     /// Returns an error if finishing fails
     pub fn finish(mut self, header: &sam::Header) -> Result<()> {
         self.writer.finish(header).map_err(|e| {
-            DataFusionError::Execution(format!("Failed to finish CRAM stream: {}", e))
+            DataFusionError::Execution(format!("Failed to finish CRAM stream: {e}"))
         })?;
-        self.writer.get_mut().flush().map_err(|e| {
-            DataFusionError::Execution(format!("Failed to flush CRAM output: {}", e))
-        })?;
+        self.writer
+            .get_mut()
+            .flush()
+            .map_err(|e| DataFusionError::Execution(format!("Failed to flush CRAM output: {e}")))?;
         Ok(())
     }
 }
@@ -277,7 +276,7 @@ mod tests {
         // Build reference repository
         let fasta_file = File::open(ref_path).unwrap();
         let fasta_reader = std::io::BufReader::new(fasta_file);
-        let fai_path = format!("{}.fai", ref_path);
+        let fai_path = format!("{ref_path}.fai");
         let index_file = File::open(&fai_path).unwrap();
         let mut index_reader = fasta::fai::io::Reader::new(std::io::BufReader::new(index_file));
         let index = index_reader.read_index().unwrap();
@@ -297,7 +296,7 @@ mod tests {
             match result {
                 Ok(record) => records.push(record),
                 Err(e) => {
-                    eprintln!("Error reading record: {}", e);
+                    eprintln!("Error reading record: {e}");
                     break;
                 }
             }
@@ -370,6 +369,6 @@ mod tests {
             count, num_original,
             "Should read back the same number of records"
         );
-        eprintln!("Roundtrip successful: {} records", count);
+        eprintln!("Roundtrip successful: {count} records");
     }
 }

--- a/datafusion/bio-format-cram/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-cram/tests/indexed_read_test.rs
@@ -91,13 +91,11 @@ async fn test_cram_multi_chromosome_query() -> datafusion::error::Result<()> {
 
     assert!(
         chroms.contains("chr1"),
-        "Expected chr1 in results: {:?}",
-        chroms
+        "Expected chr1 in results: {chroms:?}"
     );
     assert!(
         chroms.contains("chr2"),
-        "Expected chr2 in results: {:?}",
-        chroms
+        "Expected chr2 in results: {chroms:?}"
     );
 
     Ok(())
@@ -118,11 +116,7 @@ async fn test_cram_full_scan_total_count() -> datafusion::error::Result<()> {
     assert_eq!(
         total,
         chr1 + chr2 + chrx,
-        "Full scan total ({}) should equal sum of per-chrom counts (chr1={}, chr2={}, chrX={})",
-        total,
-        chr1,
-        chr2,
-        chrx
+        "Full scan total ({total}) should equal sum of per-chrom counts (chr1={chr1}, chr2={chr2}, chrX={chrx})"
     );
 
     Ok(())
@@ -142,9 +136,7 @@ async fn test_cram_record_level_filter() -> datafusion::error::Result<()> {
     );
     assert!(
         filtered <= total,
-        "Filtered count ({}) should be <= total ({})",
-        filtered,
-        total
+        "Filtered count ({filtered}) should be <= total ({total})"
     );
 
     Ok(())
@@ -165,9 +157,7 @@ async fn test_cram_combined_genomic_and_record_filter() -> datafusion::error::Re
     assert!(combined > 0, "Expected some reads matching combined filter");
     assert!(
         combined <= chr1_total,
-        "Combined filter count ({}) should be <= chr1 total ({})",
-        combined,
-        chr1_total
+        "Combined filter count ({combined}) should be <= chr1 total ({chr1_total})"
     );
 
     Ok(())
@@ -189,9 +179,7 @@ async fn test_cram_region_with_start_end() -> datafusion::error::Result<()> {
     assert!(region_count > 0, "Expected reads in the specified region");
     assert!(
         region_count <= chr1_total,
-        "Region count ({}) should be <= chr1 total ({})",
-        region_count,
-        chr1_total
+        "Region count ({region_count}) should be <= chr1 total ({chr1_total})"
     );
 
     Ok(())
@@ -222,8 +210,7 @@ async fn test_cram_indexed_vs_full_scan_correctness() -> datafusion::error::Resu
 
     assert_eq!(
         indexed_count, manual_count,
-        "Indexed chr1 count ({}) should equal manual count from full scan ({})",
-        indexed_count, manual_count
+        "Indexed chr1 count ({indexed_count}) should equal manual count from full scan ({manual_count})"
     );
 
     Ok(())

--- a/datafusion/bio-format-cram/tests/tag_tests.rs
+++ b/datafusion/bio-format-cram/tests/tag_tests.rs
@@ -57,8 +57,7 @@ async fn test_cram_read_with_tags() {
     let nm_count: usize = results.iter().map(|b| b.num_rows()).sum();
     assert!(
         nm_count > 400,
-        "NM should be present in most reads, got {}",
-        nm_count
+        "NM should be present in most reads, got {nm_count}"
     );
 
     for batch in &results {
@@ -72,8 +71,7 @@ async fn test_cram_read_with_tags() {
                 let nm = nm_col.value(i);
                 assert!(
                     (0..100).contains(&nm),
-                    "NM={} should be a small non-negative integer",
-                    nm
+                    "NM={nm} should be a small non-negative integer"
                 );
             }
         }
@@ -89,8 +87,7 @@ async fn test_cram_read_with_tags() {
     let md_count: usize = results.iter().map(|b| b.num_rows()).sum();
     assert!(
         md_count > 400,
-        "MD should be present in most reads, got {}",
-        md_count
+        "MD should be present in most reads, got {md_count}"
     );
 
     for batch in &results {
@@ -115,8 +112,7 @@ async fn test_cram_read_with_tags() {
     let mq_count = count_rows(&ctx, "SELECT \"MQ\" FROM cram WHERE \"MQ\" IS NOT NULL").await;
     assert!(
         mq_count > 400,
-        "MQ should be present in most reads, got {}",
-        mq_count
+        "MQ should be present in most reads, got {mq_count}"
     );
 }
 
@@ -148,13 +144,11 @@ async fn test_cram_nullable_tags_with_mixed_presence() {
     // NM and MQ should be present in most reads
     assert!(
         nm_count > 400,
-        "NM should be present in most reads, got {}",
-        nm_count
+        "NM should be present in most reads, got {nm_count}"
     );
     assert!(
         mq_count > 400,
-        "MQ should be present in most reads, got {}",
-        mq_count
+        "MQ should be present in most reads, got {mq_count}"
     );
 
     // E2 may be present in some or all — just verify the query runs and count is reasonable

--- a/datafusion/bio-format-fasta/src/physical_exec.rs
+++ b/datafusion/bio-format-fasta/src/physical_exec.rs
@@ -70,7 +70,7 @@ impl DisplayAs for FastaExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "FastaExec: projection=[{}]", proj_str)
+        write!(f, "FastaExec: projection=[{proj_str}]")
     }
 }
 
@@ -169,7 +169,7 @@ async fn get_remote_fasta_stream(
             record_num += 1;
             // Once the batch size is reached, build and yield a record batch.
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let batch = build_record_batch(
                     Arc::clone(&schema.clone()),
                     &name,
@@ -178,7 +178,7 @@ async fn get_remote_fasta_stream(
                     projection.clone(),
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 name.clear();
@@ -237,7 +237,7 @@ async fn get_local_fasta(
             record_num += 1;
             // Once the batch size is reached, build and yield a record batch.
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let batch = build_record_batch(
                     Arc::clone(&schema.clone()),
                     &name,
@@ -246,7 +246,7 @@ async fn get_local_fasta(
                     projection.clone(),
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 name.clear();
@@ -289,7 +289,7 @@ async fn get_local_fasta_sync(
     std::thread::spawn(move || {
         let read_and_send = || -> Result<(), DataFusionError> {
             let mut reader = open_local_fasta_sync(&file_path, compression_type)
-                .map_err(|e| DataFusionError::Execution(format!("Failed to open FASTA: {}", e)))?;
+                .map_err(|e| DataFusionError::Execution(format!("Failed to open FASTA: {e}")))?;
 
             let mut name: Vec<String> = Vec::with_capacity(batch_size);
             let mut description: Vec<Option<String>> = Vec::with_capacity(batch_size);
@@ -306,14 +306,13 @@ async fn get_local_fasta_sync(
                     Ok(_) => {
                         seq_buf.clear();
                         reader.read_sequence(&mut seq_buf).map_err(|e| {
-                            DataFusionError::Execution(format!("FASTA sequence read error: {}", e))
+                            DataFusionError::Execution(format!("FASTA sequence read error: {e}"))
                         })?;
 
                         let definition: noodles_fasta::record::Definition =
                             def_buf.parse().map_err(|e| {
                                 DataFusionError::Execution(format!(
-                                    "FASTA definition parse error: {}",
-                                    e
+                                    "FASTA definition parse error: {e}"
                                 ))
                             })?;
 
@@ -332,7 +331,7 @@ async fn get_local_fasta_sync(
                         record_num += 1;
 
                         if record_num % batch_size == 0 {
-                            debug!("Record number: {}", record_num);
+                            debug!("Record number: {record_num}");
                             let batch = build_record_batch(
                                 Arc::clone(&schema),
                                 &name,
@@ -355,10 +354,7 @@ async fn get_local_fasta_sync(
                         }
                     }
                     Err(e) => {
-                        return Err(DataFusionError::Execution(format!(
-                            "FASTA read error: {}",
-                            e
-                        )));
+                        return Err(DataFusionError::Execution(format!("FASTA read error: {e}")));
                     }
                 }
             }
@@ -381,7 +377,7 @@ async fn get_local_fasta_sync(
                 }
             }
 
-            debug!("Local FASTA sync scan: {} records", record_num);
+            debug!("Local FASTA sync scan: {record_num} records");
             Ok(())
         };
         if let Err(e) = read_and_send() {
@@ -436,7 +432,7 @@ fn build_record_batch(
         }
     };
     RecordBatch::try_new(schema.clone(), arrays)
-        .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+        .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
 }
 
 async fn get_stream(
@@ -462,7 +458,7 @@ async fn get_stream(
             )
             .await
             .map_err(|e| {
-                DataFusionError::Execution(format!("Failed to detect compression: {}", e))
+                DataFusionError::Execution(format!("Failed to detect compression: {e}"))
             })?;
 
             if matches!(compression_type, CompressionType::GZIP) {

--- a/datafusion/bio-format-fasta/src/storage.rs
+++ b/datafusion/bio-format-fasta/src/storage.rs
@@ -189,7 +189,7 @@ impl FastaRemoteReader {
         let compression_type =
             get_compression_type(file_path.clone(), None, object_storage_options.clone())
                 .await
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
         match compression_type {
             CompressionType::BGZF => {
                 let reader =
@@ -235,6 +235,7 @@ impl FastaRemoteReader {
 /// - `BGZF`: Reads BGZF-compressed files with multithreaded decompression
 /// - `GZIP`: Reads GZIP-compressed files asynchronously
 /// - `PLAIN`: Reads uncompressed files synchronously
+#[allow(clippy::large_enum_variant)]
 pub enum FastaLocalReader {
     /// BGZF-compressed reader variant
     BGZF(fasta::io::Reader<bgzf::Reader<std::fs::File>>),
@@ -269,7 +270,7 @@ impl FastaLocalReader {
             object_storage_options.clone(),
         )
         .await
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(std::io::Error::other)?;
         match compression_type {
             CompressionType::BGZF => {
                 let reader = get_local_fasta_bgzf_reader(file_path)?;
@@ -349,10 +350,7 @@ pub fn open_local_fasta_sync(
         )?)),
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
-            format!(
-                "Sync FASTA reader does not support compression: {:?}",
-                compression_type
-            ),
+            format!("Sync FASTA reader does not support compression: {compression_type:?}"),
         )),
     }
 }

--- a/datafusion/bio-format-fasta/src/table_provider.rs
+++ b/datafusion/bio-format-fasta/src/table_provider.rs
@@ -28,7 +28,7 @@ fn determine_schema() -> datafusion::common::Result<SchemaRef> {
         Field::new("sequence", DataType::Utf8, false),
     ];
     let schema = Schema::new(fields);
-    debug!("Schema: {:?}", schema);
+    debug!("Schema: {schema:?}");
     Ok(Arc::new(schema))
 }
 

--- a/datafusion/bio-format-fastq/examples/performance_test.rs
+++ b/datafusion/bio-format-fastq/examples/performance_test.rs
@@ -42,7 +42,7 @@ async fn main() -> datafusion::common::Result<()> {
     }
     let file_path = &args[1];
 
-    println!("Using file: {}", file_path);
+    println!("Using file: {file_path}");
 
     // Create a SessionContext with 16 target partitions for parallel reading
     let config = SessionConfig::new().with_target_partitions(16);
@@ -59,7 +59,7 @@ async fn main() -> datafusion::common::Result<()> {
     println!("{}", batches.len());
     let elapsed = start_time.elapsed();
 
-    println!("Query executed in: {:?}", elapsed);
+    println!("Query executed in: {elapsed:?}");
 
     Ok(())
 }

--- a/datafusion/bio-format-fastq/examples/projection_pushdown_demo.rs
+++ b/datafusion/bio-format-fastq/examples/projection_pushdown_demo.rs
@@ -28,13 +28,13 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 "#;
 
 async fn create_test_file(content: &str, filename: &str) -> std::io::Result<String> {
-    let file_path = format!("/tmp/{}", filename);
+    let file_path = format!("/tmp/{filename}");
 
     // Create a larger file by repeating the content
     let mut large_content = String::new();
     for i in 0..1000 {
         // Repeat 1000 times for performance testing
-        let modified_content = content.replace("@read", &format!("@read_{}", i));
+        let modified_content = content.replace("@read", &format!("@read_{i}"));
         large_content.push_str(&modified_content);
     }
 
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "   Rows: {}",
         results.iter().map(|b| b.num_rows()).sum::<usize>()
     );
-    println!("   Time: {:?}\n", all_columns_time);
+    println!("   Time: {all_columns_time:?}\n");
 
     // Test 2: Query only name column (should benefit from projection pushdown)
     println!("Test 2: Querying ONLY 'name' column (projection pushdown)");
@@ -86,11 +86,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "   Rows: {}",
         results.iter().map(|b| b.num_rows()).sum::<usize>()
     );
-    println!("   Time: {:?}", name_only_time);
+    println!("   Time: {name_only_time:?}");
 
     // Calculate speedup
     let speedup = all_columns_time.as_nanos() as f64 / name_only_time.as_nanos() as f64;
-    println!("   Speedup: {:.2}x faster\n", speedup);
+    println!("   Speedup: {speedup:.2}x faster\n");
 
     // Test 3: Query name and sequence (partial projection)
     println!("Test 3: Querying 'name' and 'sequence' columns");
@@ -106,10 +106,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "   Rows: {}",
         results.iter().map(|b| b.num_rows()).sum::<usize>()
     );
-    println!("   Time: {:?}", two_columns_time);
+    println!("   Time: {two_columns_time:?}");
 
     let speedup = all_columns_time.as_nanos() as f64 / two_columns_time.as_nanos() as f64;
-    println!("   Speedup vs all columns: {:.2}x faster\n", speedup);
+    println!("   Speedup vs all columns: {speedup:.2}x faster\n");
 
     // Test 4: COUNT query (should skip all field parsing)
     println!("Test 4: COUNT query (maximum optimization)");
@@ -127,10 +127,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap()
             .value(0)
     );
-    println!("   Time: {:?}", count_time);
+    println!("   Time: {count_time:?}");
 
     let speedup = all_columns_time.as_nanos() as f64 / count_time.as_nanos() as f64;
-    println!("   Speedup vs all columns: {:.2}x faster\n", speedup);
+    println!("   Speedup vs all columns: {speedup:.2}x faster\n");
 
     // Test 5: Demonstrate projection with complex query
     println!("Test 5: Complex query with projection");
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             results.iter().map(|b| b.num_rows()).sum::<usize>()
         );
     }
-    println!("   Time: {:?}\n", complex_time);
+    println!("   Time: {complex_time:?}\n");
 
     // Show sample data
     println!("Sample data from projection query:");

--- a/datafusion/bio-format-fastq/examples/test_fastq_reader.rs
+++ b/datafusion/bio-format-fastq/examples/test_fastq_reader.rs
@@ -22,6 +22,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ctx.register_table("example", Arc::new(table)).unwrap();
     let df = ctx.sql("SELECT * FROM example").await?;
     let results = df.count().await?;
-    println!("Count: {:?}", results);
+    println!("Count: {results:?}");
     Ok(())
 }

--- a/datafusion/bio-format-fastq/src/physical_exec.rs
+++ b/datafusion/bio-format-fastq/src/physical_exec.rs
@@ -107,7 +107,7 @@ pub(crate) fn detect_local_strategy(
     match compression {
         DetectedCompression::Bgzf => {
             // Try to read GZI index
-            let gzi_path = format!("{}.gzi", file_path);
+            let gzi_path = format!("{file_path}.gzi");
             match gzi::fs::read(&gzi_path) {
                 Ok(index) => {
                     let partitions = get_bgzf_partition_bounds(&index, target_partitions);
@@ -291,7 +291,7 @@ impl DisplayAs for FastqExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "FastqExec: projection=[{}]", proj_str)
+        write!(f, "FastqExec: projection=[{proj_str}]")
     }
 }
 
@@ -589,7 +589,7 @@ fn execute_bgzf_partition(
     Ok(Box::pin(RecordBatchStreamAdapter::new(
         schema.clone(),
         rx.map(move |(item, count)| {
-            debug!("Partition {}: processed {} rows", partition, count);
+            debug!("Partition {partition}: processed {count} rows");
             item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
         }),
     )))
@@ -653,7 +653,7 @@ fn execute_byte_range_partition(
     Ok(Box::pin(RecordBatchStreamAdapter::new(
         schema.clone(),
         rx.map(move |(item, count)| {
-            debug!("Partition {}: processed {} rows", partition, count);
+            debug!("Partition {partition}: processed {count} rows");
             item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
         }),
     )))
@@ -768,7 +768,7 @@ async fn get_remote_fastq_stream(
                 count,
             )?;
             batch_num += 1;
-            debug!("Batch {}: {} records (total: {})", batch_num, count, record_num);
+            debug!("Batch {batch_num}: {count} records (total: {record_num})");
             yield batch;
         }
     };
@@ -839,7 +839,7 @@ async fn get_local_fastq(
                 count,
             )?;
             batch_num += 1;
-            debug!("Batch {}: {} records (total: {})", batch_num, count, record_num);
+            debug!("Batch {batch_num}: {count} records (total: {record_num})");
             yield batch;
         }
     };

--- a/datafusion/bio-format-fastq/src/serializer.rs
+++ b/datafusion/bio-format-fastq/src/serializer.rs
@@ -48,8 +48,7 @@ fn get_string_column<'a>(
     }
 
     Err(DataFusionError::Execution(format!(
-        "Column {} ({}) must be Utf8 or LargeUtf8 type",
-        index, name
+        "Column {index} ({name}) must be Utf8 or LargeUtf8 type"
     )))
 }
 
@@ -81,8 +80,7 @@ pub fn batch_to_fastq_records(batch: &RecordBatch) -> Result<Vec<fastq::Record>>
     // Validate schema - we need at least 4 columns (name, description, sequence, quality_scores)
     if num_columns < 4 {
         return Err(DataFusionError::Execution(format!(
-            "FASTQ batch must have at least 4 columns, got {}",
-            num_columns
+            "FASTQ batch must have at least 4 columns, got {num_columns}"
         )));
     }
 
@@ -100,8 +98,7 @@ pub fn batch_to_fastq_records(batch: &RecordBatch) -> Result<Vec<fastq::Record>>
         let name = names.value(i);
         if name.is_empty() {
             return Err(DataFusionError::Execution(format!(
-                "Row {}: name cannot be empty",
-                i
+                "Row {i}: name cannot be empty"
             )));
         }
 
@@ -116,8 +113,7 @@ pub fn batch_to_fastq_records(batch: &RecordBatch) -> Result<Vec<fastq::Record>>
         let sequence = sequences.value(i);
         if sequence.is_empty() {
             return Err(DataFusionError::Execution(format!(
-                "Row {}: sequence cannot be empty",
-                i
+                "Row {i}: sequence cannot be empty"
             )));
         }
 
@@ -125,8 +121,7 @@ pub fn batch_to_fastq_records(batch: &RecordBatch) -> Result<Vec<fastq::Record>>
         let quality = quality_scores.value(i);
         if quality.is_empty() {
             return Err(DataFusionError::Execution(format!(
-                "Row {}: quality_scores cannot be empty",
-                i
+                "Row {i}: quality_scores cannot be empty"
             )));
         }
 

--- a/datafusion/bio-format-fastq/src/storage.rs
+++ b/datafusion/bio-format-fastq/src/storage.rs
@@ -128,7 +128,7 @@ impl FastqRemoteReader {
         let compression_type =
             get_compression_type(file_path.clone(), None, object_storage_options.clone())
                 .await
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
         match compression_type {
             CompressionType::BGZF => {
                 let reader =
@@ -161,6 +161,7 @@ impl FastqRemoteReader {
 }
 
 /// A FASTQ reader that automatically detects and handles local file compression
+#[allow(clippy::large_enum_variant)]
 pub enum FastqLocalReader {
     /// BGZF-compressed local FASTQ file reader
     BGZF(fastq::io::Reader<bgzf::Reader<std::fs::File>>),
@@ -193,7 +194,7 @@ impl FastqLocalReader {
                 opts.clone(),
             )
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
+            .map_err(std::io::Error::other)?,
             None => {
                 // Detect compression from magic bytes synchronously
                 let detected = crate::physical_exec::detect_compression_sync(&file_path)?;

--- a/datafusion/bio-format-fastq/src/table_provider.rs
+++ b/datafusion/bio-format-fastq/src/table_provider.rs
@@ -27,7 +27,7 @@ fn determine_schema() -> datafusion::common::Result<SchemaRef> {
         Field::new("quality_scores", DataType::Utf8, false),
     ];
     let schema = Schema::new(fields);
-    debug!("Schema: {:?}", schema);
+    debug!("Schema: {schema:?}");
     Ok(Arc::new(schema))
 }
 

--- a/datafusion/bio-format-fastq/src/write_exec.rs
+++ b/datafusion/bio-format-fastq/src/write_exec.rs
@@ -203,15 +203,12 @@ async fn write_fastq_stream(
 
     writer.finish()?;
 
-    debug!(
-        "FastqWriteExec: wrote {} records to {}",
-        total_count, output_path
-    );
+    debug!("FastqWriteExec: wrote {total_count} records to {output_path}");
 
     // Return a batch with the count
     let count_array = Arc::new(UInt64Array::from(vec![total_count]));
     RecordBatch::try_new(output_schema, vec![count_array])
-        .map_err(|e| DataFusionError::Execution(format!("Failed to create result batch: {}", e)))
+        .map_err(|e| DataFusionError::Execution(format!("Failed to create result batch: {e}")))
 }
 
 #[cfg(test)]

--- a/datafusion/bio-format-fastq/src/writer.rs
+++ b/datafusion/bio-format-fastq/src/writer.rs
@@ -106,7 +106,7 @@ impl FastqLocalWriter {
         compression: FastqCompressionType,
     ) -> Result<Self> {
         let file = File::create(path.as_ref()).map_err(|e| {
-            DataFusionError::Execution(format!("Failed to create output file: {}", e))
+            DataFusionError::Execution(format!("Failed to create output file: {e}"))
         })?;
         let buf_writer = BufWriter::new(file);
 
@@ -140,13 +140,13 @@ impl FastqLocalWriter {
     pub fn write_record(&mut self, record: &fastq::Record) -> Result<()> {
         match self {
             FastqLocalWriter::Plain(writer) => writer.write_record(record).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write FASTQ record: {}", e))
+                DataFusionError::Execution(format!("Failed to write FASTQ record: {e}"))
             }),
             FastqLocalWriter::Gzip(writer) => writer.write_record(record).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write FASTQ record: {}", e))
+                DataFusionError::Execution(format!("Failed to write FASTQ record: {e}"))
             }),
             FastqLocalWriter::Bgzf(writer) => writer.write_record(record).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write FASTQ record: {}", e))
+                DataFusionError::Execution(format!("Failed to write FASTQ record: {e}"))
             }),
         }
     }
@@ -180,15 +180,15 @@ impl FastqLocalWriter {
             FastqLocalWriter::Plain(writer) => writer
                 .get_mut()
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
             FastqLocalWriter::Gzip(writer) => writer
                 .get_mut()
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
             FastqLocalWriter::Bgzf(writer) => writer
                 .get_mut()
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
         }
     }
 
@@ -204,21 +204,21 @@ impl FastqLocalWriter {
         match self {
             FastqLocalWriter::Plain(writer) => {
                 let mut buf_writer = writer.into_inner();
-                buf_writer.flush().map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to flush writer: {}", e))
-                })
+                buf_writer
+                    .flush()
+                    .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}")))
             }
             FastqLocalWriter::Gzip(writer) => {
                 let encoder = writer.into_inner();
                 encoder.finish().map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to finish GZIP stream: {}", e))
+                    DataFusionError::Execution(format!("Failed to finish GZIP stream: {e}"))
                 })?;
                 Ok(())
             }
             FastqLocalWriter::Bgzf(writer) => {
                 let bgzf_writer = writer.into_inner();
                 bgzf_writer.finish().map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to finish BGZF stream: {}", e))
+                    DataFusionError::Execution(format!("Failed to finish BGZF stream: {e}"))
                 })?;
                 Ok(())
             }

--- a/datafusion/bio-format-fastq/tests/parallel_read_test.rs
+++ b/datafusion/bio-format-fastq/tests/parallel_read_test.rs
@@ -9,7 +9,7 @@ use tempfile::TempDir;
 fn generate_test_fastq(path: &str, num_records: usize) {
     let mut file = std::fs::File::create(path).expect("Failed to create test file");
     for i in 0..num_records {
-        writeln!(file, "@read_{}", i).unwrap();
+        writeln!(file, "@read_{i}").unwrap();
         writeln!(file, "ACGTACGTACGTACGT").unwrap();
         writeln!(file, "+").unwrap();
         writeln!(file, "IIIIIIIIIIIIIIII").unwrap();
@@ -39,8 +39,7 @@ async fn test_bgzf_parallel_row_count() {
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(
             total_rows, 2000,
-            "Row count mismatch for {} target partitions: got {}",
-            partitions, total_rows
+            "Row count mismatch for {partitions} target partitions: got {total_rows}"
         );
     }
 }
@@ -151,8 +150,7 @@ async fn test_bgzf_parallel_with_limit() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert!(
         total_rows <= 10,
-        "Expected at most 10 rows, got {}",
-        total_rows
+        "Expected at most 10 rows, got {total_rows}"
     );
 }
 
@@ -212,8 +210,7 @@ async fn test_uncompressed_parallel_row_count() {
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(
             total_rows, 500,
-            "Row count mismatch for {} target partitions: got {}",
-            partitions, total_rows
+            "Row count mismatch for {partitions} target partitions: got {total_rows}"
         );
     }
 }
@@ -314,8 +311,7 @@ async fn test_uncompressed_parallel_with_limit() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert!(
         total_rows <= 10,
-        "Expected at most 10 rows, got {}",
-        total_rows
+        "Expected at most 10 rows, got {total_rows}"
     );
 }
 
@@ -342,8 +338,7 @@ async fn test_uncompressed_parallel_small_file() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(
         total_rows, 3,
-        "Expected 3 rows for small file, got {}",
-        total_rows
+        "Expected 3 rows for small file, got {total_rows}"
     );
 }
 
@@ -368,7 +363,7 @@ async fn test_uncompressed_parallel_single_record() {
     let batches = df.collect().await.expect("Failed to collect results");
 
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-    assert_eq!(total_rows, 1, "Expected exactly 1 row, got {}", total_rows);
+    assert_eq!(total_rows, 1, "Expected exactly 1 row, got {total_rows}");
 }
 
 // ---- GZIP sequential fallback test ----
@@ -390,7 +385,7 @@ async fn test_gzip_reads_sequentially() {
         .expect("Failed to create writer");
         for i in 0..num_records {
             let record = noodles_fastq::Record::new(
-                Definition::new(format!("read_{}", i), ""),
+                Definition::new(format!("read_{i}"), ""),
                 b"ACGTACGT".to_vec(),
                 b"IIIIIIII".to_vec(),
             );
@@ -416,7 +411,6 @@ async fn test_gzip_reads_sequentially() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(
         total_rows, num_records,
-        "Expected {} rows from gzip file, got {}",
-        num_records, total_rows
+        "Expected {num_records} rows from gzip file, got {total_rows}"
     );
 }

--- a/datafusion/bio-format-fastq/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-fastq/tests/projection_pushdown_test.rs
@@ -19,7 +19,7 @@ KKKKKKKKKKKK
 "#;
 
 async fn create_test_fastq_file(test_name: &str) -> std::io::Result<String> {
-    let temp_file = format!("/tmp/test_projection_{}.fastq", test_name);
+    let temp_file = format!("/tmp/test_projection_{test_name}.fastq");
     fs::write(&temp_file, SAMPLE_FASTQ_CONTENT).await?;
     Ok(temp_file)
 }

--- a/datafusion/bio-format-fastq/tests/row_count_integration_test.rs
+++ b/datafusion/bio-format-fastq/tests/row_count_integration_test.rs
@@ -30,10 +30,6 @@ async fn test_bgzf_fastq_table_provider_row_count() {
             .unwrap()
             .value(0);
 
-        assert_eq!(
-            count, 2000,
-            "Row count mismatch for {} target partitions",
-            i
-        );
+        assert_eq!(count, 2000, "Row count mismatch for {i} target partitions");
     }
 }

--- a/datafusion/bio-format-fastq/tests/write_test.rs
+++ b/datafusion/bio-format-fastq/tests/write_test.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 fn generate_test_fastq(path: &str, num_records: usize) {
     let mut file = std::fs::File::create(path).expect("Failed to create test file");
     for i in 0..num_records {
-        writeln!(file, "@read_{} sample description {}", i, i).unwrap();
+        writeln!(file, "@read_{i} sample description {i}").unwrap();
         writeln!(file, "ACGTACGTACGTACGT").unwrap();
         writeln!(file, "+").unwrap();
         writeln!(file, "IIIIIIIIIIIIIIII").unwrap();
@@ -83,8 +83,7 @@ async fn test_write_plain_round_trip() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(
         total_rows, num_records,
-        "Expected {} rows, got {}",
-        num_records, total_rows
+        "Expected {num_records} rows, got {total_rows}"
     );
 
     // Verify all names are unique
@@ -337,8 +336,7 @@ async fn test_write_with_sql_filter() {
     // read_1, read_10, read_11, ..., read_19 = 11 records
     assert_eq!(
         total_rows, 11,
-        "Expected 11 filtered rows, got {}",
-        total_rows
+        "Expected 11 filtered rows, got {total_rows}"
     );
 
     // Verify all names match the filter

--- a/datafusion/bio-format-gff/src/bin/arrow_batch_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/arrow_batch_benchmark.rs
@@ -95,15 +95,12 @@ async fn benchmark_with_arrow_building(
 
         record_count += 1;
         if record_count % 100_000 == 0 {
-            println!("  Processed {} records", record_count);
+            println!("  Processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ WITH Arrow building: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ WITH Arrow building: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -133,15 +130,12 @@ async fn benchmark_without_arrow_building(
 
         record_count += 1;
         if record_count % 100_000 == 0 {
-            println!("  Processed {} records", record_count);
+            println!("  Processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ WITHOUT Arrow building: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ WITHOUT Arrow building: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -150,11 +144,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("⚡ ARROW BATCH BUILDING Performance Analysis");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("============================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -173,19 +167,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let no_arrow_records_per_sec = 3_148_136.0 / no_arrow_time.as_secs_f64();
     let with_arrow_records_per_sec = 3_148_136.0 / with_arrow_time.as_secs_f64();
 
-    println!(
-        "🚀 PARSING ONLY: {:?} ({:.0} records/sec)",
-        no_arrow_time, no_arrow_records_per_sec
-    );
-    println!(
-        "🐌 WITH ARROW:   {:?} ({:.0} records/sec)",
-        with_arrow_time, with_arrow_records_per_sec
-    );
+    println!("🚀 PARSING ONLY: {no_arrow_time:?} ({no_arrow_records_per_sec:.0} records/sec)");
+    println!("🐌 WITH ARROW:   {with_arrow_time:?} ({with_arrow_records_per_sec:.0} records/sec)");
 
     let arrow_slowdown = with_arrow_time.as_secs_f64() / no_arrow_time.as_secs_f64();
     println!();
     println!("📊 ARROW BUILDING IMPACT:");
-    println!("Arrow building adds {:.1}x slowdown", arrow_slowdown);
+    println!("Arrow building adds {arrow_slowdown:.1}x slowdown");
 
     if arrow_slowdown > 5.0 {
         println!("🚨 CRITICAL: Arrow building is a major bottleneck!");

--- a/datafusion/bio-format-gff/src/bin/attribute_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/attribute_benchmark.rs
@@ -33,15 +33,12 @@ async fn benchmark_with_attributes(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Processed {} records", record_count);
+            println!("  Processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ WITH attributes: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ WITH attributes: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -67,15 +64,12 @@ async fn benchmark_without_attributes(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Processed {} records", record_count);
+            println!("  Processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ WITHOUT attributes: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ WITHOUT attributes: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -84,11 +78,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("📊 GFF Attribute Processing Performance Analysis");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("============================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -107,19 +101,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let no_attr_records_per_sec = 3_148_136.0 / no_attr_time.as_secs_f64();
     let with_attr_records_per_sec = 3_148_136.0 / with_attr_time.as_secs_f64();
 
+    println!("🚀 WITHOUT attributes: {no_attr_time:?} ({no_attr_records_per_sec:.0} records/sec)");
     println!(
-        "🚀 WITHOUT attributes: {:?} ({:.0} records/sec)",
-        no_attr_time, no_attr_records_per_sec
-    );
-    println!(
-        "🐌 WITH attributes:    {:?} ({:.0} records/sec)",
-        with_attr_time, with_attr_records_per_sec
+        "🐌 WITH attributes:    {with_attr_time:?} ({with_attr_records_per_sec:.0} records/sec)"
     );
 
     let slowdown = with_attr_time.as_secs_f64() / no_attr_time.as_secs_f64();
     println!();
     println!("🎯 VERDICT:");
-    println!("Attribute processing is {:.1}x SLOWER", slowdown);
+    println!("Attribute processing is {slowdown:.1}x SLOWER");
 
     if slowdown > 5.0 {
         println!("❌ MAJOR BOTTLENECK: Attribute processing is the primary performance killer!");

--- a/datafusion/bio-format-gff/src/bin/benchmark_parsers.rs
+++ b/datafusion/bio-format-gff/src/bin/benchmark_parsers.rs
@@ -7,7 +7,7 @@ async fn benchmark_parser(
     parser_type: GffParserType,
     parser_name: &str,
 ) -> Result<(usize, std::time::Duration), Box<dyn std::error::Error>> {
-    println!("Starting benchmark for {} parser...", parser_name);
+    println!("Starting benchmark for {parser_name} parser...");
 
     let start = Instant::now();
 
@@ -29,15 +29,12 @@ async fn benchmark_parser(
 
         // Print progress every 100k records
         if record_count % 100_000 == 0 {
-            println!("{} parser: processed {} records", parser_name, record_count);
+            println!("{parser_name} parser: processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "{} parser completed: {} records in {:?}",
-        parser_name, record_count, duration
-    );
+    println!("{parser_name} parser completed: {record_count} records in {duration:?}");
 
     Ok((record_count, duration))
 }
@@ -46,12 +43,12 @@ async fn benchmark_parser(
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
-    println!("Benchmarking GFF parsers with file: {}", file_path);
+    println!("Benchmarking GFF parsers with file: {file_path}");
     println!("=========================================");
 
     // Check if file exists
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("Error: File {} not found", file_path);
+        eprintln!("Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -72,8 +69,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     println!("BENCHMARK RESULTS");
     println!("=================");
-    println!("File: {}", file_path);
-    println!("Records processed: {}", std_count);
+    println!("File: {file_path}");
+    println!("Records processed: {std_count}");
     println!();
     println!(
         "Standard parser: {:?} ({:.2} ns/record)",
@@ -94,22 +91,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if std_time > fast_time {
         let speedup = std_time.as_nanos() as f64 / fast_time.as_nanos() as f64;
-        println!("Fast parser is {:.2}x faster than Standard", speedup);
+        println!("Fast parser is {speedup:.2}x faster than Standard");
     }
 
     if std_time > simd_time {
         let speedup = std_time.as_nanos() as f64 / simd_time.as_nanos() as f64;
-        println!("SIMD parser is {:.2}x faster than Standard", speedup);
+        println!("SIMD parser is {speedup:.2}x faster than Standard");
     }
 
     match fast_time.cmp(&simd_time) {
         std::cmp::Ordering::Greater => {
             let speedup = fast_time.as_nanos() as f64 / simd_time.as_nanos() as f64;
-            println!("SIMD parser is {:.2}x faster than Fast", speedup);
+            println!("SIMD parser is {speedup:.2}x faster than Fast");
         }
         std::cmp::Ordering::Less => {
             let speedup = simd_time.as_nanos() as f64 / fast_time.as_nanos() as f64;
-            println!("Fast parser is {:.2}x faster than SIMD", speedup);
+            println!("Fast parser is {speedup:.2}x faster than SIMD");
         }
         std::cmp::Ordering::Equal => {}
     }

--- a/datafusion/bio-format-gff/src/bin/conditional_parsing_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/conditional_parsing_benchmark.rs
@@ -84,15 +84,12 @@ async fn benchmark_always_parse(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  OLD: {} records", record_count);
+            println!("  OLD: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ OLD (always parse): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ OLD (always parse): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -125,15 +122,12 @@ async fn benchmark_conditional_parse(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  NEW: {} records", record_count);
+            println!("  NEW: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ NEW (conditional): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ NEW (conditional): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -161,15 +155,12 @@ async fn benchmark_never_parse(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  BASELINE: {} records", record_count);
+            println!("  BASELINE: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ BASELINE (never parse): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ BASELINE (never parse): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -178,11 +169,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🎯 CONDITIONAL ATTRIBUTE PARSING Benchmark");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("===========================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -210,21 +201,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conditional_0_rps = 3_148_136.0 / conditional_0_time.as_secs_f64();
     let conditional_50_rps = 3_148_136.0 / conditional_50_time.as_secs_f64();
 
+    println!("🚀 BASELINE (no parsing):    {baseline_time:?} ({baseline_rps:.0} records/sec)");
+    println!("🐌 OLD (always parse):       {always_time:?} ({always_rps:.0} records/sec)");
     println!(
-        "🚀 BASELINE (no parsing):    {:?} ({:.0} records/sec)",
-        baseline_time, baseline_rps
+        "⚡ NEW (conditional 0%):     {conditional_0_time:?} ({conditional_0_rps:.0} records/sec)"
     );
     println!(
-        "🐌 OLD (always parse):       {:?} ({:.0} records/sec)",
-        always_time, always_rps
-    );
-    println!(
-        "⚡ NEW (conditional 0%):     {:?} ({:.0} records/sec)",
-        conditional_0_time, conditional_0_rps
-    );
-    println!(
-        "⚡ NEW (conditional 50%):    {:?} ({:.0} records/sec)",
-        conditional_50_time, conditional_50_rps
+        "⚡ NEW (conditional 50%):    {conditional_50_time:?} ({conditional_50_rps:.0} records/sec)"
     );
 
     let always_slowdown = always_time.as_secs_f64() / baseline_time.as_secs_f64();
@@ -236,28 +219,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!();
     println!("📊 PERFORMANCE ANALYSIS:");
-    println!(
-        "• Always parsing slowdown:     {:.1}x vs baseline",
-        always_slowdown
-    );
-    println!(
-        "• Conditional 0% slowdown:     {:.1}x vs baseline",
-        conditional_0_slowdown
-    );
-    println!(
-        "• Conditional 50% slowdown:    {:.1}x vs baseline",
-        conditional_50_slowdown
-    );
+    println!("• Always parsing slowdown:     {always_slowdown:.1}x vs baseline");
+    println!("• Conditional 0% slowdown:     {conditional_0_slowdown:.1}x vs baseline");
+    println!("• Conditional 50% slowdown:    {conditional_50_slowdown:.1}x vs baseline");
     println!();
     println!("🎉 OPTIMIZATION IMPACT:");
-    println!(
-        "• Skip all attributes:   {:.1}x FASTER than always parsing",
-        optimization_0
-    );
-    println!(
-        "• Parse 50% attributes:  {:.1}x FASTER than always parsing",
-        optimization_50
-    );
+    println!("• Skip all attributes:   {optimization_0:.1}x FASTER than always parsing");
+    println!("• Parse 50% attributes:  {optimization_50:.1}x FASTER than always parsing");
 
     if optimization_0 > 2.0 {
         println!("✅ EXCELLENT! Major speedup when attributes not needed");

--- a/datafusion/bio-format-gff/src/bin/filter_performance_analysis.rs
+++ b/datafusion/bio-format-gff/src/bin/filter_performance_analysis.rs
@@ -25,9 +25,9 @@ async fn run_timing_test(
     let mut times = Vec::new();
     let mut total_rows = 0;
 
-    println!("\n🔍 {}", description);
-    println!("Query: {}", query);
-    print!("Running {} times: ", runs);
+    println!("\n🔍 {description}");
+    println!("Query: {query}");
+    print!("Running {runs} times: ");
 
     for i in 0..runs {
         print!("{}.", i + 1);
@@ -52,9 +52,9 @@ async fn run_timing_test(
     let min_time = times.iter().cloned().fold(f64::INFINITY, f64::min);
 
     println!(" Done!");
-    println!("  Rows: {}", total_rows);
-    println!("  Average time: {:.3}s", avg_time);
-    println!("  Best time: {:.3}s", min_time);
+    println!("  Rows: {total_rows}");
+    println!("  Average time: {avg_time:.3}s");
+    println!("  Best time: {min_time:.3}s");
     println!(
         "  Throughput: {:.0} rows/sec (avg)",
         total_rows as f64 / avg_time
@@ -72,11 +72,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let object_storage_options = create_object_storage_options();
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} does not exist!", file_path);
+        eprintln!("❌ Error: File {file_path} does not exist!");
         return Ok(());
     }
 
-    println!("📁 File: {} (~146MB, 7.75M records)", file_path);
+    println!("📁 File: {file_path} (~146MB, 7.75M records)");
 
     let table = GffTableProvider::new(
         file_path.to_string(),
@@ -137,7 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 results.push((description.to_string(), avg_time, min_time, rows));
             }
             Err(e) => {
-                println!("❌ Query failed: {}", e);
+                println!("❌ Query failed: {e}");
             }
         }
     }
@@ -159,10 +159,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             baseline_time / avg_time
         };
-        println!(
-            "{:<65} {:>10.3} {:>10.3} {:>14.1}x",
-            description, avg_time, min_time, speedup
-        );
+        println!("{description:<65} {avg_time:>10.3} {min_time:>10.3} {speedup:>14.1}x");
     }
 
     println!("\n🎯 Key Performance Insights");
@@ -174,7 +171,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let chr1_efficiency =
                 (*chr1_rows as f64 / *baseline_rows as f64) / (chr1_avg / baseline_avg);
 
-            println!("• chr1 filter shows {:.1}x speedup", chr1_speedup);
+            println!("• chr1 filter shows {chr1_speedup:.1}x speedup");
             println!(
                 "• chr1 processes {:.1}% of data in {:.1}% of time (efficiency: {:.1}x)",
                 (*chr1_rows as f64 / *baseline_rows as f64) * 100.0,
@@ -188,7 +185,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let gene_efficiency =
                 (*gene_rows as f64 / *baseline_rows as f64) / (gene_avg / baseline_avg);
 
-            println!("• chr1+gene filter shows {:.1}x speedup", gene_speedup);
+            println!("• chr1+gene filter shows {gene_speedup:.1}x speedup");
             println!(
                 "• chr1+gene processes {:.3}% of data in {:.1}% of time (efficiency: {:.1}x)",
                 (*gene_rows as f64 / *baseline_rows as f64) * 100.0,

--- a/datafusion/bio-format-gff/src/bin/filter_pushdown_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/filter_pushdown_benchmark.rs
@@ -21,8 +21,8 @@ async fn run_benchmark_query(
     query: &str,
     description: &str,
 ) -> Result<(u64, f64), Box<dyn std::error::Error>> {
-    println!("\n🔍 Running: {}", description);
-    println!("Query: {}", query);
+    println!("\n🔍 Running: {description}");
+    println!("Query: {query}");
 
     let start_time = Instant::now();
     let df = ctx.sql(query).await?;
@@ -52,12 +52,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check if file exists
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} does not exist!", file_path);
+        eprintln!("❌ Error: File {file_path} does not exist!");
         eprintln!("Please ensure the file is available for benchmarking.");
         return Ok(());
     }
 
-    println!("📁 File: {}", file_path);
+    println!("📁 File: {file_path}");
 
     // Create table provider
     let table = GffTableProvider::new(
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 results.push((description.to_string(), rows, duration));
             }
             Err(e) => {
-                println!("❌ Query failed: {}", e);
+                println!("❌ Query failed: {e}");
             }
         }
 
@@ -150,10 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             0.0
         };
-        println!(
-            "{:<60} {:>10} {:>10.3} {:>15.0}",
-            description, rows, duration, throughput
-        );
+        println!("{description:<60} {rows:>10} {duration:>10.3} {throughput:>15.0}");
     }
 
     println!("\n🎯 Performance Analysis");
@@ -177,8 +174,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (filter_expr, description) in filter_tests {
-        let query = format!("SELECT COUNT(*) FROM gff WHERE {}", filter_expr);
-        println!("Testing: {} ({})", description, filter_expr);
+        let query = format!("SELECT COUNT(*) FROM gff WHERE {filter_expr}");
+        println!("Testing: {description} ({filter_expr})");
 
         match ctx.sql(&query).await {
             Ok(df) => {
@@ -187,12 +184,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Ok(results) => {
                         let duration = start.elapsed();
                         let rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-                        println!("  ✅ Success: {} rows in {:?}", rows, duration);
+                        println!("  ✅ Success: {rows} rows in {duration:?}");
                     }
-                    Err(e) => println!("  ❌ Execution failed: {}", e),
+                    Err(e) => println!("  ❌ Execution failed: {e}"),
                 }
             }
-            Err(e) => println!("  ❌ Parse failed: {}", e),
+            Err(e) => println!("  ❌ Parse failed: {e}"),
         }
     }
 

--- a/datafusion/bio-format-gff/src/bin/full_pipeline_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/full_pipeline_benchmark.rs
@@ -73,15 +73,12 @@ async fn benchmark_full_attribute_processing(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Processed {} records", record_count);
+            println!("  Processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ FULL processing: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ FULL processing: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -107,15 +104,12 @@ async fn benchmark_minimal_processing(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Processed {} records", record_count);
+            println!("  Processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ MINIMAL processing: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ MINIMAL processing: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -124,11 +118,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🔬 GFF FULL PIPELINE Performance Analysis");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("=========================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -147,19 +141,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let minimal_records_per_sec = 3_148_136.0 / minimal_time.as_secs_f64();
     let full_records_per_sec = 3_148_136.0 / full_time.as_secs_f64();
 
-    println!(
-        "🚀 MINIMAL:     {:?} ({:.0} records/sec)",
-        minimal_time, minimal_records_per_sec
-    );
-    println!(
-        "🐌 FULL ATTRS:  {:?} ({:.0} records/sec)",
-        full_time, full_records_per_sec
-    );
+    println!("🚀 MINIMAL:     {minimal_time:?} ({minimal_records_per_sec:.0} records/sec)");
+    println!("🐌 FULL ATTRS:  {full_time:?} ({full_records_per_sec:.0} records/sec)");
 
     let slowdown = full_time.as_secs_f64() / minimal_time.as_secs_f64();
     println!();
     println!("📊 ATTRIBUTE PROCESSING IMPACT:");
-    println!("Full attribute processing is {:.1}x SLOWER", slowdown);
+    println!("Full attribute processing is {slowdown:.1}x SLOWER");
 
     if slowdown > 8.0 {
         println!("🚨 CRITICAL: This matches your 10x slowdown observation!");

--- a/datafusion/bio-format-gff/src/bin/lazy_allocation_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/lazy_allocation_benchmark.rs
@@ -114,15 +114,12 @@ async fn benchmark_eager_allocation(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  OLD: {} records", record_count);
+            println!("  OLD: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ OLD (eager allocation): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ OLD (eager allocation): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -151,15 +148,12 @@ async fn benchmark_lazy_allocation(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  NEW: {} records", record_count);
+            println!("  NEW: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ NEW (lazy allocation): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ NEW (lazy allocation): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -168,11 +162,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🧠 LAZY HASHMAP ALLOCATION Benchmark");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("====================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -190,20 +184,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eager_rps = 3_148_136.0 / eager_time.as_secs_f64();
     let lazy_rps = 3_148_136.0 / lazy_time.as_secs_f64();
 
-    println!(
-        "🐌 OLD (eager):     {:?} ({:.0} records/sec)",
-        eager_time, eager_rps
-    );
-    println!(
-        "⚡ NEW (lazy):      {:?} ({:.0} records/sec)",
-        lazy_time, lazy_rps
-    );
+    println!("🐌 OLD (eager):     {eager_time:?} ({eager_rps:.0} records/sec)");
+    println!("⚡ NEW (lazy):      {lazy_time:?} ({lazy_rps:.0} records/sec)");
 
     let improvement = eager_time.as_secs_f64() / lazy_time.as_secs_f64();
 
     println!();
     println!("📊 OPTIMIZATION IMPACT:");
-    println!("Lazy allocation is {:.2}x FASTER", improvement);
+    println!("Lazy allocation is {improvement:.2}x FASTER");
 
     if improvement > 1.2 {
         println!("✅ GOOD! Lazy allocation provides measurable benefit");

--- a/datafusion/bio-format-gff/src/bin/no_filter_overhead_test.rs
+++ b/datafusion/bio-format-gff/src/bin/no_filter_overhead_test.rs
@@ -22,8 +22,8 @@ async fn run_benchmark_multiple_times(
     description: &str,
     runs: usize,
 ) -> Result<Vec<f64>, Box<dyn std::error::Error>> {
-    println!("\n🔍 {}", description);
-    println!("Query: {}", query);
+    println!("\n🔍 {description}");
+    println!("Query: {query}");
     print!("Runs: ");
 
     let mut times = Vec::new();
@@ -40,7 +40,7 @@ async fn run_benchmark_multiple_times(
         // Verify we got results (sanity check)
         let total_rows: usize = results.iter().map(|batch| batch.num_rows()).sum();
         if i == 0 {
-            println!(" ({} rows)", total_rows);
+            println!(" ({total_rows} rows)");
         }
 
         times.push(duration);
@@ -57,8 +57,8 @@ async fn run_benchmark_multiple_times(
         variance.sqrt()
     };
 
-    println!("  Average: {:.3}s", avg);
-    println!("  Range: {:.3}s - {:.3}s", min, max);
+    println!("  Average: {avg:.3}s");
+    println!("  Range: {min:.3}s - {max:.3}s");
     println!(
         "  Std Dev: {:.3}s ({:.1}%)",
         std_dev,
@@ -78,11 +78,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let object_storage_options = create_object_storage_options();
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} does not exist!", file_path);
+        eprintln!("❌ Error: File {file_path} does not exist!");
         return Ok(());
     }
 
-    println!("📁 File: {} (~146MB, 7.75M records)", file_path);
+    println!("📁 File: {file_path} (~146MB, 7.75M records)");
 
     let table = GffTableProvider::new(
         file_path.to_string(),
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 all_results.push((description.to_string(), times));
             }
             Err(e) => {
-                println!("❌ Query failed: {}", e);
+                println!("❌ Query failed: {e}");
             }
         }
     }
@@ -150,10 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         let cv_percent = (std_dev / avg) * 100.0;
 
-        println!(
-            "{:<50} {:>10.3} {:>10.3} {:>10.3} {:>9.1}%",
-            description, avg, min, max, cv_percent
-        );
+        println!("{description:<50} {avg:>10.3} {min:>10.3} {max:>10.3} {cv_percent:>9.1}%");
     }
 
     println!("\n🔍 Overhead Assessment");
@@ -171,10 +168,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             variance.sqrt()
         };
 
-        println!(
-            "• Baseline COUNT(*) performance: {:.3}s ± {:.3}s",
-            baseline_avg, baseline_std
-        );
+        println!("• Baseline COUNT(*) performance: {baseline_avg:.3}s ± {baseline_std:.3}s");
         println!(
             "• Coefficient of variation: {:.1}% (should be <5% for consistent performance)",
             (baseline_std / baseline_avg) * 100.0
@@ -210,7 +204,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         if (std_dev / avg) > 0.1 {
             // >10% coefficient of variation
-            println!("  ⚠️  High variability detected in: {}", description);
+            println!("  ⚠️  High variability detected in: {description}");
             has_overhead = true;
         }
     }

--- a/datafusion/bio-format-gff/src/bin/noodles_native_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/noodles_native_benchmark.rs
@@ -96,15 +96,12 @@ async fn benchmark_custom_parsing(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Custom: {} records", record_count);
+            println!("  Custom: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ CUSTOM parsing: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ CUSTOM parsing: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -132,15 +129,12 @@ async fn benchmark_optimized_parsing(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Optimized: {} records", record_count);
+            println!("  Optimized: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ OPTIMIZED parsing: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ OPTIMIZED parsing: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -168,12 +162,12 @@ async fn benchmark_minimal_parsing(
 
         record_count += 1;
         if record_count % 500_000 == 0 {
-            println!("  Minimal: {} records", record_count);
+            println!("  Minimal: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!("✅ MINIMAL: {} records in {:?}", record_count, duration);
+    println!("✅ MINIMAL: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -182,11 +176,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🔬 ATTRIBUTE PARSING OPTIMIZATION Benchmark");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("===========================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -209,18 +203,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let custom_rps = 3_148_136.0 / custom_time.as_secs_f64();
     let optimized_rps = 3_148_136.0 / optimized_time.as_secs_f64();
 
-    println!(
-        "🚀 MINIMAL:    {:?} ({:.0} records/sec)",
-        minimal_time, minimal_rps
-    );
-    println!(
-        "🐌 CUSTOM:     {:?} ({:.0} records/sec)",
-        custom_time, custom_rps
-    );
-    println!(
-        "⚡ OPTIMIZED:  {:?} ({:.0} records/sec)",
-        optimized_time, optimized_rps
-    );
+    println!("🚀 MINIMAL:    {minimal_time:?} ({minimal_rps:.0} records/sec)");
+    println!("🐌 CUSTOM:     {custom_time:?} ({custom_rps:.0} records/sec)");
+    println!("⚡ OPTIMIZED:  {optimized_time:?} ({optimized_rps:.0} records/sec)");
 
     let custom_slowdown = custom_time.as_secs_f64() / minimal_time.as_secs_f64();
     let optimized_slowdown = optimized_time.as_secs_f64() / minimal_time.as_secs_f64();
@@ -228,9 +213,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!();
     println!("🎯 ANALYSIS:");
-    println!("• Custom parsing slowdown:    {:.1}x", custom_slowdown);
-    println!("• Optimized parsing slowdown: {:.1}x", optimized_slowdown);
-    println!("• Improvement factor:         {:.1}x faster", improvement);
+    println!("• Custom parsing slowdown:    {custom_slowdown:.1}x");
+    println!("• Optimized parsing slowdown: {optimized_slowdown:.1}x");
+    println!("• Improvement factor:         {improvement:.1}x faster");
 
     if improvement > 2.0 {
         println!("✅ SIGNIFICANT IMPROVEMENT! Optimization is working.");

--- a/datafusion/bio-format-gff/src/bin/optimized_parsing_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/optimized_parsing_benchmark.rs
@@ -100,12 +100,12 @@ async fn benchmark_old_parsing(
 
         record_count += 1;
         if record_count % 200_000 == 0 {
-            println!("  OLD: {} records", record_count);
+            println!("  OLD: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!("✅ OLD parsing: {} records in {:?}", record_count, duration);
+    println!("✅ OLD parsing: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -133,15 +133,12 @@ async fn benchmark_optimized_parsing(
 
         record_count += 1;
         if record_count % 200_000 == 0 {
-            println!("  OPTIMIZED: {} records", record_count);
+            println!("  OPTIMIZED: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ OPTIMIZED parsing: {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ OPTIMIZED parsing: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -167,12 +164,12 @@ async fn benchmark_baseline(
 
         record_count += 1;
         if record_count % 200_000 == 0 {
-            println!("  BASELINE: {} records", record_count);
+            println!("  BASELINE: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!("✅ BASELINE: {} records in {:?}", record_count, duration);
+    println!("✅ BASELINE: {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -181,11 +178,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("⚡ OPTIMIZED ATTRIBUTE PARSING Benchmark");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("========================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -208,15 +205,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let old_rps = 3_148_136.0 / old_time.as_secs_f64();
     let optimized_rps = 3_148_136.0 / optimized_time.as_secs_f64();
 
-    println!(
-        "🚀 BASELINE:   {:?} ({:.0} records/sec)",
-        baseline_time, baseline_rps
-    );
-    println!("🐌 OLD:        {:?} ({:.0} records/sec)", old_time, old_rps);
-    println!(
-        "⚡ OPTIMIZED:  {:?} ({:.0} records/sec)",
-        optimized_time, optimized_rps
-    );
+    println!("🚀 BASELINE:   {baseline_time:?} ({baseline_rps:.0} records/sec)");
+    println!("🐌 OLD:        {old_time:?} ({old_rps:.0} records/sec)");
+    println!("⚡ OPTIMIZED:  {optimized_time:?} ({optimized_rps:.0} records/sec)");
 
     let old_slowdown = old_time.as_secs_f64() / baseline_time.as_secs_f64();
     let optimized_slowdown = optimized_time.as_secs_f64() / baseline_time.as_secs_f64();
@@ -224,9 +215,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!();
     println!("📊 PERFORMANCE ANALYSIS:");
-    println!("• Old parsing slowdown:       {:.1}x", old_slowdown);
-    println!("• Optimized parsing slowdown: {:.1}x", optimized_slowdown);
-    println!("• Improvement factor:         {:.1}x faster", improvement);
+    println!("• Old parsing slowdown:       {old_slowdown:.1}x");
+    println!("• Optimized parsing slowdown: {optimized_slowdown:.1}x");
+    println!("• Improvement factor:         {improvement:.1}x faster");
 
     if improvement > 3.0 {
         println!("🎉 EXCELLENT! Major optimization achieved!");

--- a/datafusion/bio-format-gff/src/bin/overhead_comparison.rs
+++ b/datafusion/bio-format-gff/src/bin/overhead_comparison.rs
@@ -33,7 +33,7 @@ fn main() {
     }
     let with_filter_duration = start.elapsed();
 
-    println!("Results for {} iterations:", iterations);
+    println!("Results for {iterations} iterations:");
     println!(
         "• No filters: {:?} ({:.1} ns per call)",
         no_filter_duration,
@@ -48,7 +48,7 @@ fn main() {
     let overhead_ns = (no_filter_duration.as_nanos() as f64) / (iterations as f64);
 
     println!("\n🎯 Overhead Analysis:");
-    println!("• Per-record overhead: {:.2} nanoseconds", overhead_ns);
+    println!("• Per-record overhead: {overhead_ns:.2} nanoseconds");
     println!(
         "• For 7.75M records: {:.3} milliseconds total overhead",
         (overhead_ns * 7_750_000.0) / 1_000_000.0
@@ -59,9 +59,6 @@ fn main() {
     } else if overhead_ns < 10.0 {
         println!("• ✅ Very low overhead - less than 10 nanoseconds per record");
     } else {
-        println!(
-            "• ⚠️  Measurable overhead - {} nanoseconds per record",
-            overhead_ns
-        );
+        println!("• ⚠️  Measurable overhead - {overhead_ns} nanoseconds per record");
     }
 }

--- a/datafusion/bio-format-gff/src/bin/quick_filter_test.rs
+++ b/datafusion/bio-format-gff/src/bin/quick_filter_test.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (query, description) in queries {
-        println!("\n{}: {}", description, query);
+        println!("\n{description}: {query}");
         let start = Instant::now();
         let df = ctx.sql(query).await?;
         let results = df.collect().await?;

--- a/datafusion/bio-format-gff/src/bin/quick_optimization_test.rs
+++ b/datafusion/bio-format-gff/src/bin/quick_optimization_test.rs
@@ -112,11 +112,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n🎯 QUICK TEST RESULTS");
     println!("======================");
     println!("Records tested: {}", test_data.len());
-    println!("OLD:        {:?}", old_time);
-    println!("OPTIMIZED:  {:?}", optimized_time);
+    println!("OLD:        {old_time:?}");
+    println!("OPTIMIZED:  {optimized_time:?}");
 
     let improvement = old_time.as_secs_f64() / optimized_time.as_secs_f64();
-    println!("Improvement: {:.1}x faster", improvement);
+    println!("Improvement: {improvement:.1}x faster");
 
     if improvement > 2.0 {
         println!("✅ GOOD! Optimization working");
@@ -131,8 +131,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let estimated_optimized_full = (optimized_time.as_secs_f64() / 100_000.0) * 3_148_136.0;
 
     println!("\n📈 ESTIMATED FULL FILE PERFORMANCE:");
-    println!("OLD:        {:.1}s", estimated_old_full);
-    println!("OPTIMIZED:  {:.1}s", estimated_optimized_full);
+    println!("OLD:        {estimated_old_full:.1}s");
+    println!("OPTIMIZED:  {estimated_optimized_full:.1}s");
 
     if estimated_optimized_full < 20.0 {
         println!("🎉 EXCELLENT! Under 20 seconds");

--- a/datafusion/bio-format-gff/src/bin/raw_parser_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/raw_parser_benchmark.rs
@@ -7,7 +7,7 @@ async fn benchmark_raw_parser(
     parser_type: GffParserType,
     parser_name: &str,
 ) -> Result<(usize, std::time::Duration), Box<dyn std::error::Error>> {
-    println!("Starting raw benchmark for {} parser...", parser_name);
+    println!("Starting raw benchmark for {parser_name} parser...");
 
     let start = Instant::now();
 
@@ -27,15 +27,12 @@ async fn benchmark_raw_parser(
         record_count += 1;
 
         if record_count % 100_000 == 0 {
-            println!("{} parser: processed {} records", parser_name, record_count);
+            println!("{parser_name} parser: processed {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "{} parser completed: {} records in {:?}",
-        parser_name, record_count, duration
-    );
+    println!("{parser_name} parser completed: {record_count} records in {duration:?}");
 
     Ok((record_count, duration))
 }
@@ -45,11 +42,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🚀 Raw Parser Performance Benchmark (no field processing)");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("=========================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("Error: File {} not found", file_path);
+        eprintln!("Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -72,36 +69,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     println!("RAW PARSER BENCHMARK RESULTS");
     println!("=============================");
-    println!("File: {}", file_path);
-    println!("Records processed: {}", std_count);
+    println!("File: {file_path}");
+    println!("Records processed: {std_count}");
     println!();
 
     let std_records_per_sec = std_count as f64 / std_time.as_secs_f64();
     let fast_records_per_sec = fast_count as f64 / fast_time.as_secs_f64();
     let simd_records_per_sec = simd_count as f64 / simd_time.as_secs_f64();
 
-    println!(
-        "Standard parser: {:?} ({:.0} records/sec)",
-        std_time, std_records_per_sec
-    );
-    println!(
-        "Fast parser:     {:?} ({:.0} records/sec)",
-        fast_time, fast_records_per_sec
-    );
-    println!(
-        "SIMD parser:     {:?} ({:.0} records/sec)",
-        simd_time, simd_records_per_sec
-    );
+    println!("Standard parser: {std_time:?} ({std_records_per_sec:.0} records/sec)");
+    println!("Fast parser:     {fast_time:?} ({fast_records_per_sec:.0} records/sec)");
+    println!("SIMD parser:     {simd_time:?} ({simd_records_per_sec:.0} records/sec)");
     println!();
 
     if std_time > fast_time {
         let speedup = std_time.as_secs_f64() / fast_time.as_secs_f64();
-        println!("🔥 Fast parser is {:.2}x faster than Standard", speedup);
+        println!("🔥 Fast parser is {speedup:.2}x faster than Standard");
     }
 
     if std_time > simd_time {
         let speedup = std_time.as_secs_f64() / simd_time.as_secs_f64();
-        println!("⚡ SIMD parser is {:.2}x faster than Standard", speedup);
+        println!("⚡ SIMD parser is {speedup:.2}x faster than Standard");
     }
 
     println!("\n🎯 Expected performance:");

--- a/datafusion/bio-format-gff/src/bin/select_star_timing.rs
+++ b/datafusion/bio-format-gff/src/bin/select_star_timing.rs
@@ -35,10 +35,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     let batches_count = batches.len();
 
-    println!("File: {}", file_path);
-    println!("Batches: {}", batches_count);
-    println!("Rows: {}", rows);
-    println!("Elapsed: {:?}", elapsed);
+    println!("File: {file_path}");
+    println!("Batches: {batches_count}");
+    println!("Rows: {rows}");
+    println!("Elapsed: {elapsed:?}");
     if elapsed.as_secs_f64() > 0.0 {
         println!(
             "Throughput: {:.0} rows/sec",

--- a/datafusion/bio-format-gff/src/bin/string_interning_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/string_interning_benchmark.rs
@@ -125,15 +125,12 @@ async fn benchmark_regular_keys(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  OLD: {} records", record_count);
+            println!("  OLD: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ OLD (regular keys): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ OLD (regular keys): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -162,15 +159,12 @@ async fn benchmark_interned_keys(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  NEW: {} records", record_count);
+            println!("  NEW: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ NEW (interned keys): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ NEW (interned keys): {record_count} records in {duration:?}");
 
     // Report cache statistics
     KEY_CACHE.with(|cache| {
@@ -186,11 +180,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🔑 STRING INTERNING FOR KEYS Benchmark");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("======================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -208,20 +202,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let old_rps = 3_148_136.0 / old_time.as_secs_f64();
     let new_rps = 3_148_136.0 / new_time.as_secs_f64();
 
-    println!(
-        "🐌 OLD (regular):     {:?} ({:.0} records/sec)",
-        old_time, old_rps
-    );
-    println!(
-        "⚡ NEW (interned):    {:?} ({:.0} records/sec)",
-        new_time, new_rps
-    );
+    println!("🐌 OLD (regular):     {old_time:?} ({old_rps:.0} records/sec)");
+    println!("⚡ NEW (interned):    {new_time:?} ({new_rps:.0} records/sec)");
 
     let improvement = old_time.as_secs_f64() / new_time.as_secs_f64();
 
     println!();
     println!("📊 OPTIMIZATION IMPACT:");
-    println!("String interning is {:.2}x FASTER", improvement);
+    println!("String interning is {improvement:.2}x FASTER");
 
     if improvement > 1.5 {
         println!("✅ EXCELLENT! String interning provides significant benefit");

--- a/datafusion/bio-format-gff/src/bin/test_select_attributes.rs
+++ b/datafusion/bio-format-gff/src/bin/test_select_attributes.rs
@@ -6,11 +6,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🔍 Testing SELECT attributes FROM X behavior");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("============================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             if !attributes_str.is_empty() && attributes_str != "." {
-                println!("   📋 Raw attributes: {}", attributes_str);
+                println!("   📋 Raw attributes: {attributes_str}");
 
                 // Show how attributes would be parsed in order
                 let mut ordered_attrs = Vec::new();
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             value
                         };
 
-                        ordered_attrs.push(format!("{{\"{}\":\"{}\"}}", key, decoded_value));
+                        ordered_attrs.push(format!("{{\"{key}\":\"{decoded_value}\"}}"));
                     }
                 }
                 println!("   ✅ Ordered as: [{}]", ordered_attrs.join(", "));

--- a/datafusion/bio-format-gff/src/bin/zero_copy_benchmark.rs
+++ b/datafusion/bio-format-gff/src/bin/zero_copy_benchmark.rs
@@ -133,15 +133,12 @@ async fn benchmark_old_url_decoding(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  OLD: {} records", record_count);
+            println!("  OLD: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ OLD (multiple replacements): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ OLD (multiple replacements): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -170,15 +167,12 @@ async fn benchmark_new_zero_copy(
 
         record_count += 1;
         if record_count % 300_000 == 0 {
-            println!("  NEW: {} records", record_count);
+            println!("  NEW: {record_count} records");
         }
     }
 
     let duration = start.elapsed();
-    println!(
-        "✅ NEW (zero-copy): {} records in {:?}",
-        record_count, duration
-    );
+    println!("✅ NEW (zero-copy): {record_count} records in {duration:?}");
     Ok(duration)
 }
 
@@ -187,11 +181,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/tmp/gencode.v38.annotation.gff3.gz";
 
     println!("🚀 ZERO-COPY URL DECODING Benchmark");
-    println!("File: {}", file_path);
+    println!("File: {file_path}");
     println!("===================================");
 
     if !std::path::Path::new(file_path).exists() {
-        eprintln!("❌ Error: File {} not found", file_path);
+        eprintln!("❌ Error: File {file_path} not found");
         std::process::exit(1);
     }
 
@@ -209,20 +203,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let old_rps = 3_148_136.0 / old_time.as_secs_f64();
     let new_rps = 3_148_136.0 / new_time.as_secs_f64();
 
-    println!(
-        "🐌 OLD (multiple replace): {:?} ({:.0} records/sec)",
-        old_time, old_rps
-    );
-    println!(
-        "⚡ NEW (zero-copy):        {:?} ({:.0} records/sec)",
-        new_time, new_rps
-    );
+    println!("🐌 OLD (multiple replace): {old_time:?} ({old_rps:.0} records/sec)");
+    println!("⚡ NEW (zero-copy):        {new_time:?} ({new_rps:.0} records/sec)");
 
     let improvement = old_time.as_secs_f64() / new_time.as_secs_f64();
 
     println!();
     println!("📊 OPTIMIZATION IMPACT:");
-    println!("Zero-copy decoding is {:.2}x FASTER", improvement);
+    println!("Zero-copy decoding is {improvement:.2}x FASTER");
 
     if improvement > 1.5 {
         println!("✅ EXCELLENT! Zero-copy provides significant benefit");

--- a/datafusion/bio-format-gff/src/physical_exec.rs
+++ b/datafusion/bio-format-gff/src/physical_exec.rs
@@ -68,7 +68,7 @@ impl DisplayAs for GffExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "GffExec: projection=[{}]", proj_str)
+        write!(f, "GffExec: projection=[{proj_str}]")
     }
 }
 
@@ -371,7 +371,7 @@ fn load_attributes(
     let mut vec_attributes: Vec<Attribute> = Vec::with_capacity(estimated_capacity);
 
     for (tag, value) in attributes.as_ref().iter() {
-        debug!("Loading attribute: {} with value: {:?}", tag, value);
+        debug!("Loading attribute: {tag} with value: {value:?}");
         match value {
             Value::String(v) => vec_attributes.push(Attribute {
                 tag: tag.to_string(),       // Still need owned string for Attribute struct
@@ -511,8 +511,7 @@ async fn get_remote_gff_stream(
     let needs_phase = projection.as_ref().is_none_or(|proj| proj.contains(&7));
 
     debug!(
-        "GFF remote projection {:?}: needs_chrom={}, needs_end={}, needs_type={}, needs_source={}",
-        projection, needs_chrom, needs_end, needs_type, needs_source
+        "GFF remote projection {projection:?}: needs_chrom={needs_chrom}, needs_end={needs_end}, needs_type={needs_type}, needs_source={needs_source}"
     );
 
     //unnest builder
@@ -627,7 +626,7 @@ async fn get_remote_gff_stream(
             record_num += 1;
             // Once the batch size is reached, build and yield a record batch.
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let attribute_arrays = if unnest_enable {
                     Some(builders_to_arrays(&mut attribute_builders.2))
                 } else {
@@ -656,7 +655,7 @@ async fn get_remote_gff_stream(
                     batch_size,
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 chroms.clear();
@@ -883,7 +882,7 @@ async fn get_local_gff(
             record_num += 1;
             // Once the batch size is reached, build and yield a record batch.
             if record_num % batch_size == 0 {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let batch = build_record_batch_optimized(
                     Arc::clone(&schema.clone()),
                     &chroms,
@@ -911,7 +910,7 @@ async fn get_local_gff(
                     batch_size,
                 )?;
                 batch_num += 1;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
                 // Clear vectors for the next batch.
                 chroms.clear();
@@ -1129,13 +1128,12 @@ fn build_record_batch_optimized(
         )
         .map_err(|e| {
             DataFusionError::Execution(format!(
-                "Error creating empty GFF batch for COUNT(*): {:?}",
-                e
+                "Error creating empty GFF batch for COUNT(*): {e:?}"
             ))
         })
     } else {
         RecordBatch::try_new(schema, arrays).map_err(|e| {
-            DataFusionError::Execution(format!("Error creating optimized GFF batch: {:?}", e))
+            DataFusionError::Execution(format!("Error creating optimized GFF batch: {e:?}"))
         })
     }
 }
@@ -1201,7 +1199,7 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
     region_str
         .parse::<noodles_core::Region>()
-        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{}': {}", region_str, e)))
+        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{region_str}': {e}")))
 }
 
 /// Get a streaming RecordBatch stream from an indexed GFF file for one or more regions.
@@ -1230,7 +1228,7 @@ async fn get_indexed_gff_stream(
         let mut read_and_send = || -> Result<(), DataFusionError> {
             let mut indexed_reader =
                 IndexedGffReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed GFF: {}", e))
+                    DataFusionError::Execution(format!("Failed to open indexed GFF: {e}"))
                 })?;
 
             // Determine which fields are needed
@@ -1291,12 +1289,12 @@ async fn get_indexed_gff_stream(
                 let noodles_region = build_noodles_region(region)?;
 
                 let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("GFF region query failed: {}", e))
+                    DataFusionError::Execution(format!("GFF region query failed: {e}"))
                 })?;
 
                 for result in records {
                     let raw_record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("GFF indexed record read error: {}", e))
+                        DataFusionError::Execution(format!("GFF indexed record read error: {e}"))
                     })?;
 
                     // Parse the raw GFF line (tab-separated, 9 fields)

--- a/datafusion/bio-format-gff/src/storage.rs
+++ b/datafusion/bio-format-gff/src/storage.rs
@@ -386,7 +386,7 @@ impl GffRemoteReader {
         let compression_type =
             get_compression_type(file_path.clone(), None, object_storage_options.clone())
                 .await
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
 
         match (compression_type.clone(), parser_type) {
             // GZIP variants
@@ -660,7 +660,7 @@ impl GffLocalReader {
             object_storage_options.clone(),
         )
         .await
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(std::io::Error::other)?;
 
         match (compression_type.clone(), parser_type) {
             // GZIP variants - using sync readers
@@ -929,7 +929,7 @@ pub fn estimate_sizes_from_tbi(
     let index = match noodles_tabix::fs::read(index_path) {
         Ok(idx) => idx,
         Err(e) => {
-            log::debug!("Failed to read TBI index for size estimation: {}", e);
+            log::debug!("Failed to read TBI index for size estimation: {e}");
             return regions
                 .iter()
                 .map(|r| RegionSizeEstimate {
@@ -1088,7 +1088,7 @@ impl IndexedGffReader {
         let reader = noodles_tabix::io::indexed_reader::Builder::default()
             .set_index(index)
             .build_from_path(Path::new(file_path))
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         Ok(Self {
             reader,

--- a/datafusion/bio-format-gff/src/table_provider.rs
+++ b/datafusion/bio-format-gff/src/table_provider.rs
@@ -142,12 +142,12 @@ impl GffTableProvider {
         let storage_type = get_storage_type(file_path.clone());
         let (index_path, contig_names) = if matches!(storage_type, StorageType::LOCAL) {
             if let Some((idx_path, idx_fmt)) = discover_gff_index(&file_path) {
-                debug!("Discovered GFF index: {} (format: {:?})", idx_path, idx_fmt);
+                debug!("Discovered GFF index: {idx_path} (format: {idx_fmt:?})");
                 // Read contig names from the index
                 let names = match IndexedGffReader::new(&file_path, &idx_path) {
                     Ok(reader) => reader.contig_names().to_vec(),
                     Err(e) => {
-                        debug!("Failed to read GFF index contig names: {}", e);
+                        debug!("Failed to read GFF index contig names: {e}");
                         Vec::new()
                     }
                 };
@@ -159,10 +159,7 @@ impl GffTableProvider {
             (None, Vec::new())
         };
 
-        debug!(
-            "GffTableProvider::new - constructed schema for file: {}",
-            file_path
-        );
+        debug!("GffTableProvider::new - constructed schema for file: {file_path}");
 
         Ok(Self {
             file_path,
@@ -205,13 +202,13 @@ impl TableProvider for GffTableProvider {
             .iter()
             .map(|expr| {
                 if self.index_path.is_some() && is_genomic_coordinate_filter(expr) {
-                    debug!("GFF filter can be pushed down (indexed): {:?}", expr);
+                    debug!("GFF filter can be pushed down (indexed): {expr:?}");
                     TableProviderFilterPushDown::Inexact
                 } else if can_push_down_filter(expr, &self.schema) {
-                    debug!("GFF filter can be pushed down (record-level): {:?}", expr);
+                    debug!("GFF filter can be pushed down (record-level): {expr:?}");
                     TableProviderFilterPushDown::Inexact
                 } else {
-                    debug!("GFF filter cannot be pushed down: {:?}", expr);
+                    debug!("GFF filter cannot be pushed down: {expr:?}");
                     TableProviderFilterPushDown::Unsupported
                 }
             })
@@ -234,7 +231,7 @@ impl TableProvider for GffTableProvider {
             self.contig_names
         );
         for (i, f) in filters.iter().enumerate() {
-            debug!("  filter[{}]: {:?}", i, f);
+            debug!("  filter[{i}]: {f:?}");
         }
 
         fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {

--- a/datafusion/bio-format-gff/tests/attribute_projection_test.rs
+++ b/datafusion/bio-format-gff/tests/attribute_projection_test.rs
@@ -18,7 +18,7 @@ async fn create_test_gff_file_with_attributes() -> std::io::Result<String> {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let temp_file = format!("/tmp/test_attribute_projection_{}.gff", nanos);
+    let temp_file = format!("/tmp/test_attribute_projection_{nanos}.gff");
     fs::write(&temp_file, SAMPLE_GFF_CONTENT_WITH_ATTRIBUTES).await?;
     Ok(temp_file)
 }

--- a/datafusion/bio-format-gff/tests/filter_pushdown_test.rs
+++ b/datafusion/bio-format-gff/tests/filter_pushdown_test.rs
@@ -23,7 +23,7 @@ async fn create_test_gff_file() -> std::io::Result<String> {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let temp_file = format!("/tmp/test_filter_pushdown_{}.gff3", nanos);
+    let temp_file = format!("/tmp/test_filter_pushdown_{nanos}.gff3");
     fs::write(&temp_file, SAMPLE_GFF_CONTENT).await?;
     Ok(temp_file)
 }
@@ -289,8 +289,7 @@ async fn test_filter_pushdown_between() -> Result<(), Box<dyn std::error::Error>
         let start_val = start_array.value(i);
         assert!(
             (1000..=4000).contains(&start_val),
-            "All results should have start between 1000 and 4000, got {}",
-            start_val
+            "All results should have start between 1000 and 4000, got {start_val}"
         );
     }
 
@@ -331,8 +330,7 @@ async fn test_filter_pushdown_in_list() -> Result<(), Box<dyn std::error::Error>
         let chrom_val = chrom_array.value(i);
         assert!(
             chrom_val == "chr1" || chrom_val == "chr2",
-            "All results should be from chr1 or chr2, got {}",
-            chrom_val
+            "All results should be from chr1 or chr2, got {chrom_val}"
         );
     }
 
@@ -419,8 +417,7 @@ async fn test_filter_pushdown_score_field() -> Result<(), Box<dyn std::error::Er
             let score_val = score_array.value(i);
             assert!(
                 score_val > 75.0,
-                "All results should have score > 75.0, got {}",
-                score_val
+                "All results should have score > 75.0, got {score_val}"
             );
         }
     }

--- a/datafusion/bio-format-gff/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-gff/tests/indexed_read_test.rs
@@ -85,13 +85,11 @@ async fn test_gff_multi_chromosome_query() -> datafusion::error::Result<()> {
 
     assert!(
         chroms.contains("chr1"),
-        "Expected chr1 in results: {:?}",
-        chroms
+        "Expected chr1 in results: {chroms:?}"
     );
     assert!(
         chroms.contains("chr2"),
-        "Expected chr2 in results: {:?}",
-        chroms
+        "Expected chr2 in results: {chroms:?}"
     );
 
     let count = count_rows(
@@ -119,11 +117,7 @@ async fn test_gff_full_scan_total_count() -> datafusion::error::Result<()> {
     assert_eq!(
         total,
         chr1 + chr2 + chrx,
-        "Full scan total ({}) should equal sum of per-chrom counts (chr1={}, chr2={}, chrX={})",
-        total,
-        chr1,
-        chr2,
-        chrx
+        "Full scan total ({total}) should equal sum of per-chrom counts (chr1={chr1}, chr2={chr2}, chrX={chrx})"
     );
 
     Ok(())
@@ -141,9 +135,7 @@ async fn test_gff_record_level_filter() -> datafusion::error::Result<()> {
     assert!(filtered > 0, "Expected some gene features");
     assert!(
         filtered < total,
-        "Filtered count ({}) should be < total ({}) since not all features are genes",
-        filtered,
-        total
+        "Filtered count ({filtered}) should be < total ({total}) since not all features are genes"
     );
 
     Ok(())
@@ -164,9 +156,7 @@ async fn test_gff_combined_filters() -> datafusion::error::Result<()> {
     assert!(combined > 0, "Expected some gene features on chr1");
     assert!(
         combined <= chr1_total,
-        "Combined filter count ({}) should be <= chr1 total ({})",
-        combined,
-        chr1_total
+        "Combined filter count ({combined}) should be <= chr1 total ({chr1_total})"
     );
 
     Ok(())
@@ -192,9 +182,7 @@ async fn test_gff_region_with_positions() -> datafusion::error::Result<()> {
     );
     assert!(
         region_count <= chr1_total,
-        "Region count ({}) should be <= chr1 total ({})",
-        region_count,
-        chr1_total
+        "Region count ({region_count}) should be <= chr1 total ({chr1_total})"
     );
 
     Ok(())
@@ -225,8 +213,7 @@ async fn test_gff_indexed_correctness() -> datafusion::error::Result<()> {
 
     assert_eq!(
         indexed_count, manual_count,
-        "Indexed chr1 count ({}) should equal manual count from full scan ({})",
-        indexed_count, manual_count
+        "Indexed chr1 count ({indexed_count}) should equal manual count from full scan ({manual_count})"
     );
 
     Ok(())

--- a/datafusion/bio-format-gff/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-gff/tests/projection_pushdown_test.rs
@@ -17,7 +17,7 @@ async fn create_test_gff_file() -> std::io::Result<String> {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let temp_file = format!("/tmp/test_projection_{}.gff3", nanos);
+    let temp_file = format!("/tmp/test_projection_{nanos}.gff3");
     fs::write(&temp_file, SAMPLE_GFF_CONTENT).await?;
     Ok(temp_file)
 }
@@ -501,7 +501,7 @@ async fn test_gff_count_star_bug() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .value(0);
 
-    println!("GFF COUNT(*) result: {}", count_star);
+    println!("GFF COUNT(*) result: {count_star}");
 
     // Test COUNT(chrom) - this should work as a comparison
     println!("Testing GFF COUNT(chrom)...");
@@ -519,15 +519,14 @@ async fn test_gff_count_star_bug() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .value(0);
 
-    println!("GFF COUNT(chrom) result: {}", count_chrom);
+    println!("GFF COUNT(chrom) result: {count_chrom}");
 
     // They should be equal and match the expected record count (3 records in test GFF)
     assert_eq!(
         count_star, count_chrom,
-        "COUNT(*) should equal COUNT(chrom) but got {} vs {}",
-        count_star, count_chrom
+        "COUNT(*) should equal COUNT(chrom) but got {count_star} vs {count_chrom}"
     );
-    assert_eq!(count_star, 3, "COUNT(*) should be 3 but got {}", count_star);
+    assert_eq!(count_star, 3, "COUNT(*) should be 3 but got {count_star}");
 
     Ok(())
 }

--- a/datafusion/bio-format-pairs/src/physical_exec.rs
+++ b/datafusion/bio-format-pairs/src/physical_exec.rs
@@ -67,7 +67,7 @@ impl DisplayAs for PairsExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "PairsExec: projection=[{}]", proj_str)
+        write!(f, "PairsExec: projection=[{proj_str}]")
     }
 }
 
@@ -226,7 +226,7 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
     region_str
         .parse::<noodles_core::Region>()
-        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{}': {}", region_str, e)))
+        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{region_str}': {e}")))
 }
 
 enum ColumnValue {
@@ -337,7 +337,7 @@ async fn get_local_pairs_stream(
     let stream = try_stream! {
         let opts = object_storage_options.unwrap_or_default();
         let mut reader = new_local_reader(&file_path, opts).await
-            .map_err(|e| DataFusionError::Execution(format!("Failed to open Pairs file: {}", e)))?;
+            .map_err(|e| DataFusionError::Execution(format!("Failed to open Pairs file: {e}")))?;
 
         let num_columns = columns.len();
         let mut column_data: Vec<Vec<ColumnValue>> = (0..num_columns).map(|_| Vec::with_capacity(batch_size)).collect();
@@ -347,7 +347,7 @@ async fn get_local_pairs_stream(
         loop {
             line.clear();
             let bytes = reader.read_line(&mut line)
-                .map_err(|e| DataFusionError::Execution(format!("Read error: {}", e)))?;
+                .map_err(|e| DataFusionError::Execution(format!("Read error: {e}")))?;
             if bytes == 0 {
                 break;
             }
@@ -446,7 +446,7 @@ async fn get_indexed_pairs_stream(
         let mut read_and_send = || -> Result<(), DataFusionError> {
             let mut indexed_reader =
                 IndexedPairsReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed Pairs: {}", e))
+                    DataFusionError::Execution(format!("Failed to open indexed Pairs: {e}"))
                 })?;
 
             let num_columns = columns.len();
@@ -476,15 +476,12 @@ async fn get_indexed_pairs_stream(
 
                 let noodles_region = build_noodles_region(region)?;
                 let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("Pairs region query failed: {}", e))
+                    DataFusionError::Execution(format!("Pairs region query failed: {e}"))
                 })?;
 
                 for result in records {
                     let raw_record = result.map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Pairs indexed record read error: {}",
-                            e
-                        ))
+                        DataFusionError::Execution(format!("Pairs indexed record read error: {e}"))
                     })?;
 
                     let line: &str = raw_record.as_ref();

--- a/datafusion/bio-format-pairs/src/storage.rs
+++ b/datafusion/bio-format-pairs/src/storage.rs
@@ -80,7 +80,7 @@ pub async fn new_local_reader(
         object_storage_options,
     )
     .await
-    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     let file = File::open(file_path)?;
     match compression {
@@ -131,7 +131,7 @@ impl IndexedPairsReader {
         let reader = noodles_tabix::io::indexed_reader::Builder::default()
             .set_index(index)
             .build_from_path(Path::new(file_path))
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         // Parse header from the BGZF file for column info
         let header = {
@@ -181,7 +181,7 @@ pub fn estimate_sizes_from_tbi(
     let index = match noodles_tabix::fs::read(index_path) {
         Ok(idx) => idx,
         Err(e) => {
-            log::debug!("Failed to read TBI index for size estimation: {}", e);
+            log::debug!("Failed to read TBI index for size estimation: {e}");
             return regions
                 .iter()
                 .map(|r| RegionSizeEstimate {

--- a/datafusion/bio-format-pairs/src/table_provider.rs
+++ b/datafusion/bio-format-pairs/src/table_provider.rs
@@ -115,10 +115,7 @@ impl PairsTableProvider {
         let storage_type = get_storage_type(file_path.clone());
         if !matches!(storage_type, StorageType::LOCAL) {
             return Err(datafusion::common::DataFusionError::NotImplemented(
-                format!(
-                    "Remote Pairs file reading is not yet supported: {}",
-                    file_path
-                ),
+                format!("Remote Pairs file reading is not yet supported: {file_path}"),
             ));
         }
 
@@ -128,8 +125,7 @@ impl PairsTableProvider {
         let header =
             crate::storage::get_local_pairs_header(&file_path, &storage_opts).map_err(|e| {
                 datafusion::common::DataFusionError::Execution(format!(
-                    "Failed to read Pairs header from {}: {}",
-                    file_path, e
+                    "Failed to read Pairs header from {file_path}: {e}"
                 ))
             })?;
 
@@ -138,14 +134,11 @@ impl PairsTableProvider {
         // Auto-discover index file
         let (index_path, contig_names) =
             if let Some((idx_path, idx_fmt)) = discover_pairs_index(&file_path) {
-                debug!(
-                    "Discovered Pairs index: {} (format: {:?})",
-                    idx_path, idx_fmt
-                );
+                debug!("Discovered Pairs index: {idx_path} (format: {idx_fmt:?})");
                 let names = match IndexedPairsReader::new(&file_path, &idx_path) {
                     Ok(reader) => reader.contig_names().to_vec(),
                     Err(e) => {
-                        debug!("Failed to read Pairs index contig names: {}", e);
+                        debug!("Failed to read Pairs index contig names: {e}");
                         Vec::new()
                     }
                 };
@@ -195,13 +188,13 @@ impl TableProvider for PairsTableProvider {
             .iter()
             .map(|expr| {
                 if self.index_path.is_some() && is_pairs_index_filter(expr) {
-                    debug!("Pairs filter can be pushed down (indexed): {:?}", expr);
+                    debug!("Pairs filter can be pushed down (indexed): {expr:?}");
                     TableProviderFilterPushDown::Inexact
                 } else if can_push_down_record_filter(expr, &self.schema) {
-                    debug!("Pairs filter can be pushed down (record-level): {:?}", expr);
+                    debug!("Pairs filter can be pushed down (record-level): {expr:?}");
                     TableProviderFilterPushDown::Inexact
                 } else {
-                    debug!("Pairs filter cannot be pushed down: {:?}", expr);
+                    debug!("Pairs filter cannot be pushed down: {expr:?}");
                     TableProviderFilterPushDown::Unsupported
                 }
             })

--- a/datafusion/bio-format-vcf/examples/bgzf_test.rs
+++ b/datafusion/bio-format-vcf/examples/bgzf_test.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .await?;
 
                 let stream_time = stream_start.elapsed();
-                println!("Stream setup time: {:?}", stream_time);
+                println!("Stream setup time: {stream_time:?}");
 
                 let inner = bgzf::r#async::io::Reader::new(StreamReader::new(stream));
                 let mut reader = vcf::r#async::io::Reader::new(inner);
@@ -62,14 +62,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
 
                 let fileformat = header.file_format();
-                println!("VCF file format: {:?}", fileformat);
+                println!("VCF file format: {fileformat:?}");
 
                 let essential_fields = ["AC", "AF", "AN"];
                 for field in essential_fields {
                     if header.infos().get(field).is_some() {
-                        println!("Found essential INFO field: {}", field);
+                        println!("Found essential INFO field: {field}");
                     } else {
-                        println!("Warning: Missing essential INFO field: {}", field);
+                        println!("Warning: Missing essential INFO field: {field}");
                     }
                 }
 
@@ -97,8 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let batch_time = batch_start.elapsed();
                         let records_per_sec = BATCH_SIZE as f64 / batch_time.as_secs_f64();
                         println!(
-                            "Processed batch of {} records in {:?} ({:.2} records/sec). Total records: {}",
-                            BATCH_SIZE, batch_time, records_per_sec, count
+                            "Processed batch of {BATCH_SIZE} records in {batch_time:?} ({records_per_sec:.2} records/sec). Total records: {count}"
                         );
                         batch_count = 0;
                         batch_start = Instant::now();
@@ -107,9 +106,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let total_time = start_time.elapsed();
                 let avg_speed = count as f64 / total_time.as_secs_f64();
-                println!("Records count: {}", count);
-                println!("Total time: {:?}", total_time);
-                println!("Average speed: {:.2} records/sec", avg_speed);
+                println!("Records count: {count}");
+                println!("Total time: {total_time:?}");
+                println!("Average speed: {avg_speed:.2} records/sec");
                 println!("---------------------------------------------");
             }
         }

--- a/datafusion/bio-format-vcf/examples/noodles_test.rs
+++ b/datafusion/bio-format-vcf/examples/noodles_test.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .finish();
 
     let setup_time = start_time.elapsed();
-    println!("Setup time: {:?}", setup_time);
+    println!("Setup time: {setup_time:?}");
 
     let stream_start = std::time::Instant::now();
     let stream = operator
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into_bytes_stream(..)
         .await?;
     let stream_time = stream_start.elapsed();
-    println!("Stream setup time: {:?}", stream_time);
+    println!("Stream setup time: {stream_time:?}");
 
     let inner = bgzf::r#async::Reader::new(StreamReader::new(stream));
     let mut reader = vcf::r#async::io::Reader::new(inner);
@@ -78,8 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let batch_time = batch_start.elapsed();
             let records_per_sec = BATCH_SIZE as f64 / batch_time.as_secs_f64();
             println!(
-                "Processed batch of {} records in {:?} ({:.2} records/sec). Total records: {}",
-                BATCH_SIZE, batch_time, records_per_sec, count
+                "Processed batch of {BATCH_SIZE} records in {batch_time:?} ({records_per_sec:.2} records/sec). Total records: {count}"
             );
             batch_count = 0;
             batch_start = std::time::Instant::now();
@@ -88,9 +87,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let total_time = start_time.elapsed();
     let avg_speed = count as f64 / total_time.as_secs_f64();
-    println!("Total records processed: {}", count);
-    println!("Total time: {:?}", total_time);
-    println!("Average speed: {:.2} records/sec", avg_speed);
+    println!("Total records processed: {count}");
+    println!("Total time: {total_time:?}");
+    println!("Average speed: {avg_speed:.2} records/sec");
     Ok(())
 }
 

--- a/datafusion/bio-format-vcf/src/bin/baseline_vcf_benchmark.rs
+++ b/datafusion/bio-format-vcf/src/bin/baseline_vcf_benchmark.rs
@@ -11,16 +11,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vcf_file = "/tmp/homo_sapiens-chr1.vcf.bgz";
 
     if !std::path::Path::new(vcf_file).exists() {
-        eprintln!("❌ VCF file not found: {}", vcf_file);
+        eprintln!("❌ VCF file not found: {vcf_file}");
         return Ok(());
     }
 
     println!("🧬 Baseline VCF Performance Test (Regular VcfTableProvider)");
-    println!("📁 File: {}", vcf_file);
+    println!("📁 File: {vcf_file}");
 
     let metadata = std::fs::metadata(vcf_file)?;
     let file_size_mb = metadata.len() as f64 / (1024.0 * 1024.0);
-    println!("💾 File size: {:.2} MB", file_size_mb);
+    println!("💾 File size: {file_size_mb:.2} MB");
     println!();
 
     {
@@ -76,13 +76,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map(|batch| batch.num_rows())
             .sum::<usize>();
 
-        println!("   📊 Records: {}", record_count);
-        println!("   🎯 Projection rows: {}", projection_rows);
-        println!("   ⏱️  COUNT time: {:?}", count_duration);
-        println!("   🔍 Projection time: {:?}", projection_duration);
+        println!("   📊 Records: {record_count}");
+        println!("   🎯 Projection rows: {projection_rows}");
+        println!("   ⏱️  COUNT time: {count_duration:?}");
+        println!("   🔍 Projection time: {projection_duration:?}");
 
         let records_per_sec = record_count as f64 / count_duration.as_secs_f64();
-        println!("   🚀 Throughput: {:.0} records/sec", records_per_sec);
+        println!("   🚀 Throughput: {records_per_sec:.0} records/sec");
 
         // Show sample data
         if let Some(batch) = proj_result.first() {

--- a/datafusion/bio-format-vcf/src/bin/test_gnomad_query.rs
+++ b/datafusion/bio-format-vcf/src/bin/test_gnomad_query.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Register the table
     let file_path = "gs://polars-bio-it/vep.vcf.bgz";
-    println!("Registering table from: {}", file_path);
+    println!("Registering table from: {file_path}");
 
     let table_provider = Arc::new(VcfTableProvider::new(
         file_path.to_string(),
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#;
 
     println!("Running query:");
-    println!("{}", sql);
+    println!("{sql}");
 
     let df = ctx.sql(sql).await?;
     let results = df.collect().await?;

--- a/datafusion/bio-format-vcf/src/bin/test_vcf_parallel.rs
+++ b/datafusion/bio-format-vcf/src/bin/test_vcf_parallel.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             println!("For full testing, please ensure you have a BGZF compressed VCF file:");
             for file in &test_files {
-                println!("  - {}", file);
+                println!("  - {file}");
             }
             println!("\nTesting basic VCF table provider functionality...");
 
@@ -45,14 +45,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 true, // Use 0-based coordinates (default)
             ) {
                 Ok(_) => println!("✓ VcfTableProvider created successfully"),
-                Err(e) => println!("✗ Error creating VcfTableProvider: {}", e),
+                Err(e) => println!("✗ Error creating VcfTableProvider: {e}"),
             }
 
             return Ok(());
         }
     };
 
-    println!("Testing parallel BGZF reading with file: {}", file_path);
+    println!("Testing parallel BGZF reading with file: {file_path}");
 
     // Test 1: Basic functionality with auto thread detection
     println!("\n=== Test 1: Auto thread detection ===");
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Records processed: {}", column.value(0));
         }
     }
-    println!("Time with auto threads: {:?}", duration);
+    println!("Time with auto threads: {duration:?}");
 
     // Test 2: Additional read test
     {
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _results = df.collect().await?;
         let duration = start_time.elapsed();
 
-        println!("Time: {:?}", duration);
+        println!("Time: {duration:?}");
     }
 
     println!("\nParallel BGZF VCF reading tests completed successfully!");

--- a/datafusion/bio-format-vcf/src/header_builder.rs
+++ b/datafusion/bio-format-vcf/src/header_builder.rs
@@ -70,7 +70,7 @@ pub fn build_vcf_header_lines(
         .get(VCF_FILE_FORMAT_KEY)
         .map(|s| s.as_str())
         .unwrap_or("VCFv4.3");
-    lines.push(format!("##fileformat={}", file_format));
+    lines.push(format!("##fileformat={file_format}"));
 
     // Add FILTER definitions from metadata using shared utilities
     if let Some(filters_json) = schema_metadata.get(VCF_FILTERS_KEY) {
@@ -93,7 +93,7 @@ pub fn build_vcf_header_lines(
             for contig in contigs {
                 let mut line = format!("##contig=<ID={}", contig.id);
                 if let Some(length) = contig.length {
-                    line.push_str(&format!(",length={}", length));
+                    line.push_str(&format!(",length={length}"));
                 }
                 line.push('>');
                 lines.push(line);
@@ -121,8 +121,7 @@ pub fn build_vcf_header_lines(
             let (vcf_type, number, description) = get_info_field_metadata(field, info_name);
 
             lines.push(format!(
-                "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
-                info_name, number, vcf_type, description
+                "##INFO=<ID={info_name},Number={number},Type={vcf_type},Description=\"{description}\">"
             ));
         }
     }
@@ -136,8 +135,7 @@ pub fn build_vcf_header_lines(
             let (vcf_type, number, description) = get_format_field_metadata(field, format_name);
 
             lines.push(format!(
-                "##FORMAT=<ID={},Number={},Type={},Description=\"{}\">",
-                format_name, number, vcf_type, description
+                "##FORMAT=<ID={format_name},Number={number},Type={vcf_type},Description=\"{description}\">"
             ));
         }
     }
@@ -166,7 +164,7 @@ fn get_info_field_metadata(field: &Field, field_name: &str) -> (String, String, 
     let description = metadata
         .get(VCF_FIELD_DESCRIPTION_KEY)
         .cloned()
-        .unwrap_or_else(|| format!("{} field", field_name));
+        .unwrap_or_else(|| format!("{field_name} field"));
 
     (vcf_type, number, description)
 }
@@ -199,7 +197,7 @@ fn get_format_field_metadata(field: &Field, format_name: &str) -> (String, Strin
     let description = metadata
         .get(VCF_FIELD_DESCRIPTION_KEY)
         .cloned()
-        .unwrap_or_else(|| format!("{} format field", format_name));
+        .unwrap_or_else(|| format!("{format_name} format field"));
 
     (vcf_type, number, description)
 }
@@ -217,7 +215,7 @@ fn find_format_field<'a>(
 
     // Try multi-sample naming convention: {sample}_{format}
     for sample_name in sample_names {
-        let column_name = format!("{}_{}", sample_name, format_name);
+        let column_name = format!("{sample_name}_{format_name}");
         if let Ok(idx) = schema.index_of(&column_name) {
             return Some(schema.field(idx));
         }

--- a/datafusion/bio-format-vcf/src/physical_exec.rs
+++ b/datafusion/bio-format-vcf/src/physical_exec.rs
@@ -50,7 +50,7 @@ where
             buf.push(sep);
         }
         first = false;
-        let _ = write!(buf, "{}", item);
+        let _ = write!(buf, "{item}");
     }
 }
 
@@ -301,10 +301,10 @@ fn build_record_batch_from_builders(
         let options = datafusion::arrow::record_batch::RecordBatchOptions::new()
             .with_row_count(Some(record_count));
         RecordBatch::try_new_with_options(schema, arrays, &options)
-            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
     } else {
         RecordBatch::try_new(schema, arrays)
-            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {:?}", e)))
+            .map_err(|e| DataFusionError::Execution(format!("Error creating batch: {e:?}")))
     }
 }
 
@@ -330,8 +330,7 @@ fn load_infos_single_pass(
     for result in info.iter(header) {
         let (key, value) = result.map_err(|e| {
             datafusion::arrow::error::ArrowError::InvalidArgumentError(format!(
-                "Error reading INFO field: {}",
-                e
+                "Error reading INFO field: {e}"
             ))
         })?;
 
@@ -378,7 +377,7 @@ fn load_infos_single_pass(
                 }
                 _ => {
                     return Err(datafusion::arrow::error::ArrowError::InvalidArgumentError(
-                        format!("Unsupported INFO value type for field '{}'", key),
+                        format!("Unsupported INFO value type for field '{key}'"),
                     ));
                 }
             }
@@ -569,7 +568,7 @@ async fn get_local_vcf(
             }
 
             if batch_row_count == batch_size {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let info_arrays = if flags.any_info {
                     Some(builders_to_arrays(&mut info_builders.2))
                 } else {
@@ -592,7 +591,7 @@ async fn get_local_vcf(
                 )?;
                 batch_num += 1;
                 batch_row_count = 0;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
             }
         }
@@ -650,7 +649,7 @@ async fn get_local_vcf_sync(
     std::thread::spawn(move || {
         let read_and_send = || -> Result<(), DataFusionError> {
             let (mut reader, header) = open_local_vcf_sync(&file_path, compression_type)
-                .map_err(|e| DataFusionError::Execution(format!("Failed to open VCF: {}", e)))?;
+                .map_err(|e| DataFusionError::Execution(format!("Failed to open VCF: {e}")))?;
 
             let infos = header.infos();
             let formats = header.formats();
@@ -717,7 +716,7 @@ async fn get_local_vcf_sync(
                                     DataFusionError::Execution("Missing variant start".to_string())
                                 })?
                                 .map_err(|e| {
-                                    DataFusionError::Execution(format!("VCF position error: {}", e))
+                                    DataFusionError::Execution(format!("VCF position error: {e}"))
                                 })?
                                 .get() as u32;
                             Some(if coordinate_system_zero_based {
@@ -785,7 +784,7 @@ async fn get_local_vcf_sync(
                                     .quality_score()
                                     .transpose()
                                     .map_err(|e| {
-                                        DataFusionError::Execution(format!("VCF qual error: {}", e))
+                                        DataFusionError::Execution(format!("VCF qual error: {e}"))
                                     })?
                                     .map(|v| v as f64),
                             );
@@ -831,7 +830,7 @@ async fn get_local_vcf_sync(
                         }
 
                         if batch_row_count == batch_size {
-                            debug!("Record number: {}", record_num);
+                            debug!("Record number: {record_num}");
                             let info_arrays = if flags.any_info {
                                 Some(builders_to_arrays(&mut info_builders.2))
                             } else {
@@ -869,7 +868,7 @@ async fn get_local_vcf_sync(
                         }
                     }
                     Err(e) => {
-                        return Err(DataFusionError::Execution(format!("VCF read error: {}", e)));
+                        return Err(DataFusionError::Execution(format!("VCF read error: {e}")));
                     }
                 }
             }
@@ -909,7 +908,7 @@ async fn get_local_vcf_sync(
                 }
             }
 
-            debug!("Local VCF sync scan: {} records", record_num);
+            debug!("Local VCF sync scan: {record_num} records");
             Ok(())
         };
         if let Err(e) = read_and_send() {
@@ -1070,7 +1069,7 @@ async fn get_remote_vcf_stream(
             }
 
             if batch_row_count == batch_size {
-                debug!("Record number: {}", record_num);
+                debug!("Record number: {record_num}");
                 let info_arrays = if flags.any_info {
                     Some(builders_to_arrays(&mut info_builders.2))
                 } else {
@@ -1093,7 +1092,7 @@ async fn get_remote_vcf_stream(
                 )?;
                 batch_num += 1;
                 batch_row_count = 0;
-                debug!("Batch number: {}", batch_num);
+                debug!("Batch number: {batch_num}");
                 yield batch;
             }
         }
@@ -1209,8 +1208,7 @@ fn load_formats_single_pass(
         for result in sample.iter(header) {
             let (key, value) = result.map_err(|e| {
                 datafusion::arrow::error::ArrowError::InvalidArgumentError(format!(
-                    "Error reading FORMAT field: {}",
-                    e
+                    "Error reading FORMAT field: {e}"
                 ))
             })?;
 
@@ -1240,7 +1238,7 @@ fn load_formats_single_pass(
                             first = false;
                             match allele {
                                 Some(a) => {
-                                    let _ = write!(gt_str, "{}", a);
+                                    let _ = write!(gt_str, "{a}");
                                 }
                                 None => gt_str.push('.'),
                             }
@@ -1384,7 +1382,7 @@ async fn get_stream(
             )
             .await
             .map_err(|e| {
-                DataFusionError::Execution(format!("Failed to detect compression: {}", e))
+                DataFusionError::Execution(format!("Failed to detect compression: {e}"))
             })?;
 
             if matches!(compression_type, CompressionType::GZIP) {
@@ -1486,7 +1484,7 @@ impl DisplayAs for VcfExec {
             }
             None => "*".to_string(),
         };
-        write!(f, "VcfExec: projection=[{}]", proj_str)
+        write!(f, "VcfExec: projection=[{proj_str}]")
     }
 }
 
@@ -1603,7 +1601,7 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
     region_str
         .parse::<noodles_core::Region>()
-        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{}': {}", region_str, e)))
+        .map_err(|e| DataFusionError::Execution(format!("Invalid region '{region_str}': {e}")))
 }
 
 /// Get a streaming RecordBatch stream from an indexed VCF file for one or more regions.
@@ -1635,7 +1633,7 @@ async fn get_indexed_vcf_stream(
         let read_and_send = || -> Result<(), DataFusionError> {
             let mut indexed_reader =
                 IndexedVcfReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed VCF: {}", e))
+                    DataFusionError::Execution(format!("Failed to open indexed VCF: {e}"))
                 })?;
 
             let header = indexed_reader.header().clone();
@@ -1705,12 +1703,12 @@ async fn get_indexed_vcf_stream(
                 let noodles_region = build_noodles_region(region)?;
 
                 let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("VCF region query failed: {}", e))
+                    DataFusionError::Execution(format!("VCF region query failed: {e}"))
                 })?;
 
                 for result in records {
                     let record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("VCF record read error: {}", e))
+                        DataFusionError::Execution(format!("VCF record read error: {e}"))
                     })?;
 
                     let needs_start_for_region =
@@ -1723,7 +1721,7 @@ async fn get_indexed_vcf_stream(
                                 DataFusionError::Execution("Missing variant start".to_string())
                             })?
                             .map_err(|e| {
-                                DataFusionError::Execution(format!("VCF position error: {}", e))
+                                DataFusionError::Execution(format!("VCF position error: {e}"))
                             })?
                             .get() as u32;
                         let start_val = if coordinate_system_zero_based {
@@ -1803,7 +1801,7 @@ async fn get_indexed_vcf_stream(
                                 .quality_score()
                                 .transpose()
                                 .map_err(|e| {
-                                    DataFusionError::Execution(format!("VCF qual error: {}", e))
+                                    DataFusionError::Execution(format!("VCF qual error: {e}"))
                                 })?
                                 .map(|v| v as f64),
                         );

--- a/datafusion/bio-format-vcf/src/serializer.rs
+++ b/datafusion/bio-format-vcf/src/serializer.rs
@@ -137,8 +137,7 @@ pub fn batch_to_vcf_lines(
 
         // Build the VCF line
         let mut line = format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            chrom, pos, id_str, ref_str, alt_str, qual_str, filter_str, info_str
+            "{chrom}\t{pos}\t{id_str}\t{ref_str}\t{alt_str}\t{qual_str}\t{filter_str}\t{info_str}"
         );
 
         if !format_str.is_empty() {
@@ -162,7 +161,7 @@ fn get_string_column_by_name<'a>(
     name: &str,
 ) -> Result<StringColumnRef<'a>> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     let column = batch.column(idx);
 
@@ -175,21 +174,20 @@ fn get_string_column_by_name<'a>(
     }
 
     Err(DataFusionError::Execution(format!(
-        "Column '{}' must be Utf8 or LargeUtf8 type",
-        name
+        "Column '{name}' must be Utf8 or LargeUtf8 type"
     )))
 }
 
 /// Gets a u32 column from the batch by name
 fn get_u32_column_by_name<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a UInt32Array> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<UInt32Array>()
-        .ok_or_else(|| DataFusionError::Execution(format!("Column '{}' must be UInt32 type", name)))
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be UInt32 type")))
 }
 
 /// Gets an optional f64 column from the batch by name
@@ -198,15 +196,13 @@ fn get_optional_f64_column_by_name<'a>(
     name: &str,
 ) -> Result<&'a Float64Array> {
     let idx = batch.schema().index_of(name).map_err(|_| {
-        DataFusionError::Execution(format!("Required column '{}' not found in batch", name))
+        DataFusionError::Execution(format!("Required column '{name}' not found in batch"))
     })?;
     batch
         .column(idx)
         .as_any()
         .downcast_ref::<Float64Array>()
-        .ok_or_else(|| {
-            DataFusionError::Execution(format!("Column '{}' must be Float64 type", name))
-        })
+        .ok_or_else(|| DataFusionError::Execution(format!("Column '{name}' must be Float64 type")))
 }
 
 /// Builds a map from INFO field name to column index
@@ -238,7 +234,7 @@ fn build_format_column_map(
             let column_name = if single_sample {
                 format_field.clone()
             } else {
-                format!("{}_{}", sample_name, format_field)
+                format!("{sample_name}_{format_field}")
             };
 
             if let Ok(idx) = batch.schema().index_of(&column_name) {
@@ -274,7 +270,7 @@ fn build_info_string(
                 // Flag type - just include the name
                 info_parts.push(field_name.clone());
             } else if value_str != "false" {
-                info_parts.push(format!("{}={}", field_name, value_str));
+                info_parts.push(format!("{field_name}={value_str}"));
             }
         }
     }

--- a/datafusion/bio-format-vcf/src/table_provider.rs
+++ b/datafusion/bio-format-vcf/src/table_provider.rs
@@ -169,7 +169,7 @@ async fn determine_schema_from_header(
                 let field_name = if single_sample {
                     tag.clone()
                 } else {
-                    format!("{}_{}", sample_name, tag)
+                    format!("{sample_name}_{tag}")
                 };
                 // Store VCF header metadata in field metadata for round-trip preservation
                 let mut field_metadata = HashMap::new();
@@ -272,10 +272,7 @@ pub fn format_to_arrow_type(formats: &Formats, field: &str) -> DataType {
             }
         }
         None => {
-            log::warn!(
-                "VCF FORMAT tag '{}' not found in header; defaulting to Utf8",
-                field
-            );
+            log::warn!("VCF FORMAT tag '{field}' not found in header; defaulting to Utf8");
             DataType::Utf8
         }
     }
@@ -362,7 +359,7 @@ impl VcfTableProvider {
         let storage_type = get_storage_type(file_path.clone());
         let index_path = if matches!(storage_type, StorageType::LOCAL) {
             discover_vcf_index(&file_path).map(|(path, fmt)| {
-                debug!("Discovered VCF index: {} (format: {:?})", path, fmt);
+                debug!("Discovered VCF index: {path} (format: {fmt:?})");
                 path
             })
         } else {
@@ -396,7 +393,7 @@ impl VcfTableProvider {
                         (names, lengths)
                     }
                     Err(e) => {
-                        debug!("Failed to read TBI for contig name fallback: {}", e);
+                        debug!("Failed to read TBI for contig name fallback: {e}");
                         (contig_names, contig_lengths)
                     }
                 }
@@ -494,13 +491,13 @@ impl TableProvider for VcfTableProvider {
             .iter()
             .map(|expr| {
                 if self.index_path.is_some() && is_genomic_coordinate_filter(expr) {
-                    debug!("VCF filter can be pushed down (indexed): {:?}", expr);
+                    debug!("VCF filter can be pushed down (indexed): {expr:?}");
                     TableProviderFilterPushDown::Inexact
                 } else if can_push_down_record_filter(expr, &self.schema) {
-                    debug!("VCF filter can be pushed down (record-level): {:?}", expr);
+                    debug!("VCF filter can be pushed down (record-level): {expr:?}");
                     TableProviderFilterPushDown::Inexact
                 } else {
-                    debug!("VCF filter cannot be pushed down: {:?}", expr);
+                    debug!("VCF filter cannot be pushed down: {expr:?}");
                     TableProviderFilterPushDown::Unsupported
                 }
             })
@@ -522,7 +519,7 @@ impl TableProvider for VcfTableProvider {
             self.contig_names
         );
         for (i, f) in filters.iter().enumerate() {
-            debug!("  filter[{}]: {:?}", i, f);
+            debug!("  filter[{i}]: {f:?}");
         }
 
         fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
@@ -729,10 +726,7 @@ pub fn info_to_arrow_type(infos: &Infos, field: &str) -> DataType {
             }
         }
         None => {
-            log::warn!(
-                "VCF tag '{}' not found in header; defaulting to Utf8",
-                field
-            );
+            log::warn!("VCF tag '{field}' not found in header; defaulting to Utf8");
             DataType::Utf8
         }
     }

--- a/datafusion/bio-format-vcf/src/write_exec.rs
+++ b/datafusion/bio-format-vcf/src/write_exec.rs
@@ -268,15 +268,12 @@ async fn write_vcf_stream(
 
     writer.finish()?;
 
-    debug!(
-        "VcfWriteExec: wrote {} records to {}",
-        total_count, output_path
-    );
+    debug!("VcfWriteExec: wrote {total_count} records to {output_path}");
 
     // Return a batch with the count
     let count_array = Arc::new(UInt64Array::from(vec![total_count]));
     RecordBatch::try_new(output_schema, vec![count_array])
-        .map_err(|e| DataFusionError::Execution(format!("Failed to create result batch: {}", e)))
+        .map_err(|e| DataFusionError::Execution(format!("Failed to create result batch: {e}")))
 }
 
 #[cfg(test)]

--- a/datafusion/bio-format-vcf/src/writer.rs
+++ b/datafusion/bio-format-vcf/src/writer.rs
@@ -108,7 +108,7 @@ impl VcfLocalWriter {
         compression: VcfCompressionType,
     ) -> Result<Self> {
         let file = File::create(path.as_ref()).map_err(|e| {
-            DataFusionError::Execution(format!("Failed to create output file: {}", e))
+            DataFusionError::Execution(format!("Failed to create output file: {e}"))
         })?;
         let buf_writer = BufWriter::new(file);
 
@@ -164,19 +164,19 @@ impl VcfLocalWriter {
 
     /// Writes a single line to the file
     fn write_line(&mut self, line: &str) -> Result<()> {
-        let line_with_newline = format!("{}\n", line);
+        let line_with_newline = format!("{line}\n");
         let bytes = line_with_newline.as_bytes();
 
         match self {
-            VcfLocalWriter::Plain(writer) => writer.write_all(bytes).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write VCF line: {}", e))
-            }),
-            VcfLocalWriter::Gzip(writer) => writer.write_all(bytes).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write VCF line: {}", e))
-            }),
-            VcfLocalWriter::Bgzf(writer) => writer.write_all(bytes).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to write VCF line: {}", e))
-            }),
+            VcfLocalWriter::Plain(writer) => writer
+                .write_all(bytes)
+                .map_err(|e| DataFusionError::Execution(format!("Failed to write VCF line: {e}"))),
+            VcfLocalWriter::Gzip(writer) => writer
+                .write_all(bytes)
+                .map_err(|e| DataFusionError::Execution(format!("Failed to write VCF line: {e}"))),
+            VcfLocalWriter::Bgzf(writer) => writer
+                .write_all(bytes)
+                .map_err(|e| DataFusionError::Execution(format!("Failed to write VCF line: {e}"))),
         }
     }
 
@@ -218,13 +218,13 @@ impl VcfLocalWriter {
         match self {
             VcfLocalWriter::Plain(writer) => writer
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
             VcfLocalWriter::Gzip(writer) => writer
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
             VcfLocalWriter::Bgzf(writer) => writer
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
         }
     }
 
@@ -240,16 +240,16 @@ impl VcfLocalWriter {
         match self {
             VcfLocalWriter::Plain(mut writer) => writer
                 .flush()
-                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {}", e))),
+                .map_err(|e| DataFusionError::Execution(format!("Failed to flush writer: {e}"))),
             VcfLocalWriter::Gzip(encoder) => {
                 encoder.finish().map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to finish GZIP stream: {}", e))
+                    DataFusionError::Execution(format!("Failed to finish GZIP stream: {e}"))
                 })?;
                 Ok(())
             }
             VcfLocalWriter::Bgzf(bgzf_writer) => {
                 bgzf_writer.finish().map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to finish BGZF stream: {}", e))
+                    DataFusionError::Execution(format!("Failed to finish BGZF stream: {e}"))
                 })?;
                 Ok(())
             }

--- a/datafusion/bio-format-vcf/tests/format_columns_test.rs
+++ b/datafusion/bio-format-vcf/tests/format_columns_test.rs
@@ -47,7 +47,7 @@ chr1	200	.	G	C	40	PASS	.	GT:DP	1|0:30
 "#;
 
 async fn create_test_vcf_file(test_name: &str, content: &str) -> std::io::Result<String> {
-    let temp_file = format!("/tmp/test_format_{}.vcf", test_name);
+    let temp_file = format!("/tmp/test_format_{test_name}.vcf");
     fs::write(&temp_file, content).await?;
     Ok(temp_file)
 }

--- a/datafusion/bio-format-vcf/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-vcf/tests/indexed_read_test.rs
@@ -83,16 +83,8 @@ async fn test_vcf_multi_chromosome_query() -> datafusion::error::Result<()> {
     )
     .await;
 
-    assert!(
-        chroms.contains("21"),
-        "Expected 21 in results: {:?}",
-        chroms
-    );
-    assert!(
-        chroms.contains("22"),
-        "Expected 22 in results: {:?}",
-        chroms
-    );
+    assert!(chroms.contains("21"), "Expected 21 in results: {chroms:?}");
+    assert!(chroms.contains("22"), "Expected 22 in results: {chroms:?}");
 
     let count = count_rows(&ctx, "SELECT chrom FROM vcf WHERE chrom IN ('21', '22')").await;
     assert_eq!(count, 500 + 500, "Expected 1000 variants on chr 21 + 22");
@@ -114,10 +106,7 @@ async fn test_vcf_full_scan_total_count() -> datafusion::error::Result<()> {
     assert_eq!(
         total,
         chr21 + chr22,
-        "Full scan total ({}) should equal sum of per-chrom counts (21={}, 22={})",
-        total,
-        chr21,
-        chr22
+        "Full scan total ({total}) should equal sum of per-chrom counts (21={chr21}, 22={chr22})"
     );
 
     Ok(())
@@ -134,9 +123,7 @@ async fn test_vcf_record_level_filter() -> datafusion::error::Result<()> {
     assert!(filtered > 0, "Expected some variants with quality >= 50");
     assert!(
         filtered < total,
-        "Filtered count ({}) should be < total ({})",
-        filtered,
-        total
+        "Filtered count ({filtered}) should be < total ({total})"
     );
 
     Ok(())
@@ -160,9 +147,7 @@ async fn test_vcf_combined_filters() -> datafusion::error::Result<()> {
     );
     assert!(
         combined <= chr21_total,
-        "Combined filter count ({}) should be <= chr21 total ({})",
-        combined,
-        chr21_total
+        "Combined filter count ({combined}) should be <= chr21 total ({chr21_total})"
     );
 
     Ok(())
@@ -187,9 +172,7 @@ async fn test_vcf_region_with_positions() -> datafusion::error::Result<()> {
     );
     assert!(
         region_count < chr21_total,
-        "Region count ({}) should be < chr21 total ({})",
-        region_count,
-        chr21_total
+        "Region count ({region_count}) should be < chr21 total ({chr21_total})"
     );
 
     Ok(())
@@ -220,8 +203,7 @@ async fn test_vcf_indexed_correctness() -> datafusion::error::Result<()> {
 
     assert_eq!(
         indexed_count, manual_count,
-        "Indexed chr21 count ({}) should equal manual count from full scan ({})",
-        indexed_count, manual_count
+        "Indexed chr21 count ({indexed_count}) should equal manual count from full scan ({manual_count})"
     );
 
     Ok(())

--- a/datafusion/bio-format-vcf/tests/info_projection_test.rs
+++ b/datafusion/bio-format-vcf/tests/info_projection_test.rs
@@ -19,7 +19,7 @@ chr2	400	.	T	G	50	PASS	AC=1;AF=0.25;AN=4;DP=40;SVTYPE=SNV
 "#;
 
 async fn create_test_vcf_file_with_info(test_name: &str) -> std::io::Result<String> {
-    let temp_file = format!("/tmp/test_info_projection_{}.vcf", test_name);
+    let temp_file = format!("/tmp/test_info_projection_{test_name}.vcf");
     fs::write(&temp_file, SAMPLE_VCF_CONTENT_WITH_INFO).await?;
     Ok(temp_file)
 }

--- a/datafusion/bio-format-vcf/tests/limit_and_indexed_projection_test.rs
+++ b/datafusion/bio-format-vcf/tests/limit_and_indexed_projection_test.rs
@@ -29,7 +29,7 @@ chr1	1000	rs10	C	A	120	PASS	DP=55
 "#;
 
 async fn create_test_vcf_file(test_name: &str) -> std::io::Result<String> {
-    let temp_file = format!("/tmp/test_limit_{}.vcf", test_name);
+    let temp_file = format!("/tmp/test_limit_{test_name}.vcf");
     fs::write(&temp_file, SAMPLE_VCF_CONTENT).await?;
     Ok(temp_file)
 }

--- a/datafusion/bio-format-vcf/tests/projection_optimization_test.rs
+++ b/datafusion/bio-format-vcf/tests/projection_optimization_test.rs
@@ -30,7 +30,7 @@ chr2	400	.	T	G	50	PASS	AC=1;AF=0.25;AN=4;DP=40;SVTYPE=SNV;FS=0.8;MQ=49.5;QD=11.2
 "#;
 
 async fn create_test_vcf_file_with_many_info(test_name: &str) -> std::io::Result<String> {
-    let temp_file = format!("/tmp/test_projection_optimization_{}.vcf", test_name);
+    let temp_file = format!("/tmp/test_projection_optimization_{test_name}.vcf");
     fs::write(&temp_file, SAMPLE_VCF_CONTENT_WITH_MANY_INFO).await?;
     Ok(temp_file)
 }
@@ -90,7 +90,7 @@ async fn test_projection_optimization_core_fields_only() -> Result<(), Box<dyn s
     let query = "SELECT chrom, start, id FROM vcf_table LIMIT 10";
     let df = ctx.sql(query).await?;
 
-    println!("Query 1 (core fields only): {:?}", query);
+    println!("Query 1 (core fields only): {query:?}");
 
     let results = df.collect().await?;
     println!("Results count: {}", results.len());
@@ -151,7 +151,7 @@ async fn test_projection_optimization_with_info_fields() -> Result<(), Box<dyn s
     let query = "SELECT chrom, start, `AC`, `DP` FROM vcf_table LIMIT 10";
     let df = ctx.sql(query).await?;
 
-    println!("Query 2 (with specific INFO fields): {:?}", query);
+    println!("Query 2 (with specific INFO fields): {query:?}");
 
     let results = df.collect().await?;
     println!("Results count: {}", results.len());
@@ -213,7 +213,7 @@ async fn test_count_optimization() -> Result<(), Box<dyn std::error::Error>> {
     let query = "SELECT COUNT(*) FROM vcf_table";
     let df = ctx.sql(query).await?;
 
-    println!("Query 3 (COUNT(*)): {:?}", query);
+    println!("Query 3 (COUNT(*)): {query:?}");
 
     let results = df.collect().await?;
 
@@ -225,7 +225,7 @@ async fn test_count_optimization() -> Result<(), Box<dyn std::error::Error>> {
             .downcast_ref::<datafusion::arrow::array::Int64Array>()
             .unwrap();
         let count = count_array.value(0);
-        println!("✅ COUNT(*) optimization works - counted {} records", count);
+        println!("✅ COUNT(*) optimization works - counted {count} records");
         assert!(count >= 4); // We have 4 records in our test file
     }
 

--- a/datafusion/bio-format-vcf/tests/projection_pushdown_test.rs
+++ b/datafusion/bio-format-vcf/tests/projection_pushdown_test.rs
@@ -17,7 +17,7 @@ chr1	300	.	G	A	50	PASS	DP=15;AF=0.7
 "#;
 
 async fn create_test_vcf_file(test_name: &str) -> std::io::Result<String> {
-    let temp_file = format!("/tmp/test_projection_{}.vcf", test_name);
+    let temp_file = format!("/tmp/test_projection_{test_name}.vcf");
     fs::write(&temp_file, SAMPLE_VCF_CONTENT).await?;
     Ok(temp_file)
 }
@@ -539,7 +539,7 @@ async fn test_vcf_count_star_bug() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .value(0);
 
-    println!("COUNT(*) result: {}", count_star);
+    println!("COUNT(*) result: {count_star}");
 
     // Test COUNT(chrom) - this should work
     println!("Testing COUNT(chrom)...");
@@ -557,15 +557,14 @@ async fn test_vcf_count_star_bug() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .value(0);
 
-    println!("COUNT(chrom) result: {}", count_chrom);
+    println!("COUNT(chrom) result: {count_chrom}");
 
     // They should be equal
     assert_eq!(
         count_star, count_chrom,
-        "COUNT(*) should equal COUNT(chrom) but got {} vs {}",
-        count_star, count_chrom
+        "COUNT(*) should equal COUNT(chrom) but got {count_star} vs {count_chrom}"
     );
-    assert_eq!(count_star, 3, "COUNT(*) should be 3 but got {}", count_star);
+    assert_eq!(count_star, 3, "COUNT(*) should be 3 but got {count_star}");
 
     Ok(())
 }

--- a/datafusion/bio-format-vcf/tests/write_test.rs
+++ b/datafusion/bio-format-vcf/tests/write_test.rs
@@ -35,7 +35,7 @@ chr1	200	rs2	G	C	40	PASS	DP=60
 "#;
 
 async fn create_test_vcf(name: &str, content: &str) -> std::io::Result<String> {
-    let path = format!("/tmp/test_write_{}.vcf", name);
+    let path = format!("/tmp/test_write_{name}.vcf");
     fs::write(&path, content).await?;
     Ok(path)
 }
@@ -149,8 +149,7 @@ async fn test_write_vcf_preserves_info_description() {
     let content = fs::read_to_string(output_path).await.unwrap();
     assert!(
         content.contains("Description=\"Read Depth\""),
-        "Output should preserve original INFO description. Got: {}",
-        content
+        "Output should preserve original INFO description. Got: {content}"
     );
 
     cleanup_files(&[&input_path, output_path]).await;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = ["rustfmt"]


### PR DESCRIPTION
## Summary
- Bumps DataFusion from 50.3.0 to 52.1.0 (Arrow 56.x → 57.x)
- Disables DataFusion's `compression` feature to resolve native library linking conflict between `liblzma-sys` (DF 52) and `lzma-sys` (noodles-cram's `xz2`) — both link to `"lzma"`
- Bumps Rust toolchain to 1.88.0 (required by DF 52.1.0)
- Updates `async-compression` to 0.4.35
- Fixes new clippy lints from Rust 1.88 (`uninlined_format_args`, `large_enum_variant`)

## Motivation
Required for polars-bio ecosystem sync — `datafusion-bio-functions` depends on this crate and needs DF 52.1.0.

## Test plan
- [x] `cargo build` — clean compile
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass
- [x] `cargo fmt -- --check` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)