### PR TITLE
fix: replicate VEP merge_features HGNC_ID propagation in cache builder

### DIFF
--- a/datafusion/bio-format-ensembl-cache/examples/storable_to_parquet.rs
+++ b/datafusion/bio-format-ensembl-cache/examples/storable_to_parquet.rs
@@ -109,7 +109,8 @@ fn build_dedup_query(
                         "COALESCE(gene_hgnc_id, \
                              CASE WHEN gene_symbol IS NOT NULL \
                                   THEN FIRST_VALUE(gene_hgnc_id) IGNORE NULLS \
-                                       OVER (PARTITION BY gene_symbol) \
+                                       OVER (PARTITION BY gene_symbol \
+                                             ORDER BY gene_hgnc_id NULLS LAST) \
                                   ELSE NULL END) AS gene_hgnc_id"
                             .to_string()
                     } else {

--- a/datafusion/bio-format-ensembl-cache/tests/hgnc_propagation_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/hgnc_propagation_tests.rs
@@ -49,7 +49,8 @@ async fn run_propagation(
                COALESCE(gene_hgnc_id, \
                     CASE WHEN gene_symbol IS NOT NULL \
                          THEN FIRST_VALUE(gene_hgnc_id) IGNORE NULLS \
-                              OVER (PARTITION BY gene_symbol) \
+                              OVER (PARTITION BY gene_symbol \
+                                             ORDER BY gene_hgnc_id NULLS LAST) \
                          ELSE NULL END) AS gene_hgnc_id \
         FROM tx \
         ORDER BY stable_id";

--- a/datafusion/bio-format-ensembl-cache/tests/real_vep_cache_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/real_vep_cache_tests.rs
@@ -1136,7 +1136,8 @@ async fn hgnc_propagation_fills_all_siblings() -> datafusion::common::Result<()>
                 "COALESCE(gene_hgnc_id, \
                      CASE WHEN gene_symbol IS NOT NULL \
                           THEN FIRST_VALUE(gene_hgnc_id) IGNORE NULLS \
-                               OVER (PARTITION BY gene_symbol) \
+                               OVER (PARTITION BY gene_symbol \
+                                             ORDER BY gene_hgnc_id NULLS LAST) \
                           ELSE NULL END) AS gene_hgnc_id"
                     .to_string()
             } else {


### PR DESCRIPTION
## Summary

- Replicate VEP's `merge_features()` HGNC_ID propagation in the Parquet cache builder (`storable_to_parquet`)
- Uses `COALESCE + FIRST_VALUE IGNORE NULLS OVER (PARTITION BY gene_symbol)` window function in the transcript dedup query
- Closes **82 HGNC_ID gaps** across 7 gene symbols genome-wide (e.g., FGF7P3 30/46 missing, GUSBP5 39/76 missing)
- Guards against cross-pollination for NULL gene_symbol transcripts

Resolves biodatageeks/datafusion-bio-functions#105

## Changes

- `storable_to_parquet.rs`: Modified `build_dedup_query()` to build an explicit column list for transcripts, replacing `gene_hgnc_id` with the propagation expression
- `hgnc_propagation_tests.rs`: **6 new unit tests** using synthetic MemTable data covering: basic propagation, no-overwrite, NULL symbol, all-NULL HGNC, multiple symbols, mixed scenario
- `real_vep_cache_tests.rs`: **1 new integration test** against real VEP 115 chr22 fixture verifying zero remaining gaps after propagation

## Performance

The window function adds one hash partition over `gene_symbol` (~20K distinct values). On ~3M transcript rows this is negligible (+1-2s) compared to the existing ROW_NUMBER window + ORDER BY + Parquet write.

## Test plan

- [x] All 6 synthetic HGNC propagation tests pass
- [x] Real-data test (`hgnc_propagation_fills_all_siblings`) passes on chr22 fixture
- [x] All 29 existing ensembl-cache tests pass (no regressions)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [ ] Rebuild chr9 parquet and verify FGF7P3 all 46 transcripts have HGNC:26671

🤖 Generated with [Claude Code](https://claude.com/claude-code)