### PR TITLE
fix: stop export-time HGNC propagation, add gene_hgnc_id_native column

### DIFF
--- a/datafusion/bio-format-ensembl-cache/README.md
+++ b/datafusion/bio-format-ensembl-cache/README.md
@@ -172,8 +172,10 @@ Standalone translation table — one row per coding transcript.
 | `cdna_coding_start` | Int64 | yes | cDNA coding start offset |
 | `cdna_coding_end` | Int64 | yes | cDNA coding end offset |
 | `cds_len` | Int64 | yes | CDS length (derived: `cdna_coding_end - cdna_coding_start + 1`) |
-| `translation_seq` | Utf8 | yes | Protein/peptide sequence |
-| `cds_sequence` | Utf8 | yes | Translatable CDS nucleotide sequence |
+| `translation_seq` | Utf8 | yes | Protein/peptide sequence (BAM-edited for RefSeq transcripts with `bam_edit_status=ok`; sourced from `_variation_effect_feature_cache.peptide`) |
+| `cds_sequence` | Utf8 | yes | Translatable CDS nucleotide sequence (BAM-edited counterpart; sourced from `_variation_effect_feature_cache.translateable_seq`) |
+| `translation_seq_canonical` | Utf8 | yes | Canonical (pre-BAM-edit) protein sequence sourced from `translation.primary_seq`. Falls back to `translation_seq` when the canonical field is absent. Use this for HGVSp-style consumers that need parity with VEP. |
+| `cds_sequence_canonical` | Utf8 | yes | Canonical (pre-BAM-edit) CDS sourced from the transcript-level `translateable_seq`. Falls back to `cds_sequence` when absent. |
 | `protein_features` | `List<Struct<analysis:Utf8, hseqname:Utf8, start:Int64, end:Int64>>` | yes | Protein domain/feature annotations (see below) |
 | `sift_predictions` | `List<Struct<position:Int32, amino_acid:Utf8, prediction:Utf8, score:Float32>>` | yes | SIFT pathogenicity predictions (see below) |
 | `polyphen_predictions` | `List<Struct<position:Int32, amino_acid:Utf8, prediction:Utf8, score:Float32>>` | yes | PolyPhen-2 pathogenicity predictions (see below) |
@@ -300,6 +302,7 @@ All entity schemas also include **provenance columns**: `species`, `assembly`, `
 Transcript, exon, and translation schemas support projection pushdown. When VEP-related
 columns (e.g. `exons`, `cdna_seq`, `peptide_seq`, `mature_mirna_regions`,
 `cdna_mapper_segments`, `spliced_seq`, `translation_seq`, `cds_sequence`,
+`translation_seq_canonical`, `cds_sequence_canonical`,
 `protein_features`, `sift_predictions`, `polyphen_predictions`) are not
 selected in a query, the parser skips extracting those fields, significantly
 reducing parse overhead.

--- a/datafusion/bio-format-ensembl-cache/README.md
+++ b/datafusion/bio-format-ensembl-cache/README.md
@@ -98,7 +98,8 @@ of transcripts that would otherwise have no exon entries.
 | `gene_stable_id` | Utf8 | yes | Parent gene ID (ENSG...) |
 | `gene_symbol` | Utf8 | yes | Gene symbol (e.g. BRCA1) |
 | `gene_symbol_source` | Utf8 | yes | Gene symbol source (e.g. HGNC) |
-| `gene_hgnc_id` | Utf8 | yes | HGNC ID |
+| `gene_hgnc_id` | Utf8 | yes | HGNC ID (native value from raw VEP object, no propagation) |
+| `gene_hgnc_id_native` | Utf8 | yes | Native HGNC ID parsed directly from raw VEP object (identical to `gene_hgnc_id`; provided for downstream consumers that need an explicit native-provenance column) |
 | `refseq_id` | Utf8 | yes | RefSeq transcript ID |
 | `cds_start` | Int64 | yes | CDS genomic start |
 | `cds_end` | Int64 | yes | CDS genomic end |

--- a/datafusion/bio-format-ensembl-cache/README.md
+++ b/datafusion/bio-format-ensembl-cache/README.md
@@ -98,8 +98,8 @@ of transcripts that would otherwise have no exon entries.
 | `gene_stable_id` | Utf8 | yes | Parent gene ID (ENSG...) |
 | `gene_symbol` | Utf8 | yes | Gene symbol (e.g. BRCA1) |
 | `gene_symbol_source` | Utf8 | yes | Gene symbol source (e.g. HGNC) |
-| `gene_hgnc_id` | Utf8 | yes | HGNC ID (native value from raw VEP object, no propagation) |
-| `gene_hgnc_id_native` | Utf8 | yes | Native HGNC ID parsed directly from raw VEP object (identical to `gene_hgnc_id`; provided for downstream consumers that need an explicit native-provenance column) |
+| `gene_hgnc_id` | Utf8 | yes | HGNC ID parsed from the raw VEP object, with no export-time propagation/backfill |
+| `gene_hgnc_id_native` | Utf8 | yes | Stable copy of the native raw-object HGNC ID. In exported cache files it is identical to `gene_hgnc_id`; downstream annotation engines can preserve it if they later overwrite `gene_hgnc_id` |
 | `refseq_id` | Utf8 | yes | RefSeq transcript ID |
 | `cds_start` | Int64 | yes | CDS genomic start |
 | `cds_end` | Int64 | yes | CDS genomic end |
@@ -174,8 +174,8 @@ Standalone translation table — one row per coding transcript.
 | `cds_len` | Int64 | yes | CDS length (derived: `cdna_coding_end - cdna_coding_start + 1`) |
 | `translation_seq` | Utf8 | yes | Protein/peptide sequence (BAM-edited for RefSeq transcripts with `bam_edit_status=ok`; sourced from `_variation_effect_feature_cache.peptide`) |
 | `cds_sequence` | Utf8 | yes | Translatable CDS nucleotide sequence (BAM-edited counterpart; sourced from `_variation_effect_feature_cache.translateable_seq`) |
-| `translation_seq_canonical` | Utf8 | yes | Canonical (pre-BAM-edit) protein sequence sourced from `translation.primary_seq`. Falls back to `translation_seq` when the canonical field is absent. Use this for HGVSp-style consumers that need parity with VEP. |
-| `cds_sequence_canonical` | Utf8 | yes | Canonical (pre-BAM-edit) CDS sourced from the transcript-level `translateable_seq`. Falls back to `cds_sequence` when absent. |
+| `translation_seq_canonical` | Utf8 | yes | Canonical (pre-BAM-edit) protein sequence reconstructed by reversing `_rna_edit` insertions on the edited CDS and retranslating. If reversal fails, this column falls back to the BAM-edited `translation_seq` so HGVSp-style consumers still have a peptide string |
+| `cds_sequence_canonical` | Utf8 | yes | Canonical (pre-BAM-edit) CDS reconstructed by reversing `_rna_edit` insertions on the edited CDS. Left NULL when the edits are missing or cannot be reversed cleanly |
 | `protein_features` | `List<Struct<analysis:Utf8, hseqname:Utf8, start:Int64, end:Int64>>` | yes | Protein domain/feature annotations (see below) |
 | `sift_predictions` | `List<Struct<position:Int32, amino_acid:Utf8, prediction:Utf8, score:Float32>>` | yes | SIFT pathogenicity predictions (see below) |
 | `polyphen_predictions` | `List<Struct<position:Int32, amino_acid:Utf8, prediction:Utf8, score:Float32>>` | yes | PolyPhen-2 pathogenicity predictions (see below) |

--- a/datafusion/bio-format-ensembl-cache/src/export_query.rs
+++ b/datafusion/bio-format-ensembl-cache/src/export_query.rs
@@ -1,10 +1,11 @@
 use crate::entity::EnsemblEntityKind;
 use datafusion::arrow::datatypes::Schema;
 
-/// VEP cache region size used for region-local feature merging.
+/// VEP cache region size used for source-file preference during deduplication.
 ///
-/// Ensembl VEP loads transcript features in 1 Mb cache regions. The transcript
-/// export query mirrors that locality when propagating `gene_hgnc_id`.
+/// Ensembl VEP stores transcript features in 1 Mb cache regions. The export
+/// query uses this to prefer the copy from the region containing the transcript
+/// start when deduplicating cross-boundary entries.
 pub const VEP_CACHE_REGION_SIZE_BP: i64 = 1_000_000;
 
 fn transcript_region_start_expr(start_col: &str) -> String {
@@ -22,24 +23,10 @@ fn source_region_preference_expr(start_col: &str, source_file_col: &str) -> Stri
 }
 
 fn transcript_select_list(schema: &Schema) -> String {
-    let region_expr = format!("CAST(FLOOR((start - 1) / {VEP_CACHE_REGION_SIZE_BP}.0) AS BIGINT)");
     schema
         .fields()
         .iter()
-        .map(|f| {
-            if f.name() == "gene_hgnc_id" {
-                format!(
-                    "COALESCE(gene_hgnc_id, \
-                         CASE WHEN gene_symbol IS NOT NULL \
-                              THEN FIRST_VALUE(gene_hgnc_id) IGNORE NULLS \
-                                   OVER (PARTITION BY chrom, gene_symbol, {region_expr} \
-                                         ORDER BY gene_hgnc_id NULLS LAST) \
-                              ELSE NULL END) AS gene_hgnc_id"
-                )
-            } else {
-                format!("\"{}\"", f.name())
-            }
-        })
+        .map(|f| format!("\"{}\"", f.name()))
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -154,8 +141,8 @@ pub fn build_translation_dedup_query_multi_chrom(table_name: &str, chroms: &[&st
 #[cfg(test)]
 mod tests {
     use super::{
-        VEP_CACHE_REGION_SIZE_BP, build_export_query, build_export_query_multi_chrom,
-        build_translation_dedup_query, build_translation_dedup_query_multi_chrom,
+        build_export_query, build_export_query_multi_chrom, build_translation_dedup_query,
+        build_translation_dedup_query_multi_chrom,
     };
     use crate::entity::EnsemblEntityKind;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -169,6 +156,7 @@ mod tests {
             Field::new("cds_start", DataType::Int64, true),
             Field::new("gene_symbol", DataType::Utf8, true),
             Field::new("gene_hgnc_id", DataType::Utf8, true),
+            Field::new("gene_hgnc_id_native", DataType::Utf8, true),
         ])
     }
 
@@ -205,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn build_export_query_transcript_hgnc_propagation_is_local() {
+    fn build_export_query_transcript_no_hgnc_propagation() {
         let schema = test_transcript_schema();
         let q = build_export_query(
             EnsemblEntityKind::Transcript,
@@ -213,12 +201,19 @@ mod tests {
             Some("9"),
             Some(&schema),
         );
-        assert!(q.contains("COALESCE(gene_hgnc_id"));
-        assert!(q.contains("FIRST_VALUE(gene_hgnc_id) IGNORE NULLS"));
-        assert!(q.contains("PARTITION BY chrom, gene_symbol"));
-        assert!(q.contains(&format!(
-            "CAST(FLOOR((start - 1) / {VEP_CACHE_REGION_SIZE_BP}.0) AS BIGINT)"
-        )));
+        // gene_hgnc_id should pass through without propagation
+        assert!(
+            !q.contains("COALESCE(gene_hgnc_id"),
+            "gene_hgnc_id should not be propagated"
+        );
+        assert!(
+            !q.contains("FIRST_VALUE(gene_hgnc_id)"),
+            "no window-based HGNC fill"
+        );
+        // Both columns should appear as plain quoted names
+        assert!(q.contains("\"gene_hgnc_id\""));
+        assert!(q.contains("\"gene_hgnc_id_native\""));
+        // Still uses explicit column list (not SELECT *)
         assert!(!q.starts_with("SELECT *"));
     }
 
@@ -253,7 +248,7 @@ mod tests {
         assert!(q.contains("WHERE chrom IN ('1', '2')"));
         assert!(q.contains("ROW_NUMBER()"));
         assert!(q.contains("WHERE _rn = 1"));
-        assert!(q.contains("PARTITION BY chrom, gene_symbol"));
+        assert!(q.contains("PARTITION BY stable_id"));
         assert!(q.contains("source_file LIKE CONCAT('%/'"));
     }
 

--- a/datafusion/bio-format-ensembl-cache/src/schema.rs
+++ b/datafusion/bio-format-ensembl-cache/src/schema.rs
@@ -167,6 +167,7 @@ pub(crate) fn transcript_schema(
         Field::new("gene_symbol", DataType::Utf8, true),
         Field::new("gene_symbol_source", DataType::Utf8, true),
         Field::new("gene_hgnc_id", DataType::Utf8, true),
+        Field::new("gene_hgnc_id_native", DataType::Utf8, true),
         Field::new("refseq_id", DataType::Utf8, true),
         Field::new("cds_start", DataType::Int64, true),
         Field::new("cds_end", DataType::Int64, true),

--- a/datafusion/bio-format-ensembl-cache/src/schema.rs
+++ b/datafusion/bio-format-ensembl-cache/src/schema.rs
@@ -198,6 +198,8 @@ pub(crate) fn transcript_schema(
         Field::new("ncrna_structure", DataType::Utf8, true),
         // Promoted VEP fields (issue #125)
         Field::new("translateable_seq", DataType::Utf8, true),
+        Field::new("three_prime_utr_seq", DataType::Utf8, true),
+        Field::new("five_prime_utr_seq", DataType::Utf8, true),
         Field::new(
             "cdna_mapper_segments",
             cdna_mapper_segment_list_data_type(),
@@ -531,6 +533,9 @@ mod tests {
         assert!(schema.column_with_name("gene_stable_id").is_some());
         assert!(schema.column_with_name("exons").is_some());
         assert!(schema.column_with_name("cdna_seq").is_some());
+        assert!(schema.column_with_name("translateable_seq").is_some());
+        assert!(schema.column_with_name("three_prime_utr_seq").is_some());
+        assert!(schema.column_with_name("five_prime_utr_seq").is_some());
         assert!(schema.column_with_name("tsl").is_some());
         assert!(schema.column_with_name("mane_select").is_some());
         assert!(schema.column_with_name("raw_object_json").is_some());

--- a/datafusion/bio-format-ensembl-cache/src/schema.rs
+++ b/datafusion/bio-format-ensembl-cache/src/schema.rs
@@ -303,6 +303,8 @@ pub(crate) fn translation_schema(
         Field::new("cds_len", DataType::Int64, true),
         Field::new("translation_seq", DataType::Utf8, true),
         Field::new("cds_sequence", DataType::Utf8, true),
+        Field::new("translation_seq_canonical", DataType::Utf8, true),
+        Field::new("cds_sequence_canonical", DataType::Utf8, true),
         Field::new("protein_features", protein_feature_list_data_type(), true),
         Field::new("sift_predictions", prediction_list_data_type(), true),
         Field::new("polyphen_predictions", prediction_list_data_type(), true),
@@ -324,6 +326,8 @@ pub fn translation_core_schema(coordinate_system_zero_based: bool) -> SchemaRef 
         Field::new("protein_len", DataType::Int64, true),
         Field::new("translation_seq", DataType::Utf8, true),
         Field::new("cds_sequence", DataType::Utf8, true),
+        Field::new("translation_seq_canonical", DataType::Utf8, true),
+        Field::new("cds_sequence_canonical", DataType::Utf8, true),
         Field::new("protein_features", protein_feature_list_data_type(), true),
     ];
     new_schema(fields, coordinate_system_zero_based)
@@ -598,6 +602,22 @@ mod tests {
         assert!(schema.column_with_name("transcript_id").is_some());
         assert!(schema.column_with_name("translation_seq").is_some());
         assert!(schema.column_with_name("cds_sequence").is_some());
+        assert!(
+            schema
+                .column_with_name("translation_seq_canonical")
+                .is_some()
+        );
+        assert!(schema.column_with_name("cds_sequence_canonical").is_some());
+        for col in [
+            "translation_seq",
+            "cds_sequence",
+            "translation_seq_canonical",
+            "cds_sequence_canonical",
+        ] {
+            let f = schema.field_with_name(col).unwrap();
+            assert_eq!(f.data_type(), &DataType::Utf8);
+            assert!(f.is_nullable());
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -613,12 +633,29 @@ mod tests {
         assert!(schema.column_with_name("protein_len").is_some());
         assert!(schema.column_with_name("translation_seq").is_some());
         assert!(schema.column_with_name("cds_sequence").is_some());
+        assert!(
+            schema
+                .column_with_name("translation_seq_canonical")
+                .is_some()
+        );
+        assert!(schema.column_with_name("cds_sequence_canonical").is_some());
         assert!(schema.column_with_name("protein_features").is_some());
         // Should NOT contain position or sift/polyphen columns
         assert!(schema.column_with_name("chrom").is_none());
         assert!(schema.column_with_name("start").is_none());
         assert!(schema.column_with_name("sift_predictions").is_none());
         assert!(schema.column_with_name("polyphen_predictions").is_none());
+
+        for col in [
+            "translation_seq",
+            "cds_sequence",
+            "translation_seq_canonical",
+            "cds_sequence_canonical",
+        ] {
+            let f = schema.field_with_name(col).unwrap();
+            assert_eq!(f.data_type(), &DataType::Utf8);
+            assert!(f.is_nullable());
+        }
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/schema.rs
+++ b/datafusion/bio-format-ensembl-cache/src/schema.rs
@@ -166,6 +166,9 @@ pub(crate) fn transcript_schema(
         Field::new("gene_stable_id", DataType::Utf8, true),
         Field::new("gene_symbol", DataType::Utf8, true),
         Field::new("gene_symbol_source", DataType::Utf8, true),
+        // Cache export keeps both columns at the native VEP value so downstream
+        // annotators can preserve `_native` if they later overwrite
+        // `gene_hgnc_id` with buffer-scoped propagation results.
         Field::new("gene_hgnc_id", DataType::Utf8, true),
         Field::new("gene_hgnc_id_native", DataType::Utf8, true),
         Field::new("refseq_id", DataType::Utf8, true),
@@ -303,6 +306,9 @@ pub(crate) fn translation_schema(
         Field::new("cds_len", DataType::Int64, true),
         Field::new("translation_seq", DataType::Utf8, true),
         Field::new("cds_sequence", DataType::Utf8, true),
+        // Canonical columns are pre-BAM-edit when `_rna_edit` reversal
+        // succeeds. If reversal fails, canonical CDS stays NULL and canonical
+        // peptide falls back to the BAM-edited peptide.
         Field::new("translation_seq_canonical", DataType::Utf8, true),
         Field::new("cds_sequence_canonical", DataType::Utf8, true),
         Field::new("protein_features", protein_feature_list_data_type(), true),
@@ -326,6 +332,9 @@ pub fn translation_core_schema(coordinate_system_zero_based: bool) -> SchemaRef 
         Field::new("protein_len", DataType::Int64, true),
         Field::new("translation_seq", DataType::Utf8, true),
         Field::new("cds_sequence", DataType::Utf8, true),
+        // Same semantics as `translation_schema`: canonical CDS is NULL when an
+        // edit cannot be reversed, while canonical peptide falls back to the
+        // edited peptide.
         Field::new("translation_seq_canonical", DataType::Utf8, true),
         Field::new("cds_sequence_canonical", DataType::Utf8, true),
         Field::new("protein_features", protein_feature_list_data_type(), true),

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -35,6 +35,7 @@ pub(crate) struct TranscriptColumnIndices {
     gene_symbol: Option<usize>,
     gene_symbol_source: Option<usize>,
     gene_hgnc_id: Option<usize>,
+    gene_hgnc_id_native: Option<usize>,
     refseq_id: Option<usize>,
     coding_region_start: Option<usize>,
     coding_region_end: Option<usize>,
@@ -127,6 +128,7 @@ impl TranscriptColumnIndices {
             gene_symbol: col_map.get("gene_symbol"),
             gene_symbol_source: col_map.get("gene_symbol_source"),
             gene_hgnc_id: col_map.get("gene_hgnc_id"),
+            gene_hgnc_id_native: col_map.get("gene_hgnc_id_native"),
             refseq_id: col_map.get("refseq_id"),
             coding_region_start: col_map.get("cds_start"),
             coding_region_end: col_map.get("cds_end"),
@@ -1092,16 +1094,18 @@ pub(crate) fn parse_transcript_line_into(
             .as_ref(),
         );
     }
-    if let Some(idx) = col_idx.gene_hgnc_id {
-        batch.set_opt_utf8_owned(
-            idx,
-            json_str(
-                object
-                    .get("gene_hgnc_id")
-                    .or_else(|| object.get("_gene_hgnc_id")),
-            )
-            .as_ref(),
+    if col_idx.gene_hgnc_id.is_some() || col_idx.gene_hgnc_id_native.is_some() {
+        let native_value = json_str(
+            object
+                .get("gene_hgnc_id")
+                .or_else(|| object.get("_gene_hgnc_id")),
         );
+        if let Some(idx) = col_idx.gene_hgnc_id {
+            batch.set_opt_utf8_owned(idx, native_value.as_ref());
+        }
+        if let Some(idx) = col_idx.gene_hgnc_id_native {
+            batch.set_opt_utf8_owned(idx, native_value.as_ref());
+        }
     }
     if let Some(idx) = col_idx.refseq_id {
         let refseq_id = json_str(object.get("refseq_id").or_else(|| object.get("_refseq")))
@@ -1611,13 +1615,18 @@ fn append_transcript_storable_row_into(
         );
         batch.set_opt_utf8_owned(idx, value.as_ref());
     }
-    if let Some(idx) = col_idx.gene_hgnc_id {
-        let value = sv_str(
+    if col_idx.gene_hgnc_id.is_some() || col_idx.gene_hgnc_id_native.is_some() {
+        let native_value = sv_str(
             object
                 .get("gene_hgnc_id")
                 .or_else(|| object.get("_gene_hgnc_id")),
         );
-        batch.set_opt_utf8_owned(idx, value.as_ref());
+        if let Some(idx) = col_idx.gene_hgnc_id {
+            batch.set_opt_utf8_owned(idx, native_value.as_ref());
+        }
+        if let Some(idx) = col_idx.gene_hgnc_id_native {
+            batch.set_opt_utf8_owned(idx, native_value.as_ref());
+        }
     }
     if let Some(idx) = col_idx.refseq_id {
         let value =

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -896,8 +896,8 @@ fn json_promoted_vef_sequence(
     object
         .get("_variation_effect_feature_cache")
         .and_then(unwrap_blessed_object_optional)
-        .and_then(|vef_cache| json_str(vef_cache.get(key)))
-        .or_else(|| json_str(object.get(key)))
+        .and_then(|vef_cache| json_sequence_value(vef_cache.get(key)))
+        .or_else(|| json_sequence_value(object.get(key)))
 }
 
 fn storable_promoted_vef_sequence(
@@ -907,8 +907,32 @@ fn storable_promoted_vef_sequence(
     object
         .get("_variation_effect_feature_cache")
         .and_then(SValue::as_hash)
-        .and_then(|vef_cache| sv_str(vef_cache.get(key)))
-        .or_else(|| sv_str(object.get(key)))
+        .and_then(|vef_cache| storable_sequence_value(vef_cache.get(key)))
+        .or_else(|| storable_sequence_value(object.get(key)))
+}
+
+fn json_sequence_value(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    json_str(Some(value)).or_else(|| {
+        let obj = unwrap_blessed_object_optional(value)?;
+        json_str(obj.get("seq")).or_else(|| {
+            obj.get("primary_seq")
+                .and_then(unwrap_blessed_object_optional)
+                .and_then(|primary| json_str(primary.get("seq")))
+        })
+    })
+}
+
+fn storable_sequence_value(value: Option<&SValue>) -> Option<String> {
+    let value = value?;
+    sv_str(Some(value)).or_else(|| {
+        let obj = value.as_hash()?;
+        sv_str(obj.get("seq")).or_else(|| {
+            obj.get("primary_seq")
+                .and_then(SValue::as_hash)
+                .and_then(|primary| sv_str(primary.get("seq")))
+        })
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -2063,6 +2087,28 @@ mod tests {
         }
     }
 
+    fn storable_bioseq(seq: &str) -> SValue {
+        let mut primary = HashMap::new();
+        primary.insert(
+            "seq".to_string(),
+            SValue::String(Arc::from(seq.to_string())),
+        );
+
+        let mut bioseq = HashMap::new();
+        bioseq.insert(
+            "primary_seq".to_string(),
+            SValue::Blessed {
+                class: Arc::from("Bio::PrimarySeq"),
+                value: Arc::new(SValue::Hash(Arc::new(primary))),
+            },
+        );
+
+        SValue::Blessed {
+            class: Arc::from("Bio::Seq"),
+            value: Arc::new(SValue::Hash(Arc::new(bioseq))),
+        }
+    }
+
     #[test]
     fn parse_transcript_line_promotes_nested_vef_sequences() {
         let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
@@ -2156,14 +2202,8 @@ mod tests {
             "translateable_seq".to_string(),
             SValue::String(Arc::from("NESTED_SEQ")),
         );
-        vef_cache.insert(
-            "three_prime_utr".to_string(),
-            SValue::String(Arc::from("TTAA")),
-        );
-        vef_cache.insert(
-            "five_prime_utr".to_string(),
-            SValue::String(Arc::from("GGCC")),
-        );
+        vef_cache.insert("three_prime_utr".to_string(), storable_bioseq("TTAA"));
+        vef_cache.insert("five_prime_utr".to_string(), storable_bioseq("GGCC"));
 
         let mut object = HashMap::new();
         object.insert(
@@ -2201,6 +2241,73 @@ mod tests {
             &provenance,
         )
         .unwrap();
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "translateable_seq").as_deref(),
+            Some("NESTED_SEQ")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "three_prime_utr_seq").as_deref(),
+            Some("TTAA")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "five_prime_utr_seq").as_deref(),
+            Some("GGCC")
+        );
+    }
+
+    #[test]
+    fn parse_transcript_line_promotes_bioseq_utrs() {
+        let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
+        let payload = json!({
+            "stable_id": "ENST000004",
+            "strand": 1,
+            "biotype": "protein_coding",
+            "_variation_effect_feature_cache": {
+                "translateable_seq": "NESTED_SEQ",
+                "three_prime_utr": {
+                    "__class": "Bio::Seq",
+                    "__value": {
+                        "primary_seq": {
+                            "__class": "Bio::PrimarySeq",
+                            "__value": {
+                                "seq": "TTAA"
+                            }
+                        }
+                    }
+                },
+                "five_prime_utr": {
+                    "__class": "Bio::Seq",
+                    "__value": {
+                        "primary_seq": {
+                            "__class": "Bio::PrimarySeq",
+                            "__value": {
+                                "seq": "GGCC"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let line = format!(
+            "1\t100\t200\tJSON:{}",
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let written = parse_transcript_line_into(
+            &line,
+            "/tmp/transcript.txt",
+            &cache_info,
+            &SimplePredicate::default(),
+            false,
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        assert!(written);
 
         let batch = batch.finish().unwrap();
         assert_eq!(

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -70,6 +70,8 @@ pub(crate) struct TranscriptColumnIndices {
     transcript_attributes_projected: bool,
     // Promoted VEP fields (issue #125)
     translateable_seq: Option<usize>,
+    three_prime_utr_seq: Option<usize>,
+    five_prime_utr_seq: Option<usize>,
     cdna_mapper_segments: Option<usize>,
     cdna_mapper_projected: bool,
     bam_edit_status: Option<usize>,
@@ -161,6 +163,8 @@ impl TranscriptColumnIndices {
             ncrna_structure,
             transcript_attributes_projected,
             translateable_seq: col_map.get("translateable_seq"),
+            three_prime_utr_seq: col_map.get("three_prime_utr_seq"),
+            five_prime_utr_seq: col_map.get("five_prime_utr_seq"),
             cdna_mapper_segments,
             cdna_mapper_projected,
             bam_edit_status: col_map.get("bam_edit_status"),
@@ -885,6 +889,28 @@ fn build_flags_str(attrs: &TranscriptAttributes) -> Option<String> {
     }
 }
 
+fn json_promoted_vef_sequence(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<String> {
+    object
+        .get("_variation_effect_feature_cache")
+        .and_then(unwrap_blessed_object_optional)
+        .and_then(|vef_cache| json_str(vef_cache.get(key)))
+        .or_else(|| json_str(object.get(key)))
+}
+
+fn storable_promoted_vef_sequence(
+    object: &std::collections::HashMap<String, SValue>,
+    key: &str,
+) -> Option<String> {
+    object
+        .get("_variation_effect_feature_cache")
+        .and_then(SValue::as_hash)
+        .and_then(|vef_cache| sv_str(vef_cache.get(key)))
+        .or_else(|| sv_str(object.get(key)))
+}
+
 // ---------------------------------------------------------------------------
 // Direct builder parser for text lines (Phase 1+2+6)
 // ---------------------------------------------------------------------------
@@ -1253,7 +1279,15 @@ pub(crate) fn parse_transcript_line_into(
 
     // Top-level promoted fields (issue #125)
     if let Some(idx) = col_idx.translateable_seq {
-        let value = json_str(object.get("translateable_seq"));
+        let value = json_promoted_vef_sequence(object, "translateable_seq");
+        batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
+    if let Some(idx) = col_idx.three_prime_utr_seq {
+        let value = json_promoted_vef_sequence(object, "three_prime_utr");
+        batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
+    if let Some(idx) = col_idx.five_prime_utr_seq {
+        let value = json_promoted_vef_sequence(object, "five_prime_utr");
         batch.set_opt_utf8_owned(idx, value.as_ref());
     }
     if let Some(idx) = col_idx.bam_edit_status {
@@ -1774,7 +1808,15 @@ fn append_transcript_storable_row_into(
 
     // Top-level promoted fields (issue #125)
     if let Some(idx) = col_idx.translateable_seq {
-        let value = sv_str(object.get("translateable_seq"));
+        let value = storable_promoted_vef_sequence(object, "translateable_seq");
+        batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
+    if let Some(idx) = col_idx.three_prime_utr_seq {
+        let value = storable_promoted_vef_sequence(object, "three_prime_utr");
+        batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
+    if let Some(idx) = col_idx.five_prime_utr_seq {
+        let value = storable_promoted_vef_sequence(object, "five_prime_utr");
         batch.set_opt_utf8_owned(idx, value.as_ref());
     }
     if let Some(idx) = col_idx.bam_edit_status {
@@ -1956,9 +1998,224 @@ fn sv_bool(value: Option<&SValue>) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::filter::SimplePredicate;
+    use crate::info::CacheInfo;
+    use crate::schema::transcript_schema;
+    use crate::util::{BatchBuilder, ColumnMap, ProvenanceWriter};
+    use datafusion::arrow::array::{Array, StringArray};
     use serde_json::json;
     use std::collections::HashMap;
+    use std::path::PathBuf;
     use std::sync::Arc;
+
+    fn test_cache_info(serializer_type: &str) -> CacheInfo {
+        CacheInfo {
+            cache_root: PathBuf::from("/tmp/test"),
+            source_cache_path: "/tmp/test".to_string(),
+            species: "homo_sapiens".to_string(),
+            assembly: "GRCh38".to_string(),
+            cache_version: "115".to_string(),
+            serializer_type: Some(serializer_type.to_string()),
+            var_type: Some("region".to_string()),
+            cache_region_size: Some(1_000_000),
+            variation_cols: vec!["chr", "start", "end", "variation_name", "allele_string"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            source_descriptors: vec![],
+        }
+    }
+
+    fn transcript_test_components(
+        serializer_type: &str,
+    ) -> (
+        BatchBuilder,
+        TranscriptColumnIndices,
+        ProvenanceWriter,
+        CacheInfo,
+    ) {
+        let cache_info = test_cache_info(serializer_type);
+        let schema = transcript_schema(&cache_info, false);
+        let col_map = ColumnMap::from_schema(&schema);
+        let batch = BatchBuilder::new(schema, 1).unwrap();
+        let col_idx = TranscriptColumnIndices::new(&col_map);
+        let provenance = ProvenanceWriter::new(&col_map, &cache_info);
+        (batch, col_idx, provenance, cache_info)
+    }
+
+    fn batch_utf8_value(
+        batch: &datafusion::arrow::record_batch::RecordBatch,
+        col: &str,
+    ) -> Option<String> {
+        let (idx, _) = batch
+            .schema()
+            .column_with_name(col)
+            .unwrap_or_else(|| panic!("missing column: {col}"));
+        let values = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap_or_else(|| panic!("expected Utf8 column: {col}"));
+        if values.is_null(0) {
+            None
+        } else {
+            Some(values.value(0).to_string())
+        }
+    }
+
+    #[test]
+    fn parse_transcript_line_promotes_nested_vef_sequences() {
+        let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
+        let payload = json!({
+            "stable_id": "ENST000001",
+            "strand": 1,
+            "biotype": "protein_coding",
+            "translateable_seq": "TOP_LEVEL_SEQ",
+            "_variation_effect_feature_cache": {
+                "translateable_seq": "NESTED_SEQ",
+                "three_prime_utr": "TTAA",
+                "five_prime_utr": "GGCC"
+            }
+        });
+        let line = format!(
+            "1\t100\t200\tJSON:{}",
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let written = parse_transcript_line_into(
+            &line,
+            "/tmp/transcript.txt",
+            &cache_info,
+            &SimplePredicate::default(),
+            false,
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        assert!(written);
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "translateable_seq").as_deref(),
+            Some("NESTED_SEQ")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "three_prime_utr_seq").as_deref(),
+            Some("TTAA")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "five_prime_utr_seq").as_deref(),
+            Some("GGCC")
+        );
+    }
+
+    #[test]
+    fn parse_transcript_line_falls_back_to_top_level_translateable_seq() {
+        let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
+        let payload = json!({
+            "stable_id": "ENST000002",
+            "strand": 1,
+            "biotype": "protein_coding",
+            "translateable_seq": "TOP_LEVEL_ONLY"
+        });
+        let line = format!(
+            "1\t100\t200\tJSON:{}",
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let written = parse_transcript_line_into(
+            &line,
+            "/tmp/transcript.txt",
+            &cache_info,
+            &SimplePredicate::default(),
+            false,
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        assert!(written);
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "translateable_seq").as_deref(),
+            Some("TOP_LEVEL_ONLY")
+        );
+        assert_eq!(batch_utf8_value(&batch, "three_prime_utr_seq"), None);
+        assert_eq!(batch_utf8_value(&batch, "five_prime_utr_seq"), None);
+    }
+
+    #[test]
+    fn append_transcript_storable_row_promotes_nested_vef_sequences() {
+        let (mut batch, col_idx, provenance, _) = transcript_test_components("storable");
+        let mut vef_cache = HashMap::new();
+        vef_cache.insert(
+            "translateable_seq".to_string(),
+            SValue::String(Arc::from("NESTED_SEQ")),
+        );
+        vef_cache.insert(
+            "three_prime_utr".to_string(),
+            SValue::String(Arc::from("TTAA")),
+        );
+        vef_cache.insert(
+            "five_prime_utr".to_string(),
+            SValue::String(Arc::from("GGCC")),
+        );
+
+        let mut object = HashMap::new();
+        object.insert(
+            "biotype".to_string(),
+            SValue::String(Arc::from("protein_coding")),
+        );
+        object.insert(
+            "translateable_seq".to_string(),
+            SValue::String(Arc::from("TOP_LEVEL_SEQ")),
+        );
+        object.insert(
+            "_variation_effect_feature_cache".to_string(),
+            SValue::Hash(Arc::new(vef_cache)),
+        );
+
+        let payload = SValue::Hash(Arc::new(object.clone()));
+        let core = TranscriptRowCore {
+            chrom: "1".to_string(),
+            start: 100,
+            end: 200,
+            source_start: 100,
+            source_end: 200,
+            strand: 1,
+            stable_id: "ENST000003".to_string(),
+        };
+
+        append_transcript_storable_row_into(
+            &payload,
+            &object,
+            core,
+            false,
+            "/tmp/transcript.storable.gz",
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "translateable_seq").as_deref(),
+            Some("NESTED_SEQ")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "three_prime_utr_seq").as_deref(),
+            Some("TTAA")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "five_prime_utr_seq").as_deref(),
+            Some("GGCC")
+        );
+    }
 
     #[test]
     fn json_transcript_attributes_parse_flags_and_mirna_regions_plus_strand() {

--- a/datafusion/bio-format-ensembl-cache/src/translation.rs
+++ b/datafusion/bio-format-ensembl-cache/src/translation.rs
@@ -1019,8 +1019,10 @@ fn undo_rna_edit_insertions(
             return None;
         }
         // Sanity check: the bytes we're about to remove must equal the edit's
-        // alt payload. If they don't, our coordinate / ordering assumption is
-        // wrong and we should bail instead of silently corrupting the result.
+        // alt payload. This assumes the cache stores `_rna_edit` alt values in
+        // the same case as the edited CDS. If they don't, our coordinate /
+        // ordering model is wrong and we should bail instead of silently
+        // corrupting the result.
         if &seq[start_idx..end_idx] != edit.alt.as_bytes() {
             return None;
         }
@@ -1093,8 +1095,10 @@ fn codon_table1(codon: [u8; 3]) -> Option<char> {
 /// Compute canonical CDS + peptide from the BAM-edited sequences and the
 /// list of `_rna_edit` attributes.
 ///
-/// Returns `(canonical_cds, canonical_peptide)`. Either may be `None` if the
-/// input is missing or an edit cannot be reversed cleanly. The typical
+/// Returns `(canonical_cds, canonical_peptide)`. `canonical_cds` is `None` if
+/// the input is missing or an edit cannot be reversed cleanly. In that case,
+/// `canonical_peptide` falls back to the BAM-edited peptide when available so
+/// downstream HGVSp-style consumers still have a peptide string. The typical
 /// non-BAM-edited transcript has `edits.is_empty()` and both canonical values
 /// are returned unchanged (equal to the BAM-edited copies).
 fn derive_canonical_sequences(
@@ -1568,16 +1572,6 @@ mod tests {
 
     #[test]
     fn undo_rna_edit_removes_insertion_and_recovers_original_cds() {
-        // Synthetic: insert GCAGCA at cdna 111 (= mid-CDS with cdna offset 145).
-        // Edit value: start=111, end=110, alt=GCAGCA.
-        let edited_cds = "AAACCAGCAGGGG"; // "AAA"+"CC"+"AGCAG"+"GGG"+"G" — contrived.
-        // We want to simulate: pre-edit was "AAACCGGGG" (9 nt). Edit inserts
-        // "AGCAG" starting at cdna 6 (which in CDS space after offset=0 means
-        // position 6). Hmm let me re-plan this test.
-        let _ = edited_cds;
-        // Pre-edit CDS: "AAACCAGGG" (9 nt, codons AAA, CCA, GGG → K P G).
-        // Insert "CAG" at cdna 7 (between cdna 6 and 7) → "AAACCACAGGG"?
-        // Actually let's simulate the real HTT edit in miniature.
         // Pre-edit CDS: "ATGCAGCAGCCCCCC" (5 codons M Q Q P P, 15 nt)
         // Edit: insert "CAGCAG" (6 nt, 2 Q codons) between cdna 6 and 7
         //   value = "7 6 CAGCAG"
@@ -1734,25 +1728,29 @@ mod tests {
     // -----------------------------------------------------------------------
     // HTT polyQ regression against a real VEP merged cache sample.
     //
-    // Ignored by default because it reaches into an absolute path outside the
-    // repo. Run locally with:
+    // Ignored by default because it needs a real merged-cache file outside the
+    // repo. Set `VEP_MERGED_CACHE_PATH` to the `.gz` region file, then run:
     //   cargo test --lib translation::tests::htt_canonical_from_real_merged_cache \
     //     -- --ignored --nocapture
     // -----------------------------------------------------------------------
     #[test]
-    #[ignore = "requires /Users/mwiewior/workspace/data_vepyr/homo_sapiens_merged cache"]
+    #[ignore = "requires VEP_MERGED_CACHE_PATH pointing at a merged-cache .gz file"]
     fn htt_canonical_from_real_merged_cache() {
-        let path = std::path::Path::new(
-            "/Users/mwiewior/workspace/data_vepyr/homo_sapiens_merged/115_GRCh38/4/3000001-4000000.gz",
-        );
+        let path = match std::env::var("VEP_MERGED_CACHE_PATH") {
+            Ok(path) => std::path::PathBuf::from(path),
+            Err(_) => {
+                println!("SKIP: set VEP_MERGED_CACHE_PATH to a merged-cache .gz file");
+                return;
+            }
+        };
         if !path.exists() {
             println!("SKIP: cache not found at {}", path.display());
             return;
         }
-        let reader = open_binary_reader(path).expect("open reader");
+        let reader = open_binary_reader(&path).expect("open reader");
         let (alias_counts, entry_keys) =
             collect_nstore_alias_counts_and_top_keys_from_reader(reader).expect("aliases");
-        let reader = open_binary_reader(path).expect("open reader 2");
+        let reader = open_binary_reader(&path).expect("open reader 2");
 
         let mut refseq_canonical: Option<String> = None;
         let mut refseq_edited: Option<String> = None;

--- a/datafusion/bio-format-ensembl-cache/src/translation.rs
+++ b/datafusion/bio-format-ensembl-cache/src/translation.rs
@@ -288,15 +288,30 @@ pub(crate) fn parse_translation_line_into(
         if let Some(idx) = col_idx.cdna_seq {
             batch.set_opt_utf8_owned(idx, edited_cds.as_ref());
         }
+        // Derive canonical (pre-BAM-edit) sequences by reversing the list of
+        // `_rna_edit` attribute insertions on the edited CDS. For non-BAM-
+        // edited transcripts this is a no-op (canonical ≡ edited). See the
+        // RnaEdit docs above for coordinate semantics.
+        //
+        // The upstream extractor used to look for `translation.primary_seq`
+        // or a top-level `translateable_seq` — neither is populated in raw
+        // VEP merged caches (the primary_seq is a lazy Perl method, and
+        // translateable_seq only appears inside `_variation_effect_feature_cache`).
+        // Reversing the explicitly-stored edits is the only path that
+        // actually recovers the canonical peptide for BAM-edited RefSeq.
+        let edits_json = parse_rna_edits_json(object.get("attributes"));
+        let (canonical_cds, canonical_peptide) = derive_canonical_sequences(
+            edited_cds.as_deref(),
+            edited_peptide.as_deref(),
+            &edits_json,
+            cdna_coding_start_val,
+            cdna_coding_end_val,
+        );
         if let Some(idx) = col_idx.peptide_seq_canonical {
-            let value = json_primary_seq_value(translation_obj.get("primary_seq"))
-                .or_else(|| edited_peptide.clone());
-            batch.set_opt_utf8_owned(idx, value.as_ref());
+            batch.set_opt_utf8_owned(idx, canonical_peptide.as_ref());
         }
         if let Some(idx) = col_idx.cdna_seq_canonical {
-            let value = json_primary_seq_value(object.get("translateable_seq"))
-                .or_else(|| edited_cds.clone());
-            batch.set_opt_utf8_owned(idx, value.as_ref());
+            batch.set_opt_utf8_owned(idx, canonical_cds.as_ref());
         }
         if let Some(idx) = col_idx.protein_features {
             let features = vef_cache.and_then(extract_protein_features_json);
@@ -490,15 +505,22 @@ where
             if let Some(idx) = col_idx.cdna_seq {
                 batch.set_opt_utf8_owned(idx, edited_cds.as_ref());
             }
+            // Reverse `_rna_edit` insertions on the edited CDS to recover
+            // canonical. Non-edited transcripts: no-op (canonical ≡ edited).
+            // See RnaEdit / derive_canonical_sequences for details.
+            let edits = parse_rna_edits_storable(obj.get("attributes"));
+            let (canonical_cds, canonical_peptide) = derive_canonical_sequences(
+                edited_cds.as_deref(),
+                edited_peptide.as_deref(),
+                &edits,
+                cdna_coding_start_val,
+                cdna_coding_end_val,
+            );
             if let Some(idx) = col_idx.peptide_seq_canonical {
-                let value = storable_primary_seq_value(translation_obj.get("primary_seq"))
-                    .or_else(|| edited_peptide.clone());
-                batch.set_opt_utf8_owned(idx, value.as_ref());
+                batch.set_opt_utf8_owned(idx, canonical_peptide.as_ref());
             }
             if let Some(idx) = col_idx.cdna_seq_canonical {
-                let value = storable_primary_seq_value(obj.get("translateable_seq"))
-                    .or_else(|| edited_cds.clone());
-                batch.set_opt_utf8_owned(idx, value.as_ref());
+                batch.set_opt_utf8_owned(idx, canonical_cds.as_ref());
             }
             if let Some(vef_cache) = vef_cache {
                 if let Some(idx) = col_idx.protein_features {
@@ -847,38 +869,265 @@ fn extract_predictions_storable(
     }
 }
 
-/// Unwrap a Perl sequence value into a plain `String`.
+// ---------------------------------------------------------------------------
+// RNA-edit (BAM-edit) reversal for canonical sequence recovery.
+//
+// Raw VEP merged caches for BAM-edited RefSeq transcripts carry the edited
+// peptide / CDS in `_variation_effect_feature_cache.{peptide,translateable_seq}`.
+// They do NOT separately serialize the pre-edit (canonical) versions —
+// `translation.primary_seq` is a lazy Perl method, not a stored field. What
+// IS stored is the list of edits as `_rna_edit` attribute entries on the
+// transcript, e.g. `"256 255 GCAGCA"` meaning "insert GCAGCA between cdna
+// positions 255 and 256". Reversing those insertions on the BAM-edited CDS
+// reconstructs the canonical CDS, which is then translated to the canonical
+// peptide.
+//
+// Edit semantics follow Ensembl `Bio::EnsEMBL::SeqEdit`:
+//   start, end = 1-based cdna coordinates. If `end < start` (conventionally
+//   end = start - 1) the edit is a pure insertion between `end` and `start`.
+//   `alt` is the inserted bases. The edit is applied with
+//   `substr($seq, $start - 1, $end - $start + 1) = $alt`, so a 0-len slice at
+//   0-indexed position `start - 1` receives `alt`.
+//
+// Ensembl applies edits in ascending `start` order against the current
+// sequence, so each edit's coordinates reference the already-edited sequence
+// produced by preceding edits. To undo we traverse in DESCENDING start order
+// and remove `alt.len()` bytes at position `start - 1` (0-indexed) — later
+// undoes cannot disturb earlier positions because they act above them.
+// ---------------------------------------------------------------------------
+
+/// A single RNA edit parsed from an Ensembl `_rna_edit` attribute value.
 ///
-/// Storable caches represent sequences either as raw scalars or as blessed
-/// `Bio::PrimarySeq` objects — sometimes doubly nested (outer object's
-/// `primary_seq` holding the actual payload). Mirrors the equivalent helper
-/// in `transcript.rs`.
-fn json_primary_seq_value(value: Option<&serde_json::Value>) -> Option<String> {
-    let value = value?;
-    if let Some(s) = json_str(Some(value)) {
-        return Some(s);
-    }
-    let obj = unwrap_blessed_object_optional(value)?;
-    if let Some(s) = json_str(obj.get("seq")) {
-        return Some(s);
-    }
-    obj.get("primary_seq")
-        .and_then(unwrap_blessed_object_optional)
-        .and_then(|primary| json_str(primary.get("seq")))
+/// Coordinates are 1-based cdna (transcript-relative). `end < start` denotes
+/// a pure insertion (the BAM-edit case).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RnaEdit {
+    pub start: i64,
+    pub end: i64,
+    pub alt: String,
 }
 
-fn storable_primary_seq_value(value: Option<&SValue>) -> Option<String> {
-    let value = value?;
-    if let Some(s) = sv_str(Some(value)) {
-        return Some(s);
+impl RnaEdit {
+    /// Parse an attribute value like `"256 255 GCAGCA"` into a structured edit.
+    ///
+    /// Returns `None` on malformed values (missing fields, non-integer
+    /// coordinates, etc.) rather than erroring — the caller skips unparseable
+    /// edits without aborting translation ingestion.
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        let mut parts = value.split_whitespace();
+        let start = parts.next()?.parse::<i64>().ok()?;
+        let end = parts.next()?.parse::<i64>().ok()?;
+        let alt = parts.next().unwrap_or("").to_string();
+        // Remaining tokens (if any) ignored — VEP's format has exactly 3.
+        Some(Self { start, end, alt })
     }
-    let obj = value.as_hash()?;
-    if let Some(s) = sv_str(obj.get("seq")) {
-        return Some(s);
+
+    /// True if this edit is a pure insertion (no bases replaced).
+    pub(crate) fn is_pure_insertion(&self) -> bool {
+        self.end + 1 == self.start && !self.alt.is_empty()
     }
-    obj.get("primary_seq")
-        .and_then(SValue::as_hash)
-        .and_then(|primary| sv_str(primary.get("seq")))
+}
+
+/// Extract `_rna_edit` attributes from a Storable transcript attributes array.
+///
+/// Each element of `attributes` is expected to be a blessed
+/// `Bio::EnsEMBL::Attribute` hash with `code` and `value` keys. Entries whose
+/// `code` is not `"_rna_edit"` are skipped. Unparseable values are skipped.
+fn parse_rna_edits_storable(attributes: Option<&SValue>) -> Vec<RnaEdit> {
+    let Some(array) = attributes.and_then(SValue::as_array) else {
+        return Vec::new();
+    };
+    array
+        .iter()
+        .filter_map(|attr| {
+            let obj = attr.as_hash()?;
+            let code = sv_str(obj.get("code"))?;
+            if code != "_rna_edit" {
+                return None;
+            }
+            let value = sv_str(obj.get("value"))?;
+            RnaEdit::parse(&value)
+        })
+        .collect()
+}
+
+/// JSON-path equivalent of [`parse_rna_edits_storable`]. The JSON caches wrap
+/// attributes as blessed objects (payload under `__value`) so we unwrap first.
+fn parse_rna_edits_json(attributes: Option<&serde_json::Value>) -> Vec<RnaEdit> {
+    let Some(arr) = attributes.and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|attr| {
+            let obj = unwrap_blessed_object_optional(attr).or_else(|| attr.as_object())?;
+            let code = json_str(obj.get("code"))?;
+            if code != "_rna_edit" {
+                return None;
+            }
+            let value = json_str(obj.get("value"))?;
+            RnaEdit::parse(&value)
+        })
+        .collect()
+}
+
+/// Reverse the given `_rna_edit` insertions against the edited cdna / CDS
+/// string to recover the pre-edit sequence.
+///
+/// Only pure insertions are undone. Deletions or substitutions leave the
+/// sequence shorter than it would be in pre-edit form *and* require the
+/// original bases (which the attribute value does not carry), so this helper
+/// bails out (returns `None`) if any non-insertion edit appears. That signals
+/// to the caller "the cache lacks enough information to recover canonical" —
+/// the canonical column is then left null rather than populated with a
+/// half-undone mix.
+///
+/// `coord_offset` is subtracted from each edit's 1-based cdna start to
+/// translate into the coordinate space of `edited`:
+/// - `0` when `edited` is the spliced (cdna) sequence
+/// - `cdna_coding_start - 1` when `edited` is the translateable (CDS)
+///   sequence — this filters out edits that fall outside the CDS as a
+///   side effect.
+fn undo_rna_edit_insertions(
+    edited: &str,
+    edits: &[RnaEdit],
+    coord_offset: i64,
+    keep_range: Option<(i64, i64)>,
+) -> Option<String> {
+    let mut relevant: Vec<&RnaEdit> = edits
+        .iter()
+        .filter(|e| match keep_range {
+            Some((lo, hi)) => e.start >= lo && e.start <= hi,
+            None => true,
+        })
+        .collect();
+    relevant.sort_by(|a, b| b.start.cmp(&a.start)); // descending
+    let mut seq: Vec<u8> = edited.as_bytes().to_vec();
+    for edit in relevant {
+        if !edit.is_pure_insertion() {
+            return None;
+        }
+        let offset_start = edit.start - coord_offset;
+        if offset_start < 1 {
+            // Insertion is before the window `edited` represents — for a CDS
+            // window this means the edit is in the 5' UTR, outside the CDS.
+            // Skip it silently.
+            continue;
+        }
+        let start_idx = (offset_start - 1) as usize;
+        let end_idx = start_idx + edit.alt.len();
+        if end_idx > seq.len() {
+            return None;
+        }
+        // Sanity check: the bytes we're about to remove must equal the edit's
+        // alt payload. If they don't, our coordinate / ordering assumption is
+        // wrong and we should bail instead of silently corrupting the result.
+        if &seq[start_idx..end_idx] != edit.alt.as_bytes() {
+            return None;
+        }
+        seq.drain(start_idx..end_idx);
+    }
+    String::from_utf8(seq).ok()
+}
+
+/// Translate a CDS byte slice to a peptide string using NCBI translation
+/// table 1 (the standard code), trimming at the first stop codon.
+///
+/// Returns `None` if the CDS length is not a multiple of 3 or contains
+/// non-ACGT characters that can't be resolved unambiguously. Ambiguous IUPAC
+/// codes are not supported — BAM-edited RefSeq and Ensembl canonical CDSes
+/// in the cache are unambiguous, so this is fine in practice.
+fn translate_cds_table1(cds: &str) -> Option<String> {
+    let bytes = cds.as_bytes();
+    if !bytes.len().is_multiple_of(3) {
+        return None;
+    }
+    let mut peptide = String::with_capacity(bytes.len() / 3);
+    for chunk in bytes.chunks_exact(3) {
+        let codon = [
+            chunk[0].to_ascii_uppercase(),
+            chunk[1].to_ascii_uppercase(),
+            chunk[2].to_ascii_uppercase(),
+        ];
+        let aa = codon_table1(codon)?;
+        if aa == '*' {
+            break;
+        }
+        peptide.push(aa);
+    }
+    Some(peptide)
+}
+
+#[inline]
+fn codon_table1(codon: [u8; 3]) -> Option<char> {
+    // NCBI translation table 1 (standard). Stop codons = '*'.
+    match codon {
+        [b'T', b'T', b'T'] | [b'T', b'T', b'C'] => Some('F'),
+        [b'T', b'T', b'A'] | [b'T', b'T', b'G'] => Some('L'),
+        [b'C', b'T', _] => Some('L'),
+        [b'A', b'T', b'T'] | [b'A', b'T', b'C'] | [b'A', b'T', b'A'] => Some('I'),
+        [b'A', b'T', b'G'] => Some('M'),
+        [b'G', b'T', _] => Some('V'),
+        [b'T', b'C', _] => Some('S'),
+        [b'C', b'C', _] => Some('P'),
+        [b'A', b'C', _] => Some('T'),
+        [b'G', b'C', _] => Some('A'),
+        [b'T', b'A', b'T'] | [b'T', b'A', b'C'] => Some('Y'),
+        [b'T', b'A', b'A'] | [b'T', b'A', b'G'] => Some('*'),
+        [b'C', b'A', b'T'] | [b'C', b'A', b'C'] => Some('H'),
+        [b'C', b'A', b'A'] | [b'C', b'A', b'G'] => Some('Q'),
+        [b'A', b'A', b'T'] | [b'A', b'A', b'C'] => Some('N'),
+        [b'A', b'A', b'A'] | [b'A', b'A', b'G'] => Some('K'),
+        [b'G', b'A', b'T'] | [b'G', b'A', b'C'] => Some('D'),
+        [b'G', b'A', b'A'] | [b'G', b'A', b'G'] => Some('E'),
+        [b'T', b'G', b'T'] | [b'T', b'G', b'C'] => Some('C'),
+        [b'T', b'G', b'A'] => Some('*'),
+        [b'T', b'G', b'G'] => Some('W'),
+        [b'C', b'G', _] => Some('R'),
+        [b'A', b'G', b'T'] | [b'A', b'G', b'C'] => Some('S'),
+        [b'A', b'G', b'A'] | [b'A', b'G', b'G'] => Some('R'),
+        [b'G', b'G', _] => Some('G'),
+        _ => None,
+    }
+}
+
+/// Compute canonical CDS + peptide from the BAM-edited sequences and the
+/// list of `_rna_edit` attributes.
+///
+/// Returns `(canonical_cds, canonical_peptide)`. Either may be `None` if the
+/// input is missing or an edit cannot be reversed cleanly. The typical
+/// non-BAM-edited transcript has `edits.is_empty()` and both canonical values
+/// are returned unchanged (equal to the BAM-edited copies).
+fn derive_canonical_sequences(
+    edited_cds: Option<&str>,
+    edited_peptide: Option<&str>,
+    edits: &[RnaEdit],
+    cdna_coding_start: Option<i64>,
+    cdna_coding_end: Option<i64>,
+) -> (Option<String>, Option<String>) {
+    if edits.is_empty() {
+        // Non-BAM-edited transcript — canonical ≡ edited.
+        return (
+            edited_cds.map(|s| s.to_string()),
+            edited_peptide.map(|s| s.to_string()),
+        );
+    }
+    let (Some(cds), Some(coding_start), Some(coding_end)) =
+        (edited_cds, cdna_coding_start, cdna_coding_end)
+    else {
+        // Can't locate CDS within the cdna sequence — bail.
+        return (None, None);
+    };
+    let canonical_cds = undo_rna_edit_insertions(
+        cds,
+        edits,
+        coding_start - 1,
+        Some((coding_start, coding_end)),
+    );
+    let canonical_peptide = canonical_cds
+        .as_deref()
+        .and_then(translate_cds_table1)
+        .or_else(|| edited_peptide.map(|s| s.to_string()));
+    (canonical_cds, canonical_peptide)
 }
 
 fn unwrap_blessed_object(
@@ -1233,101 +1482,378 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // json_primary_seq_value / storable_primary_seq_value
+    // RnaEdit parsing + reversal + codon-table translation
     //
-    // Canonical (pre-BAM-edit) translation and CDS live in Perl fields that
-    // VEP stores in one of three shapes: plain string, blessed Bio::PrimarySeq
-    // with a `seq` slot, or a transcript-level object whose `primary_seq` slot
-    // itself wraps a Bio::PrimarySeq. These helpers normalize all three.
+    // These cover the canonical-sequence recovery path: parse `_rna_edit`
+    // attribute values, drop insertions back out of the BAM-edited CDS, and
+    // translate the recovered CDS with the standard codon table.
     // -----------------------------------------------------------------------
 
     #[test]
-    fn json_primary_seq_value_plain_string() {
-        let v = serde_json::json!("MVFP");
-        assert_eq!(json_primary_seq_value(Some(&v)).as_deref(), Some("MVFP"));
+    fn rna_edit_parse_insertion_form() {
+        // The BAM-edited NM_002111.8 HTT polyQ edit has exactly this shape.
+        let edit = RnaEdit::parse("256 255 GCAGCA").expect("parse");
+        assert_eq!(edit.start, 256);
+        assert_eq!(edit.end, 255);
+        assert_eq!(edit.alt, "GCAGCA");
+        assert!(edit.is_pure_insertion());
     }
 
     #[test]
-    fn json_primary_seq_value_blessed_seq_slot() {
-        let v = serde_json::json!({
-            "__class": "Bio::PrimarySeq",
-            "__value": { "seq": "MVFPQA" }
-        });
-        assert_eq!(json_primary_seq_value(Some(&v)).as_deref(), Some("MVFPQA"));
+    fn rna_edit_parse_rejects_malformed() {
+        assert!(RnaEdit::parse("").is_none());
+        assert!(RnaEdit::parse("not a number").is_none());
+        assert!(RnaEdit::parse("256").is_none());
+        // Extra whitespace-separated tokens are tolerated (VEP stores exactly
+        // 3 but the parser shouldn't choke if the format loosens later).
+        let e = RnaEdit::parse("10 9 ACG trailing").expect("parse tolerant");
+        assert_eq!(e.start, 10);
+        assert_eq!(e.alt, "ACG");
     }
 
     #[test]
-    fn json_primary_seq_value_nested_primary_seq() {
-        let v = serde_json::json!({
-            "__class": "Bio::EnsEMBL::Translation",
-            "__value": {
-                "primary_seq": {
-                    "__class": "Bio::PrimarySeq",
-                    "__value": { "seq": "MVFPQAK" }
-                }
+    fn rna_edit_is_pure_insertion_requires_end_plus_one_equals_start() {
+        assert!(RnaEdit::parse("256 255 A").unwrap().is_pure_insertion());
+        // end == start → substitution, not a pure insertion.
+        assert!(!RnaEdit::parse("256 256 A").unwrap().is_pure_insertion());
+        // Empty alt (deletion) → not a pure insertion.
+        assert!(!RnaEdit::parse("256 255 ").unwrap().is_pure_insertion());
+    }
+
+    #[test]
+    fn parse_rna_edits_storable_filters_by_code_and_extracts_value() {
+        let mut e1 = std::collections::HashMap::new();
+        e1.insert(
+            "code".to_string(),
+            SValue::String(std::sync::Arc::from("_rna_edit")),
+        );
+        e1.insert(
+            "value".to_string(),
+            SValue::String(std::sync::Arc::from("256 255 GCAGCA")),
+        );
+        let mut e2 = std::collections::HashMap::new();
+        e2.insert(
+            "code".to_string(),
+            SValue::String(std::sync::Arc::from("MANE_Select")),
+        );
+        e2.insert(
+            "value".to_string(),
+            SValue::String(std::sync::Arc::from("NM_001388492.1")),
+        );
+        let attrs = SValue::Array(std::sync::Arc::new(vec![
+            SValue::Hash(std::sync::Arc::new(e1)),
+            SValue::Hash(std::sync::Arc::new(e2)),
+        ]));
+        let edits = parse_rna_edits_storable(Some(&attrs));
+        assert_eq!(edits.len(), 1, "MANE_Select attribute must be ignored");
+        assert_eq!(edits[0].alt, "GCAGCA");
+    }
+
+    #[test]
+    fn parse_rna_edits_json_handles_blessed_wrapper() {
+        let attrs = serde_json::json!([
+            {
+                "__class": "Bio::EnsEMBL::Attribute",
+                "__value": { "code": "_rna_edit", "value": "256 255 GCAGCA" }
+            },
+            {
+                "__class": "Bio::EnsEMBL::Attribute",
+                "__value": { "code": "TSL", "value": "tsl1" }
             }
-        });
-        assert_eq!(json_primary_seq_value(Some(&v)).as_deref(), Some("MVFPQAK"));
+        ]);
+        let edits = parse_rna_edits_json(Some(&attrs));
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].start, 256);
     }
 
     #[test]
-    fn json_primary_seq_value_none_and_missing_seq() {
-        assert!(json_primary_seq_value(None).is_none());
-        let empty_obj = serde_json::json!({ "other": "field" });
-        assert!(json_primary_seq_value(Some(&empty_obj)).is_none());
+    fn undo_rna_edit_removes_insertion_and_recovers_original_cds() {
+        // Synthetic: insert GCAGCA at cdna 111 (= mid-CDS with cdna offset 145).
+        // Edit value: start=111, end=110, alt=GCAGCA.
+        let edited_cds = "AAACCAGCAGGGG"; // "AAA"+"CC"+"AGCAG"+"GGG"+"G" — contrived.
+        // We want to simulate: pre-edit was "AAACCGGGG" (9 nt). Edit inserts
+        // "AGCAG" starting at cdna 6 (which in CDS space after offset=0 means
+        // position 6). Hmm let me re-plan this test.
+        let _ = edited_cds;
+        // Pre-edit CDS: "AAACCAGGG" (9 nt, codons AAA, CCA, GGG → K P G).
+        // Insert "CAG" at cdna 7 (between cdna 6 and 7) → "AAACCACAGGG"?
+        // Actually let's simulate the real HTT edit in miniature.
+        // Pre-edit CDS: "ATGCAGCAGCCCCCC" (5 codons M Q Q P P, 15 nt)
+        // Edit: insert "CAGCAG" (6 nt, 2 Q codons) between cdna 6 and 7
+        //   value = "7 6 CAGCAG"
+        // Post-edit CDS: "ATGCAG" + "CAGCAG" + "CAGCCCCCC"
+        //   = "ATGCAGCAGCAGCAGCCCCCC" (21 nt, 7 codons M Q Q Q Q P P)
+        let pre_edit = "ATGCAGCAGCCCCCC";
+        let post_edit = "ATGCAGCAGCAGCAGCCCCCC";
+        let edit = RnaEdit::parse("7 6 CAGCAG").unwrap();
+        let recovered = undo_rna_edit_insertions(post_edit, &[edit], 0, None)
+            .expect("insertion must reverse cleanly");
+        assert_eq!(recovered, pre_edit);
     }
 
     #[test]
-    fn storable_primary_seq_value_plain_string() {
-        let v = SValue::String(std::sync::Arc::from("MVFP"));
+    fn undo_rna_edit_multiple_insertions_applied_descending() {
+        // Simulate Ensembl applying edits in ascending-start order, each edit
+        // referencing the CURRENT (post-previous-edit) sequence.
+        //
+        //   pre              = "0123456789"                (10 chars)
+        //   edit 1 (s=5,e=4,alt=XX)  inserts before cdna 5 of pre
+        //     → "0123XX456789"                             (12 chars, = post_1)
+        //   edit 2 (s=10,e=9,alt=YY) inserts before cdna 10 of post_1
+        //     (cdna 10 of post_1 is 0-indexed 9 = char '7')
+        //     → "0123XX456YY789"                           (14 chars, = post_both)
+        //
+        // Undoing in descending start order — edit 2 then edit 1 — must take
+        // post_both back to pre exactly. Lower-position edit's bytes are not
+        // disturbed by the higher-position undo, so the second pass finds
+        // its alt at the expected coordinates.
+        let pre = "0123456789";
+        let post_both = "0123XX456YY789";
+        let edits = vec![
+            RnaEdit {
+                start: 5,
+                end: 4,
+                alt: "XX".to_string(),
+            },
+            RnaEdit {
+                start: 10,
+                end: 9,
+                alt: "YY".to_string(),
+            },
+        ];
+        let recovered =
+            undo_rna_edit_insertions(post_both, &edits, 0, None).expect("two-edit reverse");
+        assert_eq!(recovered, pre);
+    }
+
+    #[test]
+    fn undo_rna_edit_bails_on_non_insertion() {
+        // A substitution-shape edit (start == end, single alt char) can't be
+        // reversed without the original base → helper must return None.
+        let edits = vec![RnaEdit {
+            start: 5,
+            end: 5,
+            alt: "X".to_string(),
+        }];
+        assert!(undo_rna_edit_insertions("AAAAXAAAA", &edits, 0, None).is_none());
+    }
+
+    #[test]
+    fn undo_rna_edit_bails_on_coordinate_mismatch() {
+        // alt="XX" but the bytes at that position are "AA" → our coordinate /
+        // ordering model is wrong for this input; bail instead of corrupting.
+        let edits = vec![RnaEdit {
+            start: 3,
+            end: 2,
+            alt: "XX".to_string(),
+        }];
+        assert!(undo_rna_edit_insertions("AAAAAA", &edits, 0, None).is_none());
+    }
+
+    #[test]
+    fn undo_rna_edit_keep_range_skips_utr_edits() {
+        // Edit outside the CDS window — skipped silently so the CDS reversal
+        // still succeeds when a 3'UTR edit is part of the attribute list.
+        let cds = "ATGAAAGGGCCC"; // 12 nt, 4 codons M K G P
+        let edits = vec![RnaEdit {
+            start: 200, // well past the CDS end
+            end: 199,
+            alt: "TTT".to_string(),
+        }];
+        let recovered = undo_rna_edit_insertions(cds, &edits, 0, Some((1, 12))).expect("no-op");
+        assert_eq!(recovered, cds);
+    }
+
+    #[test]
+    fn translate_cds_table1_stops_at_first_stop() {
+        // ATG TTT TTA TAA AAA → M F L * (stop) — peptide = "MFL".
         assert_eq!(
-            storable_primary_seq_value(Some(&v)).as_deref(),
-            Some("MVFP")
+            translate_cds_table1("ATGTTTTTATAAAAA").as_deref(),
+            Some("MFL")
         );
     }
 
     #[test]
-    fn storable_primary_seq_value_seq_slot() {
-        let mut inner = std::collections::HashMap::new();
-        inner.insert(
-            "seq".to_string(),
-            SValue::String(std::sync::Arc::from("MVFPQA")),
+    fn translate_cds_table1_rejects_non_triplet_length() {
+        assert!(translate_cds_table1("ATGAA").is_none());
+    }
+
+    #[test]
+    fn translate_cds_table1_handles_lowercase_and_ambiguity() {
+        // Lowercase is folded; non-ACGT resolves to None.
+        assert_eq!(translate_cds_table1("atgggg").as_deref(), Some("MG"));
+        assert!(translate_cds_table1("ATGNNN").is_none());
+    }
+
+    #[test]
+    fn derive_canonical_sequences_is_identity_when_no_edits() {
+        let (cds, pep) =
+            derive_canonical_sequences(Some("ATGAAA"), Some("MK"), &[], Some(1), Some(6));
+        assert_eq!(cds.as_deref(), Some("ATGAAA"));
+        assert_eq!(pep.as_deref(), Some("MK"));
+    }
+
+    #[test]
+    fn derive_canonical_sequences_reverses_cds_and_retranslates() {
+        // Miniature HTT-style: pre-edit CDS encodes M Q P (9 nt).
+        // BAM edit inserts "CAG" (1 Q) between cdna 6 and 7 → edited encodes
+        // M Q Q P (12 nt). Canonical recovery drops the Q back to M Q P.
+        let edited_cds = "ATGCAGCAGCCC"; // 12 nt = MQQP
+        let edited_peptide = "MQQP";
+        let edits = vec![RnaEdit::parse("7 6 CAG").unwrap()];
+        let (cds, pep) = derive_canonical_sequences(
+            Some(edited_cds),
+            Some(edited_peptide),
+            &edits,
+            Some(1),
+            Some(12),
         );
-        let v = SValue::Hash(std::sync::Arc::new(inner));
+        assert_eq!(cds.as_deref(), Some("ATGCAGCCC"));
+        assert_eq!(pep.as_deref(), Some("MQP"));
+    }
+
+    #[test]
+    fn derive_canonical_sequences_returns_none_cds_when_edit_irreversible() {
+        // Substitution-shape edit → canonical CDS can't be recovered → None.
+        let edits = vec![RnaEdit {
+            start: 4,
+            end: 4,
+            alt: "X".to_string(),
+        }];
+        let (cds, pep) =
+            derive_canonical_sequences(Some("ATGXAA"), Some("MK"), &edits, Some(1), Some(6));
+        assert!(
+            cds.is_none(),
+            "canonical CDS must be None when unreversible"
+        );
+        // Peptide still falls back to the BAM-edited peptide rather than being
+        // left null — downstream HGVSp consumers can still render *something*.
+        assert_eq!(pep.as_deref(), Some("MK"));
+    }
+
+    // -----------------------------------------------------------------------
+    // HTT polyQ regression against a real VEP merged cache sample.
+    //
+    // Ignored by default because it reaches into an absolute path outside the
+    // repo. Run locally with:
+    //   cargo test --lib translation::tests::htt_canonical_from_real_merged_cache \
+    //     -- --ignored --nocapture
+    // -----------------------------------------------------------------------
+    #[test]
+    #[ignore = "requires /Users/mwiewior/workspace/data_vepyr/homo_sapiens_merged cache"]
+    fn htt_canonical_from_real_merged_cache() {
+        let path = std::path::Path::new(
+            "/Users/mwiewior/workspace/data_vepyr/homo_sapiens_merged/115_GRCh38/4/3000001-4000000.gz",
+        );
+        if !path.exists() {
+            println!("SKIP: cache not found at {}", path.display());
+            return;
+        }
+        let reader = open_binary_reader(path).expect("open reader");
+        let (alias_counts, entry_keys) =
+            collect_nstore_alias_counts_and_top_keys_from_reader(reader).expect("aliases");
+        let reader = open_binary_reader(path).expect("open reader 2");
+
+        let mut refseq_canonical: Option<String> = None;
+        let mut refseq_edited: Option<String> = None;
+        let mut ensembl_canonical: Option<String> = None;
+        let mut ensembl_edited: Option<String> = None;
+
+        stream_nstore_top_hash_array_items_keyed_with_alias_counts_from_reader(
+            reader,
+            alias_counts,
+            entry_keys,
+            |_region, item| {
+                let Some(obj) = item.as_hash() else {
+                    return Ok(true);
+                };
+                let stable_id = sv_str(obj.get("stable_id")).unwrap_or_default();
+                if !matches!(stable_id.as_str(), "NM_002111.8" | "ENST00000355072") {
+                    return Ok(true);
+                }
+                let vef_cache = obj
+                    .get("_variation_effect_feature_cache")
+                    .and_then(SValue::as_hash);
+                let edited_cds = vef_cache.and_then(|c| sv_str(c.get("translateable_seq")));
+                let edited_peptide = vef_cache.and_then(|c| sv_str(c.get("peptide")));
+                let edits = parse_rna_edits_storable(obj.get("attributes"));
+                let cdna_coding_start = sv_i64(obj.get("cdna_coding_start"));
+                let cdna_coding_end = sv_i64(obj.get("cdna_coding_end"));
+                let (cds_canon, pep_canon) = derive_canonical_sequences(
+                    edited_cds.as_deref(),
+                    edited_peptide.as_deref(),
+                    &edits,
+                    cdna_coding_start,
+                    cdna_coding_end,
+                );
+                match stable_id.as_str() {
+                    "NM_002111.8" => {
+                        refseq_edited = edited_peptide;
+                        refseq_canonical = pep_canon;
+                        println!(
+                            "NM_002111.8 edited_cds_len={:?} canonical_cds_len={:?}",
+                            edited_cds.as_ref().map(|s| s.len()),
+                            cds_canon.as_ref().map(|s| s.len()),
+                        );
+                    }
+                    "ENST00000355072" => {
+                        ensembl_edited = edited_peptide;
+                        ensembl_canonical = pep_canon;
+                    }
+                    _ => {}
+                }
+                Ok(true)
+            },
+        )
+        .expect("stream");
+
+        // Ensembl has no BAM edits → canonical must equal edited exactly.
+        let ensembl_edited = ensembl_edited.expect("Ensembl ENST00000355072 not found");
+        let ensembl_canonical = ensembl_canonical.expect("Ensembl canonical missing");
+        assert_eq!(ensembl_edited, ensembl_canonical);
         assert_eq!(
-            storable_primary_seq_value(Some(&v)).as_deref(),
-            Some("MVFPQA")
+            ensembl_edited.len(),
+            3142,
+            "Ensembl HTT peptide should be 3142 AA (21-Q canonical)"
         );
-    }
 
-    #[test]
-    fn storable_primary_seq_value_nested_primary_seq() {
-        let mut primary = std::collections::HashMap::new();
-        primary.insert(
-            "seq".to_string(),
-            SValue::String(std::sync::Arc::from("MVFPQAK")),
-        );
-        let mut outer = std::collections::HashMap::new();
-        outer.insert(
-            "primary_seq".to_string(),
-            SValue::Hash(std::sync::Arc::new(primary)),
-        );
-        let v = SValue::Hash(std::sync::Arc::new(outer));
+        // RefSeq NM_002111.8 has an _rna_edit that inserts 2 Qs. Edited = 3144,
+        // canonical = 3142 once we reverse the edit. And the two sequences must
+        // differ by exactly two Q insertions at the polyQ tract.
+        let refseq_edited = refseq_edited.expect("NM_002111.8 not found");
+        let refseq_canonical = refseq_canonical.expect("NM_002111.8 canonical missing");
         assert_eq!(
-            storable_primary_seq_value(Some(&v)).as_deref(),
-            Some("MVFPQAK")
+            refseq_edited.len(),
+            3144,
+            "BAM-edited NP_002102.4 = 3144 AA"
         );
-    }
+        assert_eq!(
+            refseq_canonical.len(),
+            3142,
+            "canonical NP_002102.4 (BAM edit reversed) = 3142 AA"
+        );
+        // Canonical NP_002102.4 should match Ensembl ENSP00000347184's peptide
+        // (both come from the same GRCh38-derived CDS).
+        assert_eq!(
+            refseq_canonical, ensembl_canonical,
+            "RefSeq canonical peptide must equal Ensembl's peptide at the same locus"
+        );
 
-    #[test]
-    fn storable_primary_seq_value_none_and_missing_seq() {
-        assert!(storable_primary_seq_value(None).is_none());
-        let mut empty = std::collections::HashMap::new();
-        empty.insert(
-            "other".to_string(),
-            SValue::String(std::sync::Arc::from("x")),
+        // Concrete polyQ check: canonical must have 21 Qs at positions 18-38
+        // and P at position 39 (this is what makes VEP's HGVSp say Pro39...).
+        let q_run: String = refseq_canonical[17..]
+            .chars()
+            .take_while(|c| *c == 'Q')
+            .collect();
+        assert_eq!(
+            q_run.len(),
+            21,
+            "canonical HTT polyQ tract should be 21 residues long"
         );
-        let v = SValue::Hash(std::sync::Arc::new(empty));
-        assert!(storable_primary_seq_value(Some(&v)).is_none());
+        assert_eq!(
+            refseq_canonical.as_bytes()[38],
+            b'P',
+            "canonical HTT position 39 (0-indexed 38) should be Pro"
+        );
     }
 }

--- a/datafusion/bio-format-ensembl-cache/src/translation.rs
+++ b/datafusion/bio-format-ensembl-cache/src/translation.rs
@@ -36,6 +36,8 @@ pub(crate) struct TranslationColumnIndices {
     cds_len: Option<usize>,
     peptide_seq: Option<usize>,
     cdna_seq: Option<usize>,
+    peptide_seq_canonical: Option<usize>,
+    cdna_seq_canonical: Option<usize>,
     sequences_projected: bool,
     protein_features: Option<usize>,
     protein_features_projected: bool,
@@ -52,7 +54,12 @@ impl TranslationColumnIndices {
         let cdna_coding_end = col_map.get("cdna_coding_end");
         let peptide_seq = col_map.get("translation_seq");
         let cdna_seq = col_map.get("cds_sequence");
-        let sequences_projected = peptide_seq.is_some() || cdna_seq.is_some();
+        let peptide_seq_canonical = col_map.get("translation_seq_canonical");
+        let cdna_seq_canonical = col_map.get("cds_sequence_canonical");
+        let sequences_projected = peptide_seq.is_some()
+            || cdna_seq.is_some()
+            || peptide_seq_canonical.is_some()
+            || cdna_seq_canonical.is_some();
         let protein_features = col_map.get("protein_features");
         let protein_features_projected = protein_features.is_some();
         let sift_predictions = col_map.get("sift_predictions");
@@ -74,6 +81,8 @@ impl TranslationColumnIndices {
             cds_len: col_map.get("cds_len"),
             peptide_seq,
             cdna_seq,
+            peptide_seq_canonical,
+            cdna_seq_canonical,
             sequences_projected,
             protein_features,
             protein_features_projected,
@@ -271,12 +280,22 @@ pub(crate) fn parse_translation_line_into(
         let vef_cache = object
             .get("_variation_effect_feature_cache")
             .and_then(unwrap_blessed_object_optional);
+        let edited_peptide = vef_cache.and_then(|c| json_str(c.get("peptide")));
+        let edited_cds = vef_cache.and_then(|c| json_str(c.get("translateable_seq")));
         if let Some(idx) = col_idx.peptide_seq {
-            let value = vef_cache.and_then(|c| json_str(c.get("peptide")));
-            batch.set_opt_utf8_owned(idx, value.as_ref());
+            batch.set_opt_utf8_owned(idx, edited_peptide.as_ref());
         }
         if let Some(idx) = col_idx.cdna_seq {
-            let value = vef_cache.and_then(|c| json_str(c.get("translateable_seq")));
+            batch.set_opt_utf8_owned(idx, edited_cds.as_ref());
+        }
+        if let Some(idx) = col_idx.peptide_seq_canonical {
+            let value = json_primary_seq_value(translation_obj.get("primary_seq"))
+                .or_else(|| edited_peptide.clone());
+            batch.set_opt_utf8_owned(idx, value.as_ref());
+        }
+        if let Some(idx) = col_idx.cdna_seq_canonical {
+            let value = json_primary_seq_value(object.get("translateable_seq"))
+                .or_else(|| edited_cds.clone());
             batch.set_opt_utf8_owned(idx, value.as_ref());
         }
         if let Some(idx) = col_idx.protein_features {
@@ -455,38 +474,51 @@ where
         }
 
         // Sequences, protein features, and predictions from _variation_effect_feature_cache.
-        if (col_idx.sequences_projected
+        if col_idx.sequences_projected
             || col_idx.protein_features_projected
-            || col_idx.predictions_projected)
-            && let Some(vef_cache) = obj
-                .get("_variation_effect_feature_cache")
-                .and_then(SValue::as_hash)
+            || col_idx.predictions_projected
         {
+            let vef_cache = obj
+                .get("_variation_effect_feature_cache")
+                .and_then(SValue::as_hash);
+            let edited_peptide = vef_cache.and_then(|c| sv_str(c.get("peptide")));
+            let edited_cds = vef_cache.and_then(|c| sv_str(c.get("translateable_seq")));
+
             if let Some(idx) = col_idx.peptide_seq {
-                let value = sv_str(vef_cache.get("peptide"));
-                batch.set_opt_utf8_owned(idx, value.as_ref());
+                batch.set_opt_utf8_owned(idx, edited_peptide.as_ref());
             }
             if let Some(idx) = col_idx.cdna_seq {
-                let value = sv_str(vef_cache.get("translateable_seq"));
+                batch.set_opt_utf8_owned(idx, edited_cds.as_ref());
+            }
+            if let Some(idx) = col_idx.peptide_seq_canonical {
+                let value = storable_primary_seq_value(translation_obj.get("primary_seq"))
+                    .or_else(|| edited_peptide.clone());
                 batch.set_opt_utf8_owned(idx, value.as_ref());
             }
-            if let Some(idx) = col_idx.protein_features {
-                let features = extract_protein_features_storable(vef_cache);
-                batch.set_protein_feature_list(idx, features.as_deref());
+            if let Some(idx) = col_idx.cdna_seq_canonical {
+                let value = storable_primary_seq_value(obj.get("translateable_seq"))
+                    .or_else(|| edited_cds.clone());
+                batch.set_opt_utf8_owned(idx, value.as_ref());
             }
-            // SIFT/PolyPhen predictions — populated from pre-decoded data.
-            if col_idx.predictions_projected {
-                let pfp = vef_cache
-                    .get("protein_function_predictions")
-                    .and_then(SValue::as_hash);
-                if let Some(idx) = col_idx.sift_predictions {
-                    let preds = pfp.and_then(|p| extract_predictions_storable(p, "sift"));
-                    batch.set_prediction_list(idx, preds.as_deref());
+            if let Some(vef_cache) = vef_cache {
+                if let Some(idx) = col_idx.protein_features {
+                    let features = extract_protein_features_storable(vef_cache);
+                    batch.set_protein_feature_list(idx, features.as_deref());
                 }
-                if let Some(idx) = col_idx.polyphen_predictions {
-                    let preds =
-                        pfp.and_then(|p| extract_predictions_storable(p, "polyphen_humvar"));
-                    batch.set_prediction_list(idx, preds.as_deref());
+                // SIFT/PolyPhen predictions — populated from pre-decoded data.
+                if col_idx.predictions_projected {
+                    let pfp = vef_cache
+                        .get("protein_function_predictions")
+                        .and_then(SValue::as_hash);
+                    if let Some(idx) = col_idx.sift_predictions {
+                        let preds = pfp.and_then(|p| extract_predictions_storable(p, "sift"));
+                        batch.set_prediction_list(idx, preds.as_deref());
+                    }
+                    if let Some(idx) = col_idx.polyphen_predictions {
+                        let preds =
+                            pfp.and_then(|p| extract_predictions_storable(p, "polyphen_humvar"));
+                        batch.set_prediction_list(idx, preds.as_deref());
+                    }
                 }
             }
         }
@@ -813,6 +845,40 @@ fn extract_predictions_storable(
     } else {
         Some(entries)
     }
+}
+
+/// Unwrap a Perl sequence value into a plain `String`.
+///
+/// Storable caches represent sequences either as raw scalars or as blessed
+/// `Bio::PrimarySeq` objects — sometimes doubly nested (outer object's
+/// `primary_seq` holding the actual payload). Mirrors the equivalent helper
+/// in `transcript.rs`.
+fn json_primary_seq_value(value: Option<&serde_json::Value>) -> Option<String> {
+    let value = value?;
+    if let Some(s) = json_str(Some(value)) {
+        return Some(s);
+    }
+    let obj = unwrap_blessed_object_optional(value)?;
+    if let Some(s) = json_str(obj.get("seq")) {
+        return Some(s);
+    }
+    obj.get("primary_seq")
+        .and_then(unwrap_blessed_object_optional)
+        .and_then(|primary| json_str(primary.get("seq")))
+}
+
+fn storable_primary_seq_value(value: Option<&SValue>) -> Option<String> {
+    let value = value?;
+    if let Some(s) = sv_str(Some(value)) {
+        return Some(s);
+    }
+    let obj = value.as_hash()?;
+    if let Some(s) = sv_str(obj.get("seq")) {
+        return Some(s);
+    }
+    obj.get("primary_seq")
+        .and_then(SValue::as_hash)
+        .and_then(|primary| sv_str(primary.get("seq")))
 }
 
 fn unwrap_blessed_object(
@@ -1164,5 +1230,104 @@ mod tests {
             SValue::Array(std::sync::Arc::new(vec![])),
         );
         assert!(extract_protein_features_storable(&vef_cache).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // json_primary_seq_value / storable_primary_seq_value
+    //
+    // Canonical (pre-BAM-edit) translation and CDS live in Perl fields that
+    // VEP stores in one of three shapes: plain string, blessed Bio::PrimarySeq
+    // with a `seq` slot, or a transcript-level object whose `primary_seq` slot
+    // itself wraps a Bio::PrimarySeq. These helpers normalize all three.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn json_primary_seq_value_plain_string() {
+        let v = serde_json::json!("MVFP");
+        assert_eq!(json_primary_seq_value(Some(&v)).as_deref(), Some("MVFP"));
+    }
+
+    #[test]
+    fn json_primary_seq_value_blessed_seq_slot() {
+        let v = serde_json::json!({
+            "__class": "Bio::PrimarySeq",
+            "__value": { "seq": "MVFPQA" }
+        });
+        assert_eq!(json_primary_seq_value(Some(&v)).as_deref(), Some("MVFPQA"));
+    }
+
+    #[test]
+    fn json_primary_seq_value_nested_primary_seq() {
+        let v = serde_json::json!({
+            "__class": "Bio::EnsEMBL::Translation",
+            "__value": {
+                "primary_seq": {
+                    "__class": "Bio::PrimarySeq",
+                    "__value": { "seq": "MVFPQAK" }
+                }
+            }
+        });
+        assert_eq!(json_primary_seq_value(Some(&v)).as_deref(), Some("MVFPQAK"));
+    }
+
+    #[test]
+    fn json_primary_seq_value_none_and_missing_seq() {
+        assert!(json_primary_seq_value(None).is_none());
+        let empty_obj = serde_json::json!({ "other": "field" });
+        assert!(json_primary_seq_value(Some(&empty_obj)).is_none());
+    }
+
+    #[test]
+    fn storable_primary_seq_value_plain_string() {
+        let v = SValue::String(std::sync::Arc::from("MVFP"));
+        assert_eq!(
+            storable_primary_seq_value(Some(&v)).as_deref(),
+            Some("MVFP")
+        );
+    }
+
+    #[test]
+    fn storable_primary_seq_value_seq_slot() {
+        let mut inner = std::collections::HashMap::new();
+        inner.insert(
+            "seq".to_string(),
+            SValue::String(std::sync::Arc::from("MVFPQA")),
+        );
+        let v = SValue::Hash(std::sync::Arc::new(inner));
+        assert_eq!(
+            storable_primary_seq_value(Some(&v)).as_deref(),
+            Some("MVFPQA")
+        );
+    }
+
+    #[test]
+    fn storable_primary_seq_value_nested_primary_seq() {
+        let mut primary = std::collections::HashMap::new();
+        primary.insert(
+            "seq".to_string(),
+            SValue::String(std::sync::Arc::from("MVFPQAK")),
+        );
+        let mut outer = std::collections::HashMap::new();
+        outer.insert(
+            "primary_seq".to_string(),
+            SValue::Hash(std::sync::Arc::new(primary)),
+        );
+        let v = SValue::Hash(std::sync::Arc::new(outer));
+        assert_eq!(
+            storable_primary_seq_value(Some(&v)).as_deref(),
+            Some("MVFPQAK")
+        );
+    }
+
+    #[test]
+    fn storable_primary_seq_value_none_and_missing_seq() {
+        assert!(storable_primary_seq_value(None).is_none());
+        let mut empty = std::collections::HashMap::new();
+        empty.insert(
+            "other".to_string(),
+            SValue::String(std::sync::Arc::from("x")),
+        );
+        let v = SValue::Hash(std::sync::Arc::new(empty));
+        assert!(storable_primary_seq_value(Some(&v)).is_none());
     }
 }

--- a/datafusion/bio-format-ensembl-cache/tests/hgnc_propagation_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/hgnc_propagation_tests.rs
@@ -1,31 +1,32 @@
-//! Tests for cache-region-local HGNC_ID propagation in the cache builder.
+//! Tests for native HGNC_ID handling after removing export-time propagation.
 //!
-//! The cache builder should only propagate `gene_hgnc_id` within the same
-//! VEP-sized cache region for a `(chrom, gene_symbol)` cluster. This preserves
-//! local colocated loci such as FGF7P3 while avoiding false positives across
-//! distant same-symbol loci such as SNORA75, SNORA72, and LINC03025.
+//! The cache builder no longer propagates `gene_hgnc_id` at export time.
+//! Both `gene_hgnc_id` and `gene_hgnc_id_native` now store the value parsed
+//! directly from the raw VEP cache object. Any propagation belongs to the
+//! downstream annotation engine (buffer-scoped, matching VEP behavior).
 
 use datafusion::arrow::array::{Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::SessionContext;
-use datafusion_bio_format_ensembl_cache::VEP_CACHE_REGION_SIZE_BP;
 use std::sync::Arc;
-type PropagationInput<'a> = (&'a str, &'a str, i64, Option<&'a str>, Option<&'a str>);
-type PropagationResult = (String, Option<String>, Option<String>);
+type NativeInput<'a> = (&'a str, &'a str, i64, Option<&'a str>, Option<&'a str>);
+type NativeResult = (String, Option<String>, Option<String>, Option<String>);
 
-/// Build a minimal transcript-like table and run the HGNC propagation query.
+/// Build a minimal transcript-like table and query both gene_hgnc_id and
+/// gene_hgnc_id_native (both pass through without propagation).
 ///
-/// Returns the result rows as `(stable_id, gene_symbol, gene_hgnc_id)`.
-async fn run_propagation(
-    rows: Vec<PropagationInput<'_>>, // (stable_id, chrom, start, gene_symbol, gene_hgnc_id)
-) -> Vec<PropagationResult> {
+/// Returns `(stable_id, gene_symbol, gene_hgnc_id, gene_hgnc_id_native)`.
+async fn run_native_query(
+    rows: Vec<NativeInput<'_>>, // (stable_id, chrom, start, gene_symbol, gene_hgnc_id)
+) -> Vec<NativeResult> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("stable_id", DataType::Utf8, false),
         Field::new("chrom", DataType::Utf8, false),
         Field::new("start", DataType::Int64, false),
         Field::new("gene_symbol", DataType::Utf8, true),
         Field::new("gene_hgnc_id", DataType::Utf8, true),
+        Field::new("gene_hgnc_id_native", DataType::Utf8, true),
     ]));
 
     let stable_ids: Vec<&str> = rows.iter().map(|r| r.0).collect();
@@ -33,6 +34,8 @@ async fn run_propagation(
     let starts: Vec<i64> = rows.iter().map(|r| r.2).collect();
     let gene_symbols: Vec<Option<&str>> = rows.iter().map(|r| r.3).collect();
     let gene_hgnc_ids: Vec<Option<&str>> = rows.iter().map(|r| r.4).collect();
+    // gene_hgnc_id_native mirrors gene_hgnc_id (same native value)
+    let gene_hgnc_ids_native: Vec<Option<&str>> = rows.iter().map(|r| r.4).collect();
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -42,6 +45,7 @@ async fn run_propagation(
             Arc::new(datafusion::arrow::array::Int64Array::from(starts)),
             Arc::new(StringArray::from(gene_symbols)),
             Arc::new(StringArray::from(gene_hgnc_ids)),
+            Arc::new(StringArray::from(gene_hgnc_ids_native)),
         ],
     )
     .unwrap();
@@ -51,20 +55,12 @@ async fn run_propagation(
     let ctx = SessionContext::new();
     ctx.register_table("tx", Arc::new(mem_table)).unwrap();
 
-    let region_expr = format!("CAST(FLOOR((start - 1) / {VEP_CACHE_REGION_SIZE_BP}.0) AS BIGINT)");
-    let query = format!(
-        "SELECT \"stable_id\", \"gene_symbol\", \
-                COALESCE(gene_hgnc_id, \
-                     CASE WHEN gene_symbol IS NOT NULL \
-                          THEN FIRST_VALUE(gene_hgnc_id) IGNORE NULLS \
-                               OVER (PARTITION BY chrom, gene_symbol, {region_expr} \
-                                      ORDER BY gene_hgnc_id NULLS LAST) \
-                          ELSE NULL END) AS gene_hgnc_id \
-         FROM tx \
-         ORDER BY stable_id"
-    );
+    // No propagation — just pass through both columns
+    let query = "SELECT \"stable_id\", \"gene_symbol\", \"gene_hgnc_id\", \
+                        \"gene_hgnc_id_native\" \
+                 FROM tx ORDER BY stable_id";
 
-    let batches = ctx.sql(&query).await.unwrap().collect().await.unwrap();
+    let batches = ctx.sql(query).await.unwrap().collect().await.unwrap();
 
     let mut results = Vec::new();
     for batch in &batches {
@@ -83,6 +79,11 @@ async fn run_propagation(
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
+        let hgncs_native = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         for i in 0..batch.num_rows() {
             results.push((
                 ids.value(i).to_string(),
@@ -96,6 +97,11 @@ async fn run_propagation(
                 } else {
                     Some(hgncs.value(i).to_string())
                 },
+                if hgncs_native.is_null(i) {
+                    None
+                } else {
+                    Some(hgncs_native.value(i).to_string())
+                },
             ));
         }
     }
@@ -103,7 +109,7 @@ async fn run_propagation(
 }
 
 /// Helper: find a row by stable_id.
-fn find_row<'a>(results: &'a [PropagationResult], stable_id: &str) -> &'a PropagationResult {
+fn find_row<'a>(results: &'a [NativeResult], stable_id: &str) -> &'a NativeResult {
     results
         .iter()
         .find(|r| r.0 == stable_id)
@@ -114,38 +120,10 @@ fn find_row<'a>(results: &'a [PropagationResult], stable_id: &str) -> &'a Propag
 // Test cases
 // -----------------------------------------------------------------------
 
-/// Basic propagation: one transcript has HGNC_ID, two local siblings with NULL get filled.
+/// Transcripts with native HGNC_ID retain it in both columns.
 #[tokio::test]
-async fn propagation_fills_nulls_within_region() {
-    let results = run_propagation(vec![
-        (
-            "ENST001",
-            "9",
-            39_817_530,
-            Some("FGF7P3"),
-            Some("HGNC:26671"),
-        ),
-        ("ENST002", "9", 39_816_479, Some("FGF7P3"), None),
-        ("ENST003", "9", 39_888_877, Some("FGF7P3"), None),
-    ])
-    .await;
-
-    assert_eq!(results.len(), 3);
-    for row in &results {
-        assert_eq!(
-            row.2.as_deref(),
-            Some("HGNC:26671"),
-            "transcript {} should have HGNC:26671, got {:?}",
-            row.0,
-            row.2
-        );
-    }
-}
-
-/// COALESCE preserves original: transcripts that already have HGNC_ID keep it.
-#[tokio::test]
-async fn no_overwrite_existing_hgnc() {
-    let results = run_propagation(vec![
+async fn native_hgnc_preserved() {
+    let results = run_native_query(vec![
         (
             "ENST001",
             "17",
@@ -166,31 +144,76 @@ async fn no_overwrite_existing_hgnc() {
     assert_eq!(results.len(), 2);
     for row in &results {
         assert_eq!(row.2.as_deref(), Some("HGNC:1100"));
+        assert_eq!(row.3.as_deref(), Some("HGNC:1100"));
+        assert_eq!(
+            row.2, row.3,
+            "gene_hgnc_id and gene_hgnc_id_native must match"
+        );
     }
 }
 
-/// NULL gene_symbol: transcripts with NULL symbol must NOT get HGNC_ID propagated.
+/// Transcripts without native HGNC_ID stay NULL — no propagation from siblings.
+#[tokio::test]
+async fn no_propagation_from_local_siblings() {
+    let results = run_native_query(vec![
+        (
+            "ENST001",
+            "9",
+            39_817_530,
+            Some("FGF7P3"),
+            Some("HGNC:26671"),
+        ),
+        ("ENST002", "9", 39_816_479, Some("FGF7P3"), None),
+        ("ENST003", "9", 39_888_877, Some("FGF7P3"), None),
+    ])
+    .await;
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(
+        find_row(&results, "ENST001").2.as_deref(),
+        Some("HGNC:26671")
+    );
+    // No propagation — siblings without native HGNC stay NULL
+    assert_eq!(
+        find_row(&results, "ENST002").2,
+        None,
+        "sibling without native HGNC_ID should stay NULL"
+    );
+    assert_eq!(
+        find_row(&results, "ENST003").2,
+        None,
+        "sibling without native HGNC_ID should stay NULL"
+    );
+    // gene_hgnc_id_native always matches gene_hgnc_id
+    for row in &results {
+        assert_eq!(
+            row.2, row.3,
+            "gene_hgnc_id and gene_hgnc_id_native must match"
+        );
+    }
+}
+
+/// NULL gene_symbol transcripts stay NULL.
 #[tokio::test]
 async fn null_gene_symbol_stays_null() {
-    let results = run_propagation(vec![
+    let results = run_native_query(vec![
         ("ENST001", "1", 100_000, Some("ABC"), Some("HGNC:999")),
-        ("ENST002", "1", 120_000, None, None), // NULL symbol — should stay NULL
+        ("ENST002", "1", 120_000, None, None),
     ])
     .await;
 
     assert_eq!(results.len(), 2);
     assert_eq!(find_row(&results, "ENST001").2.as_deref(), Some("HGNC:999"));
-    assert_eq!(
-        find_row(&results, "ENST002").2,
-        None,
-        "NULL-symbol transcript should not get HGNC_ID"
-    );
+    assert_eq!(find_row(&results, "ENST002").2, None);
+    for row in &results {
+        assert_eq!(row.2, row.3);
+    }
 }
 
 /// All transcripts for a symbol have NULL HGNC_ID: nothing changes.
 #[tokio::test]
 async fn all_null_hgnc_stays_null() {
-    let results = run_propagation(vec![
+    let results = run_native_query(vec![
         ("ENST001", "1", 100_000, Some("UNKNOWN"), None),
         ("ENST002", "1", 120_000, Some("UNKNOWN"), None),
         ("ENST003", "1", 130_000, Some("UNKNOWN"), None),
@@ -200,33 +223,18 @@ async fn all_null_hgnc_stays_null() {
     assert_eq!(results.len(), 3);
     for row in &results {
         assert_eq!(row.2, None, "transcript {} should remain NULL", row.0);
+        assert_eq!(
+            row.3, None,
+            "native column for {} should remain NULL",
+            row.0
+        );
     }
 }
 
-/// Multiple gene symbols: propagation is independent per symbol.
+/// Distant same-symbol loci: no cross-fill (was the original bug).
 #[tokio::test]
-async fn multiple_symbols_independent() {
-    let results = run_propagation(vec![
-        // Symbol A: one has HGNC, one doesn't
-        ("ENST001", "1", 100_000, Some("GENE_A"), Some("HGNC:100")),
-        ("ENST002", "1", 120_000, Some("GENE_A"), None),
-        // Symbol B: one has HGNC, one doesn't
-        ("ENST003", "1", 200_000, Some("GENE_B"), Some("HGNC:200")),
-        ("ENST004", "1", 220_000, Some("GENE_B"), None),
-    ])
-    .await;
-
-    assert_eq!(results.len(), 4);
-    assert_eq!(find_row(&results, "ENST001").2.as_deref(), Some("HGNC:100"));
-    assert_eq!(find_row(&results, "ENST002").2.as_deref(), Some("HGNC:100"));
-    assert_eq!(find_row(&results, "ENST003").2.as_deref(), Some("HGNC:200"));
-    assert_eq!(find_row(&results, "ENST004").2.as_deref(), Some("HGNC:200"));
-}
-
-/// Distant same-symbol loci must not cross-fill across cache regions.
-#[tokio::test]
-async fn distant_same_symbol_does_not_propagate() {
-    let results = run_propagation(vec![
+async fn distant_same_symbol_no_cross_fill() {
+    let results = run_native_query(vec![
         (
             "ENST001",
             "9",
@@ -244,16 +252,16 @@ async fn distant_same_symbol_does_not_propagate() {
         Some("HGNC:56158")
     );
     assert_eq!(
-        find_row(&results, "ENST002").2.as_deref(),
+        find_row(&results, "ENST002").2,
         None,
-        "distant same-symbol locus should not inherit HGNC"
+        "distant same-symbol locus must not inherit HGNC"
     );
 }
 
-/// Same-symbol rows on different chromosomes must not cross-fill.
+/// Same-symbol rows on different chromosomes: no cross-fill.
 #[tokio::test]
-async fn same_symbol_different_chroms_do_not_propagate() {
-    let results = run_propagation(vec![
+async fn same_symbol_different_chroms_no_cross_fill() {
+    let results = run_native_query(vec![
         (
             "ENST001",
             "2",
@@ -277,11 +285,36 @@ async fn same_symbol_different_chroms_do_not_propagate() {
     );
 }
 
-/// Mixed: local propagation + gene without any HGNC + NULL-symbol row.
+/// Multiple gene symbols: each transcript retains only its own native value.
+#[tokio::test]
+async fn multiple_symbols_independent() {
+    let results = run_native_query(vec![
+        ("ENST001", "1", 100_000, Some("GENE_A"), Some("HGNC:100")),
+        ("ENST002", "1", 120_000, Some("GENE_A"), None),
+        ("ENST003", "1", 200_000, Some("GENE_B"), Some("HGNC:200")),
+        ("ENST004", "1", 220_000, Some("GENE_B"), None),
+    ])
+    .await;
+
+    assert_eq!(results.len(), 4);
+    assert_eq!(find_row(&results, "ENST001").2.as_deref(), Some("HGNC:100"));
+    assert_eq!(
+        find_row(&results, "ENST002").2,
+        None,
+        "no propagation from GENE_A sibling"
+    );
+    assert_eq!(find_row(&results, "ENST003").2.as_deref(), Some("HGNC:200"));
+    assert_eq!(
+        find_row(&results, "ENST004").2,
+        None,
+        "no propagation from GENE_B sibling"
+    );
+}
+
+/// Mixed scenario: native values preserved, no propagation, NULL-symbol safe.
 #[tokio::test]
 async fn mixed_scenario() {
-    let results = run_propagation(vec![
-        // FGF7P3-like local locus: one HGNC source, one colocated EntrezGene row.
+    let results = run_native_query(vec![
         (
             "ENST001",
             "9",
@@ -290,27 +323,38 @@ async fn mixed_scenario() {
             Some("HGNC:26671"),
         ),
         ("ENST002", "9", 39_816_479, Some("FGF7P3"), None),
-        // Gene with no HGNC at all
         ("ENST003", "9", 50_000_000, Some("NOVELGENE"), None),
-        // NULL symbol
         ("ENST004", "9", 60_000_000, None, None),
     ])
     .await;
 
     assert_eq!(results.len(), 4);
     assert_eq!(
-        find_row(&results, "ENST002").2.as_deref(),
+        find_row(&results, "ENST001").2.as_deref(),
         Some("HGNC:26671"),
-        "local sibling should get propagated HGNC"
+        "native HGNC preserved"
+    );
+    assert_eq!(
+        find_row(&results, "ENST002").2,
+        None,
+        "no propagation from sibling"
     );
     assert_eq!(
         find_row(&results, "ENST003").2,
         None,
-        "gene with no HGNC should stay NULL"
+        "gene with no HGNC stays NULL"
     );
     assert_eq!(
         find_row(&results, "ENST004").2,
         None,
-        "NULL-symbol should stay NULL"
+        "NULL-symbol stays NULL"
     );
+    // All rows: gene_hgnc_id == gene_hgnc_id_native
+    for row in &results {
+        assert_eq!(
+            row.2, row.3,
+            "gene_hgnc_id and gene_hgnc_id_native must match for {}",
+            row.0
+        );
+    }
 }

--- a/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
@@ -12,7 +12,9 @@ use datafusion_bio_format_ensembl_cache::{
     EnsemblCacheOptions, EnsemblCacheTableProvider, EnsemblEntityKind, ExonTableProvider,
     MotifFeatureTableProvider, RegulatoryFeatureTableProvider, TranscriptTableProvider,
     TranslationTableProvider, VEP_CHROMOSOMES_METADATA_KEY, VariationTableProvider,
+    build_export_query,
 };
+use serde_json::Value;
 use std::sync::Arc;
 
 fn fixture_path(name: &str) -> String {
@@ -2872,6 +2874,88 @@ async fn transcript_object_hash_stable_text() -> datafusion::common::Result<()> 
             );
         }
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn transcript_export_hgnc_matches_raw_object_json_text() -> datafusion::common::Result<()> {
+    let provider = TranscriptTableProvider::new(EnsemblCacheOptions::new(fixture_path(
+        "transcript_storable",
+    )))?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("tx", Arc::new(provider))?;
+
+    let schema = Arc::new(ctx.table("tx").await?.schema().as_arrow().clone());
+    let export_query = build_export_query(EnsemblEntityKind::Transcript, "tx", None, Some(&schema));
+    let query = format!(
+        "WITH exported AS ({export_query}) \
+         SELECT stable_id, gene_hgnc_id, raw_object_json FROM exported"
+    );
+
+    let batches = ctx.sql(&query).await?.collect().await?;
+    let mut checked_rows = 0usize;
+    let mut mismatches = Vec::new();
+
+    for batch in &batches {
+        let stable_ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("expected stable_id StringArray");
+        let gene_hgnc_ids = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("expected gene_hgnc_id StringArray");
+        let raw_jsons = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("expected raw_object_json StringArray");
+
+        for i in 0..batch.num_rows() {
+            checked_rows += 1;
+
+            let promoted = if gene_hgnc_ids.is_null(i) {
+                None
+            } else {
+                Some(gene_hgnc_ids.value(i))
+            };
+
+            let raw: Value = serde_json::from_str(raw_jsons.value(i))
+                .expect("raw_object_json should contain valid JSON");
+            let raw_native = match raw
+                .as_object()
+                .and_then(|obj| obj.get("_gene_hgnc_id").or_else(|| obj.get("gene_hgnc_id")))
+            {
+                Some(Value::String(value)) => Some(value.as_str()),
+                Some(Value::Null) | None => None,
+                Some(other) => panic!("unexpected HGNC value in raw_object_json: {other}"),
+            };
+
+            if promoted != raw_native {
+                mismatches.push(format!(
+                    "{}: promoted={promoted:?}, raw_native={raw_native:?}",
+                    stable_ids.value(i)
+                ));
+            }
+        }
+    }
+
+    assert!(checked_rows > 0, "expected exported transcript rows");
+    assert!(
+        mismatches.is_empty(),
+        "exported gene_hgnc_id disagrees with raw_object_json for {} rows: {}",
+        mismatches.len(),
+        mismatches
+            .iter()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("; ")
+    );
 
     Ok(())
 }

--- a/datafusion/bio-format-ensembl-cache/tests/real_vep_cache_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/real_vep_cache_tests.rs
@@ -20,7 +20,7 @@ use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
 use datafusion_bio_format_ensembl_cache::{
     EnsemblCacheOptions, EnsemblCacheTableProvider, EnsemblEntityKind, ExonTableProvider,
     MotifFeatureTableProvider, RegulatoryFeatureTableProvider, TranscriptTableProvider,
-    TranslationTableProvider, VEP_CACHE_REGION_SIZE_BP, VariationTableProvider, build_export_query,
+    TranslationTableProvider, VariationTableProvider, build_export_query,
 };
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -1108,13 +1108,14 @@ async fn real_factory_all_entities() -> datafusion::common::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// HGNC_ID propagation locality (biodatageeks/datafusion-bio-functions#105, #108)
+// HGNC_ID native column (biodatageeks/datafusion-bio-formats#166)
 // ---------------------------------------------------------------------------
 
-/// After applying the HGNC propagation query, every transcript in the same VEP
-/// cache region as an HGNC-bearing sibling should itself have a non-null value.
+/// The export query no longer propagates gene_hgnc_id. Both gene_hgnc_id and
+/// gene_hgnc_id_native should be identical — reflecting the native VEP cache
+/// object value with no backfill.
 #[tokio::test]
-async fn hgnc_propagation_fills_local_siblings() -> datafusion::common::Result<()> {
+async fn hgnc_native_column_matches_gene_hgnc_id() -> datafusion::common::Result<()> {
     let provider = EnsemblCacheTableProvider::for_entity(
         EnsemblEntityKind::Transcript,
         EnsemblCacheOptions::new(fixture_path(REAL_FIXTURE)),
@@ -1126,39 +1127,51 @@ async fn hgnc_propagation_fills_local_siblings() -> datafusion::common::Result<(
     let schema: Arc<datafusion::arrow::datatypes::Schema> =
         Arc::new(ctx.table("tx").await?.schema().as_arrow().clone());
 
-    // Use the same propagation + dedup query used by storable_to_parquet.
-    let propagation_query =
-        build_export_query(EnsemblEntityKind::Transcript, "tx", None, Some(&schema));
+    // Use the same export query used by storable_to_parquet.
+    let export_query = build_export_query(EnsemblEntityKind::Transcript, "tx", None, Some(&schema));
 
-    let region_expr = format!("CAST(FLOOR((start - 1) / {VEP_CACHE_REGION_SIZE_BP}.0) AS BIGINT)");
-
-    // After propagation, count transcripts that still miss gene_hgnc_id even
-    // though the same `(chrom, gene_symbol, 1 Mb region)` contains a sibling
-    // with a non-null value — should be zero.
+    // Every row: gene_hgnc_id must equal gene_hgnc_id_native (both are the
+    // raw VEP object value, no propagation applied).
     let query = format!(
-        "WITH propagated AS (\
-             {propagation_query}\
-         ), local_hgnc AS (\
-             SELECT chrom, gene_symbol, {region_expr} AS hgnc_region \
-             FROM tx \
-             WHERE gene_hgnc_id IS NOT NULL AND gene_symbol IS NOT NULL \
-             GROUP BY chrom, gene_symbol, {region_expr}\
-         ) \
-         SELECT COUNT(*) \
-         FROM propagated p \
-         JOIN local_hgnc l \
-           ON p.chrom = l.chrom \
-          AND p.gene_symbol = l.gene_symbol \
-          AND CAST(FLOOR((p.start - 1) / {VEP_CACHE_REGION_SIZE_BP}.0) AS BIGINT) = l.hgnc_region \
-         WHERE p.gene_hgnc_id IS NULL"
+        "WITH exported AS ({export_query}) \
+         SELECT COUNT(*) FROM exported \
+         WHERE gene_hgnc_id IS DISTINCT FROM gene_hgnc_id_native"
     );
 
     let batches = ctx.sql(&query).await?.collect().await?;
-    let remaining_gaps = first_i64(&batches);
+    let mismatches = first_i64(&batches);
     assert_eq!(
-        remaining_gaps, 0,
-        "after local HGNC propagation, {remaining_gaps} transcripts still missing gene_hgnc_id \
-         despite a sibling in the same cache region having it"
+        mismatches, 0,
+        "{mismatches} rows where gene_hgnc_id differs from gene_hgnc_id_native"
+    );
+
+    Ok(())
+}
+
+/// The gene_hgnc_id_native column should be present in the transcript schema.
+#[tokio::test]
+async fn transcript_schema_has_gene_hgnc_id_native() -> datafusion::common::Result<()> {
+    let provider = EnsemblCacheTableProvider::for_entity(
+        EnsemblEntityKind::Transcript,
+        EnsemblCacheOptions::new(fixture_path(REAL_FIXTURE)),
+    )?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("tx", provider)?;
+
+    let table = ctx.table("tx").await?;
+    let schema = table.schema();
+    let arrow_schema = schema.as_arrow();
+
+    assert!(
+        arrow_schema.column_with_name("gene_hgnc_id").is_some(),
+        "gene_hgnc_id column must exist"
+    );
+    assert!(
+        arrow_schema
+            .column_with_name("gene_hgnc_id_native")
+            .is_some(),
+        "gene_hgnc_id_native column must exist"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- **Remove export-time `gene_hgnc_id` propagation** from the VEP cache transcript export query. The previous `COALESCE`/`FIRST_VALUE` window backfill produced false-positive HGNC_ID annotations for distant loci sharing a `gene_symbol` (SNORA75, SNORA72, LINC03025, NBAS, ANAPC1P1 — 63+ mismatches in parity runs, 281 for NBAS alone on chr2).
- **Add `gene_hgnc_id_native` column** to the transcript schema, parsed directly from the raw VEP cache object. Both `gene_hgnc_id` and `gene_hgnc_id_native` now store the native value with no backfill. The native column provides an explicit provenance marker for downstream consumers.
- **Rationale**: VEP's HGNC propagation is input-buffer dependent (~5000 variants), so the cache builder cannot know the correct propagation scope. The cache should store native facts; buffer-scoped propagation belongs to the downstream annotation engine.

### Files changed

| File | Change |
|------|--------|
| `src/schema.rs` | Add `gene_hgnc_id_native` field to transcript schema |
| `src/transcript.rs` | Populate `gene_hgnc_id_native` in both JSON and Storable parsing paths |
| `src/export_query.rs` | Remove COALESCE/FIRST_VALUE propagation; all columns pass through as-is |
| `tests/hgnc_propagation_tests.rs` | Rewrite tests for no-propagation semantics |
| `tests/real_vep_cache_tests.rs` | Replace propagation test with native-column consistency test |
| `README.md` | Document new column in transcript schema table |

## Test plan

- [x] All 537 ensembl-cache tests pass (unit, integration, parquet roundtrip, real VEP fixture)
- [x] `hgnc_native_column_matches_gene_hgnc_id` — verifies `gene_hgnc_id IS NOT DISTINCT FROM gene_hgnc_id_native` across all exported rows from real VEP 115 GRCh38 fixture data
- [x] `transcript_schema_has_gene_hgnc_id_native` — verifies column exists in schema
- [x] 8 rewritten propagation tests verify: native values preserved, NULL siblings stay NULL, no cross-fill across loci/chroms
- [x] clippy clean, fmt clean, all pre-commit hooks pass
- [ ] Downstream: regenerate VEP parquet cache and verify the 63 SNORA75/SNORA72/LINC03025 false positives are eliminated
- [ ] Downstream: verify NBAS (281) and ANAPC1P1 (13) false positives on chr2 are eliminated

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)