### PR TITLE
feat: Add VCF and VCF Zarr describe field metadata

### DIFF
--- a/datafusion/bio-format-vcf/src/storage.rs
+++ b/datafusion/bio-format-vcf/src/storage.rs
@@ -580,11 +580,47 @@ pub async fn get_vcf_fields(header: &Header) -> arrow::array::RecordBatch {
         field_descriptions.append_value(field.description());
     }
 
-    for (field_name, field) in header.formats() {
-        field_names.append_value(field_name);
+    let sample_count = header.sample_names().len();
+    if sample_count == 1 {
+        let mut used_names: std::collections::HashSet<String> = [
+            "chrom", "start", "end", "id", "ref", "alt", "qual", "filter",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        used_names.extend(header.infos().keys().map(|name| name.to_string()));
+
+        for (field_name, field) in header.formats() {
+            let column_name = if used_names.contains(field_name.as_str()) {
+                let candidate = format!("fmt_{field_name}");
+                if used_names.contains(&candidate) {
+                    format!("format_{field_name}")
+                } else {
+                    candidate
+                }
+            } else {
+                field_name.to_string()
+            };
+            used_names.insert(column_name.clone());
+
+            field_names.append_value(column_name);
+            field_types.append_value("FORMAT");
+            data_types.append_value(field.ty());
+            field_descriptions.append_value(field.description());
+        }
+    } else if sample_count > 1 && !header.formats().is_empty() {
+        field_names.append_value("genotypes");
         field_types.append_value("FORMAT");
-        data_types.append_value(field.ty());
-        field_descriptions.append_value(field.description());
+        data_types.append_value("Struct");
+        field_descriptions.append_value(format!(
+            "FORMAT fields: {}",
+            header
+                .formats()
+                .keys()
+                .map(|field_name| field_name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
 
     // build RecordBatch

--- a/datafusion/bio-format-vcf/src/storage.rs
+++ b/datafusion/bio-format-vcf/src/storage.rs
@@ -371,15 +371,15 @@ impl VcfRemoteReader {
         match self {
             VcfRemoteReader::BGZF(reader) => {
                 let header = reader.read_header().await?;
-                Ok(get_info_fields(&header).await)
+                Ok(get_vcf_fields(&header).await)
             }
             VcfRemoteReader::GZIP(reader) => {
                 let header = reader.read_header().await?;
-                Ok(get_info_fields(&header).await)
+                Ok(get_vcf_fields(&header).await)
             }
             VcfRemoteReader::PLAIN(reader) => {
                 let header = reader.read_header().await?;
-                Ok(get_info_fields(&header).await)
+                Ok(get_vcf_fields(&header).await)
             }
         }
     }
@@ -491,15 +491,15 @@ impl VcfLocalReader {
         match self {
             VcfLocalReader::BGZF(reader) => {
                 let header = reader.read_header()?;
-                Ok(get_info_fields(&header).await)
+                Ok(get_vcf_fields(&header).await)
             }
             VcfLocalReader::GZIP(reader) => {
                 let header = reader.read_header().await?;
-                Ok(get_info_fields(&header).await)
+                Ok(get_vcf_fields(&header).await)
             }
             VcfLocalReader::PLAIN(reader) => {
                 let header = reader.read_header().await?;
-                Ok(get_info_fields(&header).await)
+                Ok(get_vcf_fields(&header).await)
             }
         }
     }
@@ -558,32 +558,44 @@ pub fn open_local_vcf_sync(
     Ok((reader, header))
 }
 
-/// Extracts INFO field metadata from a VCF header into a RecordBatch.
+/// Extracts INFO and FORMAT field metadata from a VCF header into a RecordBatch.
 ///
 /// # Arguments
 ///
-/// * `header` - The VCF header to extract INFO fields from
+/// * `header` - The VCF header to extract INFO and FORMAT fields from
 ///
 /// # Returns
 ///
-/// A RecordBatch with columns: name (String), type (String), description (String)
-pub async fn get_info_fields(header: &Header) -> arrow::array::RecordBatch {
-    let info_fields = header.infos();
+/// A RecordBatch with columns: name, field_type, data_type, description.
+pub async fn get_vcf_fields(header: &Header) -> arrow::array::RecordBatch {
     let mut field_names = StringBuilder::new();
     let mut field_types = StringBuilder::new();
+    let mut data_types = StringBuilder::new();
     let mut field_descriptions = StringBuilder::new();
-    for (field_name, field) in info_fields {
+
+    for (field_name, field) in header.infos() {
         field_names.append_value(field_name);
-        field_types.append_value(field.ty());
+        field_types.append_value("INFO");
+        data_types.append_value(field.ty());
         field_descriptions.append_value(field.description());
     }
+
+    for (field_name, field) in header.formats() {
+        field_names.append_value(field_name);
+        field_types.append_value("FORMAT");
+        data_types.append_value(field.ty());
+        field_descriptions.append_value(field.description());
+    }
+
     // build RecordBatch
     let field_names = field_names.finish();
     let field_types = field_types.finish();
+    let data_types = data_types.finish();
     let field_descriptions = field_descriptions.finish();
     let schema = arrow::datatypes::Schema::new(vec![
         arrow::datatypes::Field::new("name", arrow::datatypes::DataType::Utf8, false),
-        arrow::datatypes::Field::new("type", arrow::datatypes::DataType::Utf8, false),
+        arrow::datatypes::Field::new("field_type", arrow::datatypes::DataType::Utf8, false),
+        arrow::datatypes::Field::new("data_type", arrow::datatypes::DataType::Utf8, false),
         arrow::datatypes::Field::new("description", arrow::datatypes::DataType::Utf8, false),
     ]);
     arrow::record_batch::RecordBatch::try_new(
@@ -591,6 +603,7 @@ pub async fn get_info_fields(header: &Header) -> arrow::array::RecordBatch {
         vec![
             Arc::new(field_names),
             Arc::new(field_types),
+            Arc::new(data_types),
             Arc::new(field_descriptions),
         ],
     )

--- a/datafusion/bio-format-vcf/src/zarr/mod.rs
+++ b/datafusion/bio-format-vcf/src/zarr/mod.rs
@@ -23,4 +23,5 @@ pub(crate) mod schema;
 pub mod table_provider;
 
 pub use metadata::SUPPORTED_VCF_ZARR_VERSION;
+pub use schema::describe_fields;
 pub use table_provider::{VcfZarrReadOptions, VcfZarrTableProvider};

--- a/datafusion/bio-format-vcf/src/zarr/schema.rs
+++ b/datafusion/bio-format-vcf/src/zarr/schema.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::arrow;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result};
 use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
@@ -47,6 +48,60 @@ pub(crate) fn normalize_read_options(
         coordinate_system_zero_based: options.coordinate_system_zero_based,
         genotype_encoding_raw: options.genotype_encoding_raw,
     })
+}
+
+/// Describes discoverable VCF Zarr INFO and FORMAT fields.
+pub fn describe_fields(path: String) -> Result<arrow::array::RecordBatch> {
+    let metadata = VcfZarrMetadata::open_local(&path)?;
+    let options = normalize_read_options(&metadata, &VcfZarrReadOptions::default())?;
+    let info_fields = options.info_fields.unwrap_or_default();
+    let format_fields = options.format_fields.unwrap_or_default();
+
+    let mut names = arrow::array::StringBuilder::new();
+    let mut field_types = arrow::array::StringBuilder::new();
+    let mut data_types = arrow::array::StringBuilder::new();
+    let mut descriptions = arrow::array::StringBuilder::new();
+
+    for name in info_fields {
+        let raw_array = validate_info_array(&metadata, &name)?;
+        let data_type = logical_info_data_type(&metadata, &raw_array)?;
+        names.append_value(name);
+        field_types.append_value("INFO");
+        data_types.append_value(vcf_field_type_for_data_type(&data_type));
+        descriptions.append_value("");
+    }
+
+    for name in format_fields {
+        let raw_array = validate_format_array(&metadata, &name)?;
+        let data_type = logical_format_data_type(
+            &metadata,
+            &name,
+            &raw_array,
+            VcfZarrReadOptions::default().genotype_encoding_raw,
+        )?;
+        names.append_value(name);
+        field_types.append_value("FORMAT");
+        data_types.append_value(vcf_field_type_for_data_type(&data_type));
+        descriptions.append_value("");
+    }
+
+    let schema = Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("field_type", DataType::Utf8, false),
+        Field::new("data_type", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+    ]);
+
+    arrow::record_batch::RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(names.finish()),
+            Arc::new(field_types.finish()),
+            Arc::new(data_types.finish()),
+            Arc::new(descriptions.finish()),
+        ],
+    )
+    .map_err(DataFusionError::from)
 }
 
 pub(crate) fn build_logical_schema_with_sample_selection(

--- a/datafusion/bio-format-vcf/src/zarr/schema.rs
+++ b/datafusion/bio-format-vcf/src/zarr/schema.rs
@@ -71,18 +71,21 @@ pub fn describe_fields(path: String) -> Result<arrow::array::RecordBatch> {
         descriptions.append_value("");
     }
 
-    for name in format_fields {
-        let raw_array = validate_format_array(&metadata, &name)?;
-        let data_type = logical_format_data_type(
+    for name in &format_fields {
+        let raw_array = validate_format_array(&metadata, name)?;
+        let _ = logical_format_data_type(
             &metadata,
-            &name,
+            name,
             &raw_array,
             VcfZarrReadOptions::default().genotype_encoding_raw,
         )?;
-        names.append_value(name);
+    }
+
+    if !format_fields.is_empty() {
+        names.append_value("genotypes");
         field_types.append_value("FORMAT");
-        data_types.append_value(vcf_field_type_for_data_type(&data_type));
-        descriptions.append_value("");
+        data_types.append_value("Struct");
+        descriptions.append_value(format!("FORMAT fields: {}", format_fields.join(", ")));
     }
 
     let schema = Schema::new(vec![

--- a/datafusion/bio-format-vcf/tests/format_columns_test.rs
+++ b/datafusion/bio-format-vcf/tests/format_columns_test.rs
@@ -3,6 +3,7 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion::catalog::TableProvider;
 use datafusion::prelude::*;
 use datafusion_bio_format_core::object_storage::{CompressionType, ObjectStorageOptions};
+use datafusion_bio_format_vcf::storage::VcfReader;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use std::sync::Arc;
 use tokio::fs;
@@ -44,6 +45,76 @@ fn create_object_storage_options() -> ObjectStorageOptions {
         concurrent_fetches: Some(8),
         compression_type: Some(CompressionType::NONE),
     }
+}
+
+fn describe_rows(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+) -> Vec<(String, String, String)> {
+    let names = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("name should be Utf8");
+    let field_types = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("field_type should be Utf8");
+    let data_types = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("data_type should be Utf8");
+
+    (0..batch.num_rows())
+        .map(|index| {
+            (
+                field_types.value(index).to_string(),
+                names.value(index).to_string(),
+                data_types.value(index).to_string(),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn test_describe_multisample_format_matches_nested_genotypes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file_path = create_test_vcf_file("multi_describe", SAMPLE_VCF_MULTI).await?;
+    let mut reader = VcfReader::new(file_path, Some(create_object_storage_options())).await;
+    let batch = reader.describe().await?;
+    let rows = describe_rows(&batch);
+
+    assert!(rows.contains(&("INFO".to_string(), "DP".to_string(), "Integer".to_string())));
+    assert!(rows.contains(&(
+        "FORMAT".to_string(),
+        "genotypes".to_string(),
+        "Struct".to_string()
+    )));
+    assert!(!rows.iter().any(|row| row.0 == "FORMAT" && row.1 == "GT"));
+    assert!(!rows.iter().any(|row| row.0 == "FORMAT" && row.1 == "DP"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_describe_single_sample_format_uses_collision_column_names()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file_path =
+        create_test_vcf_file("single_collision_describe", SAMPLE_VCF_SINGLE_COLLISION).await?;
+    let mut reader = VcfReader::new(file_path, Some(create_object_storage_options())).await;
+    let batch = reader.describe().await?;
+    let rows = describe_rows(&batch);
+
+    assert!(rows.contains(&("FORMAT".to_string(), "GT".to_string(), "String".to_string())));
+    assert!(rows.contains(&(
+        "FORMAT".to_string(),
+        "fmt_DP".to_string(),
+        "Integer".to_string()
+    )));
+    assert!(!rows.iter().any(|row| row.0 == "FORMAT" && row.1 == "DP"));
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/datafusion/bio-format-vcf/tests/vcf_zarr_provider_test.rs
+++ b/datafusion/bio-format-vcf/tests/vcf_zarr_provider_test.rs
@@ -15,7 +15,7 @@ use datafusion_bio_format_core::metadata::{
     VCF_FILE_FORMAT_KEY, VCF_GENOTYPES_SAMPLE_NAMES_KEY, VCF_SAMPLE_NAMES_KEY, from_json_string,
 };
 use datafusion_bio_format_vcf::zarr::{
-    SUPPORTED_VCF_ZARR_VERSION, VcfZarrReadOptions, VcfZarrTableProvider,
+    SUPPORTED_VCF_ZARR_VERSION, VcfZarrReadOptions, VcfZarrTableProvider, describe_fields,
 };
 use futures::TryStreamExt;
 use zarrs::array::Array as ZarrArray;
@@ -347,6 +347,39 @@ fn sampled_format_store() -> tempfile::TempDir {
         ((sample + 1) * 1_000 + row) as i32
     });
     temp_dir
+}
+
+#[test]
+fn vcf_zarr_describe_fields_matches_vcf_describe_shape() {
+    let temp_dir = sampled_format_store();
+    let root = temp_dir.path().join("sampled.vcz");
+    let batch =
+        describe_fields(root.to_string_lossy().into_owned()).expect("fixture should describe");
+
+    assert_eq!(batch.schema().field(0).name(), "name");
+    assert_eq!(batch.schema().field(1).name(), "field_type");
+    assert_eq!(batch.schema().field(2).name(), "data_type");
+    assert_eq!(batch.schema().field(3).name(), "description");
+    assert_eq!(batch.num_columns(), 4);
+    assert!(batch.num_rows() >= 3);
+
+    let names = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("name should be Utf8");
+    let field_types = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("field_type should be Utf8");
+    let rows = (0..batch.num_rows())
+        .map(|index| (field_types.value(index), names.value(index)))
+        .collect::<Vec<_>>();
+
+    assert!(rows.contains(&("INFO", "DP")));
+    assert!(rows.contains(&("FORMAT", "DP")));
+    assert!(rows.contains(&("FORMAT", "GT")));
 }
 
 fn assert_i32_list_values(list: &ListArray, row: usize, expected: &[i32]) {

--- a/datafusion/bio-format-vcf/tests/vcf_zarr_provider_test.rs
+++ b/datafusion/bio-format-vcf/tests/vcf_zarr_provider_test.rs
@@ -373,13 +373,25 @@ fn vcf_zarr_describe_fields_matches_vcf_describe_shape() {
         .as_any()
         .downcast_ref::<StringArray>()
         .expect("field_type should be Utf8");
+    let data_types = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("data_type should be Utf8");
     let rows = (0..batch.num_rows())
-        .map(|index| (field_types.value(index), names.value(index)))
+        .map(|index| {
+            (
+                field_types.value(index),
+                names.value(index),
+                data_types.value(index),
+            )
+        })
         .collect::<Vec<_>>();
 
-    assert!(rows.contains(&("INFO", "DP")));
-    assert!(rows.contains(&("FORMAT", "DP")));
-    assert!(rows.contains(&("FORMAT", "GT")));
+    assert!(rows.contains(&("INFO", "DP", "Integer")));
+    assert!(rows.contains(&("FORMAT", "genotypes", "Struct")));
+    assert!(!rows.iter().any(|row| row.0 == "FORMAT" && row.1 == "DP"));
+    assert!(!rows.iter().any(|row| row.0 == "FORMAT" && row.1 == "GT"));
 }
 
 fn assert_i32_list_values(list: &ListArray, row: usize, expected: &[i32]) {


### PR DESCRIPTION
## Summary
- Extend VCF describe output to include INFO and FORMAT rows with `name`, `field_type`, `data_type`, and `description` columns.
- Add VCF Zarr `describe_fields` support for local stores using discovered INFO and FORMAT arrays.
- Add Rust coverage for the VCF Zarr describe schema shape.

## Test Plan
- `cargo test -p datafusion-bio-format-vcf vcf_zarr`