### PR TITLE
fix: exact start indexed VCF regions

### DIFF
--- a/datafusion/bio-format-bam/src/table_provider.rs
+++ b/datafusion/bio-format-bam/src/table_provider.rs
@@ -1001,6 +1001,14 @@ impl TableProvider for BamTableProvider {
         // Determine regions and partitioning when index is available
         if let Some(ref index_path) = self.index_path {
             let analysis = extract_genomic_regions(filters, self.coordinate_system_zero_based);
+
+            if analysis.unsatisfiable {
+                debug!("BAM scan: genomic filters are unsatisfiable, returning empty scan");
+                return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                    schema,
+                )));
+            }
+
             let is_full_scan = analysis.regions.is_empty();
 
             let regions = if !analysis.regions.is_empty() {

--- a/datafusion/bio-format-core/src/genomic_filter.rs
+++ b/datafusion/bio-format-core/src/genomic_filter.rs
@@ -192,8 +192,9 @@ fn collect_genomic_constraints(
                                         *start_lower = Some(
                                             start_lower.map_or(val_1based, |v| v.max(val_1based)),
                                         );
-                                        // For equality on start, also set end if not already set more tightly
-                                        // (The actual end position depends on record length, so this is approximate)
+                                        *end_upper = Some(
+                                            end_upper.map_or(val_1based, |v| v.min(val_1based)),
+                                        );
                                     }
                                     Operator::Gt => {
                                         *start_lower = Some(
@@ -379,6 +380,28 @@ mod tests {
         assert_eq!(analysis.regions.len(), 1);
         assert_eq!(analysis.regions[0].start, Some(1000));
         assert_eq!(analysis.regions[0].end, Some(2000));
+    }
+
+    #[test]
+    fn test_extract_chrom_with_exact_start_bounds_region_zero_based() {
+        let filters = vec![col("chrom").eq(lit("chr1")), col("start").eq(lit(999u32))];
+        let analysis = extract_genomic_regions(&filters, true);
+        assert_eq!(analysis.regions.len(), 1);
+        assert_eq!(analysis.regions[0].chrom, "chr1");
+        assert_eq!(analysis.regions[0].start, Some(1000));
+        assert_eq!(analysis.regions[0].end, Some(1000));
+        assert!(analysis.residual_filters.is_empty());
+    }
+
+    #[test]
+    fn test_extract_chrom_with_exact_start_bounds_region_one_based() {
+        let filters = vec![col("chrom").eq(lit("chr1")), col("start").eq(lit(1000u32))];
+        let analysis = extract_genomic_regions(&filters, false);
+        assert_eq!(analysis.regions.len(), 1);
+        assert_eq!(analysis.regions[0].chrom, "chr1");
+        assert_eq!(analysis.regions[0].start, Some(1000));
+        assert_eq!(analysis.regions[0].end, Some(1000));
+        assert!(analysis.residual_filters.is_empty());
     }
 
     #[test]

--- a/datafusion/bio-format-core/src/genomic_filter.rs
+++ b/datafusion/bio-format-core/src/genomic_filter.rs
@@ -68,7 +68,12 @@ pub fn extract_genomic_regions(
     chroms.sort();
     chroms.dedup();
 
-    let regions = if chroms.is_empty() {
+    let has_valid_bounds = match (start_lower, end_upper) {
+        (Some(start), Some(end)) => start <= end,
+        _ => true,
+    };
+
+    let regions = if chroms.is_empty() || !has_valid_bounds {
         Vec::new()
     } else {
         chroms
@@ -401,6 +406,19 @@ mod tests {
         assert_eq!(analysis.regions[0].chrom, "chr1");
         assert_eq!(analysis.regions[0].start, Some(1000));
         assert_eq!(analysis.regions[0].end, Some(1000));
+        assert!(analysis.residual_filters.is_empty());
+    }
+
+    #[test]
+    fn test_extract_chrom_with_contradictory_start_bounds_skips_invalid_region() {
+        let filters = vec![
+            col("chrom").eq(lit("chr1")),
+            col("start").eq(lit(1000u32)),
+            col("start").gt(lit(1000u32)),
+        ];
+        let analysis = extract_genomic_regions(&filters, false);
+
+        assert!(analysis.regions.is_empty());
         assert!(analysis.residual_filters.is_empty());
     }
 

--- a/datafusion/bio-format-core/src/genomic_filter.rs
+++ b/datafusion/bio-format-core/src/genomic_filter.rs
@@ -26,6 +26,8 @@ pub struct GenomicRegion {
 pub struct GenomicFilterAnalysis {
     /// Regions that can be queried via index (e.g., BAI, CRAI, TBI)
     pub regions: Vec<GenomicRegion>,
+    /// True when genomic coordinate predicates are mutually contradictory.
+    pub unsatisfiable: bool,
     /// Filters that are NOT genomic coordinate filters and should be applied post-read
     pub residual_filters: Vec<Expr>,
     /// All original filters — since index queries are inexact, DataFusion must re-evaluate
@@ -68,12 +70,12 @@ pub fn extract_genomic_regions(
     chroms.sort();
     chroms.dedup();
 
-    let has_valid_bounds = match (start_lower, end_upper) {
-        (Some(start), Some(end)) => start <= end,
-        _ => true,
+    let unsatisfiable = match (start_lower, end_upper) {
+        (Some(start), Some(end)) => start > end,
+        _ => false,
     };
 
-    let regions = if chroms.is_empty() || !has_valid_bounds {
+    let regions = if chroms.is_empty() || unsatisfiable {
         Vec::new()
     } else {
         chroms
@@ -89,6 +91,7 @@ pub fn extract_genomic_regions(
 
     GenomicFilterAnalysis {
         regions,
+        unsatisfiable,
         residual_filters,
         all_filters: filters.to_vec(),
     }
@@ -418,6 +421,7 @@ mod tests {
         ];
         let analysis = extract_genomic_regions(&filters, false);
 
+        assert!(analysis.unsatisfiable);
         assert!(analysis.regions.is_empty());
         assert!(analysis.residual_filters.is_empty());
     }
@@ -438,6 +442,7 @@ mod tests {
         let filters = vec![col("mapping_quality").gt_eq(lit(30u32))];
         let analysis = extract_genomic_regions(&filters, true);
         assert!(analysis.regions.is_empty());
+        assert!(!analysis.unsatisfiable);
         assert_eq!(analysis.residual_filters.len(), 1);
     }
 

--- a/datafusion/bio-format-cram/src/table_provider.rs
+++ b/datafusion/bio-format-cram/src/table_provider.rs
@@ -811,6 +811,13 @@ impl TableProvider for CramTableProvider {
         if let Some(ref index_path) = self.index_path {
             let analysis = extract_genomic_regions(filters, self.coordinate_system_zero_based);
 
+            if analysis.unsatisfiable {
+                debug!("CRAM scan: genomic filters are unsatisfiable, returning empty scan");
+                return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                    schema,
+                )));
+            }
+
             let regions = if !analysis.regions.is_empty() {
                 debug!(
                     "CRAM scan: using {} filter-derived region(s)",

--- a/datafusion/bio-format-gff/src/table_provider.rs
+++ b/datafusion/bio-format-gff/src/table_provider.rs
@@ -281,6 +281,13 @@ impl TableProvider for GffTableProvider {
         if let Some(ref index_path) = self.index_path {
             let analysis = extract_genomic_regions(filters, self.coordinate_system_zero_based);
 
+            if analysis.unsatisfiable {
+                debug!("GFF scan: genomic filters are unsatisfiable, returning empty scan");
+                return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                    projected_schema,
+                )));
+            }
+
             let regions = if !analysis.regions.is_empty() {
                 debug!(
                     "GFF scan: using {} filter-derived region(s)",

--- a/datafusion/bio-format-gtf/src/table_provider.rs
+++ b/datafusion/bio-format-gtf/src/table_provider.rs
@@ -247,6 +247,13 @@ impl TableProvider for GtfTableProvider {
         if let Some(ref index_path) = self.index_path {
             let analysis = extract_genomic_regions(filters, self.coordinate_system_zero_based);
 
+            if analysis.unsatisfiable {
+                debug!("GTF scan: genomic filters are unsatisfiable, returning empty scan");
+                return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                    projected_schema,
+                )));
+            }
+
             let regions = if !analysis.regions.is_empty() {
                 debug!(
                     "GTF scan: using {} filter-derived region(s)",

--- a/datafusion/bio-format-vcf/src/table_provider.rs
+++ b/datafusion/bio-format-vcf/src/table_provider.rs
@@ -844,6 +844,13 @@ impl TableProvider for VcfTableProvider {
         if let Some(ref index_path) = self.index_path {
             let analysis = extract_genomic_regions(filters, self.coordinate_system_zero_based);
 
+            if analysis.unsatisfiable {
+                debug!("VCF scan: genomic filters are unsatisfiable, returning empty scan");
+                return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                    schema,
+                )));
+            }
+
             let regions = if !analysis.regions.is_empty() {
                 debug!(
                     "VCF scan: using {} filter-derived region(s)",

--- a/datafusion/bio-format-vcf/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-vcf/tests/indexed_read_test.rs
@@ -88,7 +88,7 @@ async fn setup_vcf_ctx_without_info_fields() -> datafusion::error::Result<Sessio
         Some(Vec::new()),
         None,
         None,
-        false,
+        false, // 1-based coordinates: matches VCF POS directly.
     )?;
     ctx.register_table("vcf_no_info", Arc::new(provider))?;
     Ok(ctx)
@@ -222,6 +222,7 @@ async fn test_vcf_region_with_positions() -> datafusion::error::Result<()> {
 async fn test_vcf_exact_start_count_with_no_info_fields() -> datafusion::error::Result<()> {
     let ctx = setup_vcf_ctx_without_info_fields().await?;
 
+    // multi_chrom.vcf.gz has one generated variant at 21:5000100.
     let count = count_value(
         &ctx,
         "SELECT COUNT(*) FROM vcf_no_info WHERE chrom = '21' AND start = 5000100",
@@ -229,6 +230,26 @@ async fn test_vcf_exact_start_count_with_no_info_fields() -> datafusion::error::
     .await;
 
     assert_eq!(count, 1, "Expected exactly one variant at 21:5000100");
+
+    Ok(())
+}
+
+/// Test: contradictory start predicates return no rows instead of producing an invalid region.
+#[tokio::test]
+async fn test_vcf_contradictory_exact_start_count_with_no_info_fields()
+-> datafusion::error::Result<()> {
+    let ctx = setup_vcf_ctx_without_info_fields().await?;
+
+    let count = count_value(
+        &ctx,
+        "SELECT COUNT(*) FROM vcf_no_info WHERE chrom = '21' AND start = 5000100 AND start > 5000100",
+    )
+    .await;
+
+    assert_eq!(
+        count, 0,
+        "Contradictory start predicates should match no variants"
+    );
 
     Ok(())
 }

--- a/datafusion/bio-format-vcf/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-vcf/tests/indexed_read_test.rs
@@ -8,7 +8,7 @@
 //!
 //! Uses multi_chrom.vcf.gz: 1000 variants across 21(500), 22(500).
 
-use datafusion::arrow::array::Array;
+use datafusion::arrow::array::{Array, Int64Array, UInt64Array};
 use datafusion::catalog::TableProvider;
 use datafusion::prelude::*;
 use datafusion_bio_format_core::metadata::VCF_CONTIGS_INDEXED_KEY;
@@ -21,6 +21,29 @@ async fn count_rows(ctx: &SessionContext, sql: &str) -> u64 {
     let df = ctx.sql(sql).await.expect("SQL execution failed");
     let batches = df.collect().await.expect("collect failed");
     batches.iter().map(|b| b.num_rows() as u64).sum()
+}
+
+/// Helper: execute a SQL COUNT query and return the scalar count value.
+async fn count_value(ctx: &SessionContext, sql: &str) -> u64 {
+    let df = ctx.sql(sql).await.expect("SQL execution failed");
+    let batches = df.collect().await.expect("collect failed");
+    assert_eq!(batches.len(), 1, "COUNT query should produce one batch");
+    assert_eq!(
+        batches[0].num_rows(),
+        1,
+        "COUNT query should produce one row"
+    );
+    let count_column = batches[0].column(0);
+    if let Some(values) = count_column.as_any().downcast_ref::<UInt64Array>() {
+        values.value(0)
+    } else if let Some(values) = count_column.as_any().downcast_ref::<Int64Array>() {
+        values.value(0) as u64
+    } else {
+        panic!(
+            "expected integer COUNT column, got {:?}",
+            count_column.data_type()
+        );
+    }
 }
 
 /// Helper: collect distinct chrom values from a query result.
@@ -54,6 +77,20 @@ async fn setup_vcf_ctx() -> datafusion::error::Result<SessionContext> {
         true, // zero-based coordinates
     )?;
     ctx.register_table("vcf", Arc::new(provider))?;
+    Ok(ctx)
+}
+
+/// Create a VCF context with INFO columns explicitly disabled, matching info_fields=[].
+async fn setup_vcf_ctx_without_info_fields() -> datafusion::error::Result<SessionContext> {
+    let ctx = SessionContext::new();
+    let provider = VcfTableProvider::new(
+        "tests/multi_chrom.vcf.gz".to_string(),
+        Some(Vec::new()),
+        None,
+        None,
+        false,
+    )?;
+    ctx.register_table("vcf_no_info", Arc::new(provider))?;
     Ok(ctx)
 }
 
@@ -176,6 +213,22 @@ async fn test_vcf_region_with_positions() -> datafusion::error::Result<()> {
         region_count < chr21_total,
         "Region count ({region_count}) should be < chr21 total ({chr21_total})"
     );
+
+    Ok(())
+}
+
+/// Test: exact start equality with info_fields=[] uses a bounded indexed region.
+#[tokio::test]
+async fn test_vcf_exact_start_count_with_no_info_fields() -> datafusion::error::Result<()> {
+    let ctx = setup_vcf_ctx_without_info_fields().await?;
+
+    let count = count_value(
+        &ctx,
+        "SELECT COUNT(*) FROM vcf_no_info WHERE chrom = '21' AND start = 5000100",
+    )
+    .await;
+
+    assert_eq!(count, 1, "Expected exactly one variant at 21:5000100");
 
     Ok(())
 }

--- a/datafusion/bio-format-vcf/tests/indexed_read_test.rs
+++ b/datafusion/bio-format-vcf/tests/indexed_read_test.rs
@@ -254,6 +254,35 @@ async fn test_vcf_contradictory_exact_start_count_with_no_info_fields()
     Ok(())
 }
 
+/// Test: contradictory genomic bounds use an empty plan, not a full indexed scan.
+#[tokio::test]
+async fn test_vcf_contradictory_bounds_use_empty_plan() -> datafusion::error::Result<()> {
+    let ctx = SessionContext::new();
+    let state = ctx.state();
+    let provider = VcfTableProvider::new(
+        "tests/multi_chrom.vcf.gz".to_string(),
+        Some(Vec::new()),
+        None,
+        None,
+        false,
+    )?;
+    let filters = vec![
+        col("chrom").eq(lit("21")),
+        col("start").eq(lit(5000100u32)),
+        col("start").gt(lit(5000100u32)),
+    ];
+
+    let plan = provider.scan(&state, None, &filters, None).await?;
+
+    assert!(
+        plan.as_any()
+            .is::<datafusion::physical_plan::empty::EmptyExec>(),
+        "contradictory genomic bounds should produce an empty plan instead of a full indexed scan"
+    );
+
+    Ok(())
+}
+
 /// Test: correctness of indexed vs full scan results.
 #[tokio::test]
 async fn test_vcf_indexed_correctness() -> datafusion::error::Result<()> {


### PR DESCRIPTION
## Summary
- Convert `start = X` genomic filters into bounded index regions (`X-X`) instead of open-ended regions.
- Keep DataFusion's original filters available for exact residual evaluation.
- Add unit coverage for zero-based and one-based coordinate extraction.
- Add VCF indexed integration coverage for `COUNT(*)` with `info_fields=[]` and an exact `chrom/start` predicate.

## Validation
- `cargo test -p datafusion-bio-format-core genomic_filter`
- `cargo test -p datafusion-bio-format-vcf --test indexed_read_test`