### PR TITLE
fix: Update noodles rev to use lzma-rust2 instead of xz2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,30 +568,11 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
-dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -972,11 +953,11 @@ dependencies = [
  "futures-util",
  "hex",
  "log",
- "noodles-bam 0.82.0",
- "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
+ "noodles-bam",
+ "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-sam",
  "opendal",
  "serde",
  "serde_json",
@@ -1000,7 +981,6 @@ dependencies = [
  "futures",
  "futures-util",
  "log",
- "noodles 0.93.0",
  "noodles-bed",
  "noodles-bgzf 0.36.0",
  "opendal",
@@ -1018,10 +998,9 @@ dependencies = [
  "datafusion-execution",
  "futures",
  "log",
- "noodles 0.93.0",
  "noodles-bgzf 0.36.0",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-sam",
  "opendal",
  "serde",
  "serde_json",
@@ -1046,10 +1025,10 @@ dependencies = [
  "hex",
  "log",
  "noodles-bgzf 0.36.0",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-cram 0.85.0",
- "noodles-fasta 0.55.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-cram",
+ "noodles-fasta 0.55.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-sam",
  "opendal",
  "serde",
  "serde_json",
@@ -1071,7 +1050,6 @@ dependencies = [
  "futures",
  "futures-util",
  "log",
- "noodles 0.93.0",
  "noodles-bgzf 0.36.0",
  "noodles-fasta 0.55.0 (git+https://github.com/biodatageeks/noodles.git?rev=289ef32e7d43d142914fb3f02335044ae293871c)",
  "opendal",
@@ -1093,9 +1071,8 @@ dependencies = [
  "futures",
  "futures-util",
  "log",
- "noodles 0.93.0",
  "noodles-bgzf 0.36.0",
- "noodles-fastq 0.19.0",
+ "noodles-fastq",
  "opendal",
  "tempfile",
  "tokio",
@@ -1119,12 +1096,11 @@ dependencies = [
  "futures",
  "futures-util",
  "log",
- "noodles 0.93.0",
  "noodles-bgzf 0.36.0",
  "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
- "noodles-gff 0.51.0",
+ "noodles-gff",
  "noodles-tabix 0.56.0",
  "opendal",
  "tokio",
@@ -1174,13 +1150,13 @@ dependencies = [
  "flate2",
  "futures",
  "log",
- "noodles 0.100.0",
+ "noodles",
  "noodles-bgzf 0.36.0",
  "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-tabix 0.56.0",
- "noodles-vcf 0.80.0",
+ "noodles-vcf",
  "opendal",
  "serde_json",
  "tempfile",
@@ -2772,14 +2748,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-sys"
-version = "0.1.20"
+name = "lzma-rust2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "sha2",
 ]
 
 [[package]]
@@ -2853,82 +2827,26 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74eea88cacba7e16cb6aff1bc3e077f3f9e036e59b9107a8415bf9242d0c2d97"
-dependencies = [
- "noodles-bam 0.76.0",
- "noodles-bcf",
- "noodles-bgzf 0.36.0",
- "noodles-cram 0.79.0",
- "noodles-csi 0.44.0",
- "noodles-fasta 0.49.0",
- "noodles-fastq 0.17.0",
- "noodles-gff 0.44.0",
- "noodles-sam 0.72.0",
- "noodles-tabix 0.50.0",
- "noodles-vcf 0.74.0",
-]
-
-[[package]]
-name = "noodles"
 version = "0.100.0"
 source = "git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c#9b7b2c5b6531373918302d4c07410e583f1b5b5c"
 dependencies = [
  "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
- "noodles-vcf 0.80.0",
-]
-
-[[package]]
-name = "noodles-bam"
-version = "0.76.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac61d405ab62bd0a01956a2b1d83a7d5ce8b207ca0caf91e2b3472037f8eac8"
-dependencies = [
- "bstr",
- "byteorder",
- "futures",
- "indexmap",
- "memchr",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "noodles-csi 0.44.0",
- "noodles-sam 0.72.0",
- "pin-project-lite",
- "tokio",
+ "noodles-vcf",
 ]
 
 [[package]]
 name = "noodles-bam"
 version = "0.82.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bstr",
  "futures",
  "indexmap",
  "memchr",
- "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "noodles-bcf"
-version = "0.71.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76d44299bdc4c950dcbbfeb87b99e79de9c4082f51d892a6d7aa194fba27613"
-dependencies = [
- "byteorder",
- "futures",
- "indexmap",
- "memchr",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "noodles-csi 0.44.0",
- "noodles-vcf 0.74.0",
+ "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-sam",
  "pin-project-lite",
  "tokio",
 ]
@@ -3005,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "noodles-bgzf"
 version = "0.42.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -3015,15 +2933,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "noodles-core"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962b13b79312f773a12ffcb0cdaccab6327f8343b6f440a888eff10c749d52b0"
-dependencies = [
- "bstr",
 ]
 
 [[package]]
@@ -3054,69 +2963,30 @@ dependencies = [
 [[package]]
 name = "noodles-core"
 version = "0.18.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bstr",
-]
-
-[[package]]
-name = "noodles-cram"
-version = "0.79.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75663c2a0d6f0142581f810702add845d99b89dea2e3b8b472f7a18b7ffc2c3"
-dependencies = [
- "async-compression",
- "bitflags",
- "bstr",
- "byteorder",
- "bzip2 0.5.2",
- "flate2",
- "futures",
- "indexmap",
- "md-5",
- "noodles-bam 0.76.0",
- "noodles-core 0.16.0",
- "noodles-fasta 0.49.0",
- "noodles-sam 0.72.0",
- "pin-project-lite",
- "tokio",
- "xz2",
 ]
 
 [[package]]
 name = "noodles-cram"
 version = "0.85.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "async-compression",
  "bitflags",
  "bstr",
- "bzip2 0.6.1",
+ "bzip2",
  "flate2",
  "futures",
  "indexmap",
+ "lzma-rust2",
  "md-5",
- "noodles-bam 0.82.0",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-fasta 0.55.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
+ "noodles-bam",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-fasta 0.55.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-sam",
  "pin-project-lite",
- "tokio",
- "xz2",
-]
-
-[[package]]
-name = "noodles-csi"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b402963653cacd5df474889a1cfb969e2f66469023836ad3b0a2c75e2b4e7c"
-dependencies = [
- "bit-vec",
- "bstr",
- "byteorder",
- "indexmap",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
  "tokio",
 ]
 
@@ -3149,27 +3019,13 @@ dependencies = [
 [[package]]
 name = "noodles-csi"
 version = "0.50.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bit-vec",
  "bstr",
  "indexmap",
- "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
-]
-
-[[package]]
-name = "noodles-fasta"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd5e79e45ac2ab99e912b59a1f3dd1efcbe3ef419bf0e6fcc8eec9b425a1c1f"
-dependencies = [
- "bstr",
- "bytes",
- "memchr",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "tokio",
+ "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
 ]
 
 [[package]]
@@ -3189,26 +3045,14 @@ dependencies = [
 [[package]]
 name = "noodles-fasta"
 version = "0.55.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bstr",
  "bytes",
  "futures",
  "memchr",
- "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "tokio",
-]
-
-[[package]]
-name = "noodles-fastq"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb444bbacd329b4d867086de4bcf159e80a19f9832c9ea04aa0f5867cb77255c"
-dependencies = [
- "bstr",
- "futures",
- "memchr",
+ "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
  "tokio",
 ]
 
@@ -3221,21 +3065,6 @@ dependencies = [
  "bstr",
  "futures",
  "memchr",
- "tokio",
-]
-
-[[package]]
-name = "noodles-gff"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff9038cf76a843a570683b28bd500c3994d491f6452cdfb9a45ec38892d16564"
-dependencies = [
- "futures",
- "indexmap",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "noodles-csi 0.44.0",
- "percent-encoding",
  "tokio",
 ]
 
@@ -3259,50 +3088,17 @@ dependencies = [
 
 [[package]]
 name = "noodles-sam"
-version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7f543ae568acd97307c261fe9b34225af2e625a74d077e992ca8b37afae793"
-dependencies = [
- "bitflags",
- "bstr",
- "futures",
- "indexmap",
- "lexical-core",
- "memchr",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "noodles-csi 0.44.0",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "noodles-sam"
 version = "0.78.0"
-source = "git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b#da905fff4909ada93e407c780456332fe113858b"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bitflags",
  "bstr",
  "indexmap",
  "lexical-core",
  "memchr",
- "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
-]
-
-[[package]]
-name = "noodles-tabix"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46ee069d57770840554e3d8bd02e7415b3a2d972cdea7525bea02472032c234"
-dependencies = [
- "byteorder",
- "indexmap",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "noodles-csi 0.44.0",
- "tokio",
+ "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+ "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
 ]
 
 [[package]]
@@ -3328,24 +3124,6 @@ dependencies = [
  "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
- "tokio",
-]
-
-[[package]]
-name = "noodles-vcf"
-version = "0.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d68867aeaeda06d1149c85b4ebbefc45d31786f41b34868195ccd9dad7db532"
-dependencies = [
- "futures",
- "indexmap",
- "memchr",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.16.0",
- "noodles-csi 0.44.0",
- "noodles-tabix 0.50.0",
- "percent-encoding",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -5626,15 +5404,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,10 @@ datafusion = { version = "52.1.0", default-features = false, features = [
 datafusion-execution = "52.1.0"
 async-trait = "0.1.85"
 opendal = { version = "0.53.3", features = ["services-gcs", "services-s3","layers-blocking", "services-azblob", "services-http"] }
-noodles = { version = "0.93.0",  features = ["bam", "vcf", "bgzf", "cram", "async"]}
-
-noodles-bgzf = { version = "0.36.0",features = ["libdeflate"] }
-noodles-cram  = { git = "https://github.com/biodatageeks/noodles.git",rev = "da905fff4909ada93e407c780456332fe113858b", features = ["async"] }
-noodles-sam = { git = "https://github.com/biodatageeks/noodles.git",rev = "da905fff4909ada93e407c780456332fe113858b" }
-noodles-fasta = { git = "https://github.com/biodatageeks/noodles.git",rev = "da905fff4909ada93e407c780456332fe113858b", features = ["async"] }
+noodles-bgzf = { version = "0.36.0",features = ["libdeflate", "async"] }
+noodles-cram  = { git = "https://github.com/biodatageeks/noodles.git",rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db", features = ["async"] }
+noodles-sam = { git = "https://github.com/biodatageeks/noodles.git",rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db" }
+noodles-fasta = { git = "https://github.com/biodatageeks/noodles.git",rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db", features = ["async"] }
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "rt", "macros"] }
 tokio-util = {  version="0.7.13", features = ["io-util", "compat"] }
 bytes = "1.10.0"

--- a/datafusion/bio-format-bam/Cargo.toml
+++ b/datafusion/bio-format-bam/Cargo.toml
@@ -12,14 +12,14 @@ readme = "README.md"
 [dependencies]
 datafusion.workspace = true
 opendal.workspace = true
-noodles-bgzf = { git = "https://github.com/biodatageeks/noodles.git", rev = "da905fff4909ada93e407c780456332fe113858b", features = ["libdeflate"] }
+noodles-bgzf = { git = "https://github.com/biodatageeks/noodles.git", rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db", features = ["libdeflate"] }
 tokio-util.workspace = true
 tokio.workspace = true
 bytes.workspace = true
 datafusion-bio-format-core = {path = "../bio-format-core"}
 futures.workspace = true
 futures-util.workspace = true
-noodles-bam = { git = "https://github.com/biodatageeks/noodles.git", rev = "da905fff4909ada93e407c780456332fe113858b", features = ["async"] }
+noodles-bam = { git = "https://github.com/biodatageeks/noodles.git", rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db", features = ["async"] }
 noodles-sam.workspace = true
 async-stream = "0.3.6"
 log = "0.4.27"
@@ -27,8 +27,8 @@ async-trait = "0.1.88"
 hex = "0.4"
 serde.workspace = true
 serde_json.workspace = true
-noodles-core = { git = "https://github.com/biodatageeks/noodles.git", rev = "da905fff4909ada93e407c780456332fe113858b" }
-noodles-csi = { git = "https://github.com/biodatageeks/noodles.git", rev = "da905fff4909ada93e407c780456332fe113858b" }
+noodles-core = { git = "https://github.com/biodatageeks/noodles.git", rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db" }
+noodles-csi = { git = "https://github.com/biodatageeks/noodles.git", rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db" }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/datafusion/bio-format-bed/Cargo.toml
+++ b/datafusion/bio-format-bed/Cargo.toml
@@ -14,7 +14,6 @@ datafusion.workspace = true
 datafusion-execution.workspace = true
 async-trait.workspace = true
 opendal.workspace = true
-noodles.workspace = true
 noodles-bgzf.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/datafusion/bio-format-bed/src/storage.rs
+++ b/datafusion/bio-format-bed/src/storage.rs
@@ -9,9 +9,9 @@ use datafusion_bio_format_core::object_storage::{
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use log::{debug, error, info};
-use noodles_bgzf as bgzf;
 use noodles_bed;
 use noodles_bed::Record;
+use noodles_bgzf as bgzf;
 use noodles_bgzf::Reader as BgzfReader;
 use opendal::FuturesBytesStream;
 use std::fs::File;

--- a/datafusion/bio-format-bed/src/storage.rs
+++ b/datafusion/bio-format-bed/src/storage.rs
@@ -9,7 +9,7 @@ use datafusion_bio_format_core::object_storage::{
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use log::{debug, error, info};
-use noodles::bgzf;
+use noodles_bgzf as bgzf;
 use noodles_bed;
 use noodles_bed::Record;
 use noodles_bgzf::Reader as BgzfReader;

--- a/datafusion/bio-format-core/Cargo.toml
+++ b/datafusion/bio-format-core/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 datafusion-execution.workspace = true
 datafusion.workspace = true
 opendal.workspace = true
-noodles.workspace = true
 noodles-bgzf.workspace = true
 noodles-sam.workspace = true
 tokio-util.workspace = true
@@ -28,4 +27,4 @@ serde_json.workspace = true
 
 [dev-dependencies]
 tempfile = "3.10.1"
-noodles-core = { git = "https://github.com/biodatageeks/noodles.git", rev = "da905fff4909ada93e407c780456332fe113858b" }
+noodles-core = { git = "https://github.com/biodatageeks/noodles.git", rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db" }

--- a/datafusion/bio-format-core/src/object_storage.rs
+++ b/datafusion/bio-format-core/src/object_storage.rs
@@ -2,7 +2,7 @@ use async_compression::tokio::bufread::GzipDecoder;
 use futures::StreamExt;
 use log;
 use log::debug;
-use noodles::bgzf;
+use noodles_bgzf as bgzf;
 use noodles_bgzf::AsyncReader;
 use opendal::layers::{LoggingLayer, RetryLayer, TimeoutLayer};
 use opendal::services::{Azblob, Gcs, S3};

--- a/datafusion/bio-format-cram/Cargo.toml
+++ b/datafusion/bio-format-cram/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1.88"
 hex = "0.4"
 serde.workspace = true
 serde_json.workspace = true
-noodles-core = { git = "https://github.com/biodatageeks/noodles.git", rev = "da905fff4909ada93e407c780456332fe113858b" }
+noodles-core = { git = "https://github.com/biodatageeks/noodles.git", rev = "e2b53501afd9d327735355db68dfb33d3e6ce9db" }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/datafusion/bio-format-fasta/Cargo.toml
+++ b/datafusion/bio-format-fasta/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 [dependencies]
 datafusion.workspace = true
 opendal.workspace = true
-noodles.workspace = true
 noodles-bgzf.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/datafusion/bio-format-fasta/src/storage.rs
+++ b/datafusion/bio-format-fasta/src/storage.rs
@@ -6,7 +6,7 @@ use datafusion_bio_format_core::object_storage::{
 };
 use futures_util::stream::BoxStream;
 use futures_util::{StreamExt, stream};
-use noodles::bgzf;
+use noodles_bgzf as bgzf;
 use noodles_fasta as fasta;
 use noodles_fasta::Record;
 use noodles_fasta::io::Reader;

--- a/datafusion/bio-format-fastq/Cargo.toml
+++ b/datafusion/bio-format-fastq/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 [dependencies]
 datafusion.workspace = true
 opendal.workspace = true
-noodles.workspace = true
 noodles-bgzf.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/datafusion/bio-format-fastq/src/storage.rs
+++ b/datafusion/bio-format-fastq/src/storage.rs
@@ -12,7 +12,7 @@ use datafusion_bio_format_core::object_storage::{
 };
 use futures_util::stream::BoxStream;
 use futures_util::{StreamExt, stream};
-use noodles::bgzf;
+use noodles_bgzf as bgzf;
 use noodles_fastq as fastq;
 use noodles_fastq::Record;
 use noodles_fastq::io::Reader;

--- a/datafusion/bio-format-gff/Cargo.toml
+++ b/datafusion/bio-format-gff/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 datafusion.workspace = true
 opendal.workspace = true
 tokio-util.workspace = true
-noodles = { workspace = true }
 noodles-bgzf.workspace = true
 tokio.workspace = true
 bytes.workspace = true

--- a/datafusion/bio-format-gff/src/storage.rs
+++ b/datafusion/bio-format-gff/src/storage.rs
@@ -6,7 +6,7 @@ use datafusion_bio_format_core::object_storage::{
 };
 use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
-use noodles::bgzf;
+use noodles_bgzf as bgzf;
 use noodles_gff as gff;
 use noodles_gff::feature::RecordBuf;
 use noodles_gff::feature::record_buf::Attributes;


### PR DESCRIPTION
## Summary
- Update noodles git rev to use `lzma-rust2` (pure Rust) instead of `xz2` (`lzma-sys`, native library)
- Resolves the `lzma-sys` vs `liblzma-sys` `links="lzma"` conflict when used with DataFusion 52.x + `datafusion-python`

## Context
`datafusion-python` enables the `avro` feature on DataFusion, which pulls in `apache-avro` → `liblzma` → `liblzma-sys` (declares `links="lzma"`). The previous noodles-cram used `xz2` → `lzma-sys` (also `links="lzma"`), causing a Cargo resolver conflict.

Depends on: https://github.com/biodatageeks/noodles/pull/1

## Test plan
- [x] `cargo check -p datafusion-bio-format-cram` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)