### PR TITLE
feat: Add BigWig and BigBed table providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,6 @@ dependencies = [
  "datafusion",
  "datafusion-bio-format-core",
  "futures-util",
- "log",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -520,6 +520,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigtools"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1b9bbf6596d602e472a23ed5aa5d611fb04f14e7772226fb61c720e806202e"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "byteordered",
+ "bytes",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "index_list",
+ "itertools 0.10.5",
+ "libdeflater",
+ "serde",
+ "smallvec",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +693,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteordered"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf2cd9424f5ff404aba1959c835cbc448ee8b689b870a9981c76c0fd46280e6"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "bytes"
@@ -1049,7 +1090,7 @@ dependencies = [
  "datafusion-session",
  "datafusion-sql",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1127,6 +1168,20 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "datafusion-bio-format-bbi"
+version = "1.6.0"
+dependencies = [
+ "async-trait",
+ "bigtools",
+ "datafusion",
+ "datafusion-bio-format-core",
+ "futures-util",
+ "log",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1393,7 +1448,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1418,7 +1473,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
 ]
@@ -1436,7 +1491,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "log",
  "object_store",
@@ -1480,7 +1535,7 @@ dependencies = [
  "datafusion-session",
  "futures",
  "glob",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "rand 0.9.2",
@@ -1507,7 +1562,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "object_store",
  "tokio",
 ]
@@ -1581,7 +1636,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1634,7 +1689,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
@@ -1650,7 +1705,7 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "paste",
 ]
 
@@ -1674,7 +1729,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-macros",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "md-5",
  "memchr",
@@ -1740,7 +1795,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hashbrown 0.16.1",
- "itertools",
+ "itertools 0.14.0",
  "itoa",
  "log",
  "paste",
@@ -1814,7 +1869,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "recursive",
  "regex",
@@ -1837,7 +1892,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "paste",
  "petgraph",
@@ -1857,7 +1912,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -1873,7 +1928,7 @@ dependencies = [
  "datafusion-expr-common",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
 ]
 
@@ -1892,7 +1947,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools",
+ "itertools 0.14.0",
  "recursive",
 ]
 
@@ -1920,7 +1975,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "num-traits",
  "parking_lot",
@@ -1941,7 +1996,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools",
+ "itertools 0.14.0",
  "log",
 ]
 
@@ -2152,7 +2207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2767,6 +2822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "index_list"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30141a73bc8a129ac1ce472e33f45af3e2091d86b3479061b9c2f92fdbe9a28c"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2901,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2867,7 +2937,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3631,7 +3701,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3770,7 +3840,7 @@ dependencies = [
  "futures-util",
  "http",
  "humantime",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "thiserror 2.0.18",
@@ -4826,7 +4896,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4883,7 +4953,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5197,7 +5267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5254,7 +5324,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5365,7 +5434,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6002,7 +6071,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6531,7 +6600,7 @@ dependencies = [
  "getrandom 0.3.4",
  "half",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "itoa",
  "libz-sys",
  "log",
@@ -6570,7 +6639,7 @@ checksum = "1cf67386fd96a0336cd3e5ab5ca6cb14e0e05aee80f1acae8c4d3cf562a8bb65"
 dependencies = [
  "derive_more",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
  "thiserror 2.0.18",
  "tinyvec",
@@ -6602,7 +6671,7 @@ dependencies = [
  "derive_more",
  "futures",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
  "thiserror 2.0.18",
  "unsafe_cell_slice",
@@ -6639,7 +6708,7 @@ checksum = "270efeb0181651aee5460b3232f2fc83e91bd646cefe75001d1c8f9a4f3abf81"
 dependencies = [
  "bytes",
  "derive_more",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "page_size",
  "pathdiff",
@@ -6700,7 +6769,7 @@ dependencies = [
  "auto_impl",
  "bytes",
  "derive_more",
- "itertools",
+ "itertools 0.14.0",
  "thiserror 2.0.18",
  "unsafe_cell_slice",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = [ "datafusion/bio-format-bam", "datafusion/bio-format-bed",
+members = [ "datafusion/bio-format-bam", "datafusion/bio-format-bbi", "datafusion/bio-format-bed",
     "datafusion/bio-format-core", "datafusion/bio-format-fastq", "datafusion/bio-format-gff",
     "datafusion/bio-format-gtf", "datafusion/bio-format-vcf", "datafusion/bio-format-fasta",
     "datafusion/bio-format-cram", "datafusion/bio-format-pairs", "datafusion/bio-format-ensembl-cache",

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "c18d9a386bdb80583bfea50ae95aa234ce5f320c", default-features = false, features = ["read"] }
+bigtools = { version = "0.5.8", default-features = false, features = ["read"] }
 futures-util.workspace = true
 log.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "c18d9a386bdb80583bfea50ae95aa234ce5f320c", default-features = false, features = ["read", "write"] }
+bigtools = { version = "0.5.8", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -15,7 +15,6 @@ async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
 bigtools = { version = "0.5.8", default-features = false, features = ["read"] }
 futures-util.workspace = true
-log.workspace = true
 
 [dev-dependencies]
 bigtools = { version = "0.5.8", default-features = false, features = ["read", "write"] }

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "datafusion-bio-format-bbi"
+version = "1.6.0"
+description = "BigWig and BigBed file format support for Apache DataFusion"
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+readme = "README.md"
+
+[dependencies]
+datafusion.workspace = true
+async-trait.workspace = true
+datafusion-bio-format-core = { path = "../bio-format-core" }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "c18d9a386bdb80583bfea50ae95aa234ce5f320c", default-features = false, features = ["read"] }
+futures-util.workspace = true
+log.workspace = true
+
+[dev-dependencies]
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "c18d9a386bdb80583bfea50ae95aa234ce5f320c", default-features = false, features = ["read", "write"] }
+tempfile = "3"
+tokio.workspace = true

--- a/datafusion/bio-format-bbi/README.md
+++ b/datafusion/bio-format-bbi/README.md
@@ -1,0 +1,3 @@
+# datafusion-bio-format-bbi
+
+BigWig and BigBed table providers for Apache DataFusion.

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bigtools::BigBedRead;
 use bigtools::bed::autosql::parse::{FieldType, parse_autosql};
+use bigtools::utils::reopen::ReopenableFile;
 use datafusion::arrow::array::{
     ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray, UInt32Array, UInt64Array,
 };
@@ -25,9 +26,9 @@ use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
 use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
-use crate::bigwig::{
-    BbiScanRegion, build_batch, plan_bbi_scan_regions, project_schema, projected_indices,
-    projection_display, region_display, reject_unsupported_scheme, to_external_error,
+use crate::common::{
+    BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions, project_schema,
+    projected_indices, projection_display, region_display, to_external_error,
 };
 
 /// BigBed schema discovery mode.
@@ -67,6 +68,12 @@ impl BigBedExtraColumn {
             BigBedExtraColumn::Float64 { .. } => DataType::Float64,
         }
     }
+
+    /// Whether this column reads from the split per-field view (`true`) or the
+    /// whole trailing `rest` string (`false`).
+    fn needs_split_fields(&self) -> bool {
+        !matches!(self, BigBedExtraColumn::Rest)
+    }
 }
 
 /// Table provider for local BigBed files.
@@ -74,7 +81,6 @@ impl BigBedExtraColumn {
 pub struct BigBedTableProvider {
     file_path: String,
     schema: SchemaRef,
-    full_schema: SchemaRef,
     chroms: Vec<(String, u32)>,
     extra_columns: Vec<BigBedExtraColumn>,
     coordinate_system_zero_based: bool,
@@ -87,7 +93,7 @@ impl BigBedTableProvider {
         coordinate_system_zero_based: bool,
         schema_mode: BigBedSchemaMode,
     ) -> Result<Self> {
-        reject_unsupported_scheme(&file_path, "BigBed")?;
+        let file_path = normalize_local_path(&file_path, "BigBed")?;
         let mut reader = BigBedRead::open_file(&file_path).map_err(|error| {
             DataFusionError::External(Box::new(std::io::Error::other(format!(
                 "Failed to open BigBed file '{file_path}': {error}"
@@ -99,11 +105,10 @@ impl BigBedTableProvider {
             .map(|chrom| (chrom.name.clone(), chrom.length))
             .collect::<Vec<_>>();
         let extra_columns = discover_extra_columns(&mut reader, schema_mode);
-        let full_schema = bigbed_schema(coordinate_system_zero_based, &extra_columns);
+        let schema = bigbed_schema(coordinate_system_zero_based, &extra_columns);
         Ok(Self {
             file_path,
-            schema: full_schema.clone(),
-            full_schema,
+            schema,
             chroms,
             extra_columns,
             coordinate_system_zero_based,
@@ -133,7 +138,7 @@ impl TableProvider for BigBedTableProvider {
             .iter()
             .map(|expr| {
                 if is_genomic_coordinate_filter(expr)
-                    || can_push_down_record_filter(expr, &self.full_schema)
+                    || can_push_down_record_filter(expr, &self.schema)
                 {
                     TableProviderFilterPushDown::Inexact
                 } else {
@@ -148,9 +153,11 @@ impl TableProvider for BigBedTableProvider {
         _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
+        // `_limit` is intentionally ignored: BBI scans have no cheap row cap, so
+        // DataFusion applies the LIMIT in a `GlobalLimitExec` above this node.
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let schema = project_schema(&self.full_schema, projection);
+        let schema = project_schema(&self.schema, projection);
         let regions =
             plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
         Ok(Arc::new(BigBedExec {
@@ -160,12 +167,12 @@ impl TableProvider for BigBedTableProvider {
             regions,
             extra_columns: self.extra_columns.clone(),
             coordinate_system_zero_based: self.coordinate_system_zero_based,
-            cache: PlanProperties::new(
+            cache: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(schema),
                 Partitioning::UnknownPartitioning(1),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
-            ),
+            )),
         }))
     }
 }
@@ -178,7 +185,7 @@ pub struct BigBedExec {
     regions: Vec<BbiScanRegion>,
     extra_columns: Vec<BigBedExtraColumn>,
     coordinate_system_zero_based: bool,
-    cache: PlanProperties,
+    cache: Arc<PlanProperties>,
 }
 
 impl Debug for BigBedExec {
@@ -209,7 +216,7 @@ impl ExecutionPlan for BigBedExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.cache
     }
 
@@ -229,15 +236,28 @@ impl ExecutionPlan for BigBedExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let batch = read_bigbed_batch(
-            &self.file_path,
-            &self.schema,
-            self.projection.as_deref(),
-            &self.regions,
-            &self.extra_columns,
-            self.coordinate_system_zero_based,
-        )?;
-        let stream = futures_util::stream::iter(vec![Ok(batch)]);
+        let reader = BigBedRead::open_file(&self.file_path).map_err(|error| {
+            DataFusionError::External(Box::new(std::io::Error::other(format!(
+                "Failed to open BigBed file '{}': {error}",
+                self.file_path
+            ))))
+        })?;
+        // Emit one RecordBatch per scan region (one per chromosome when there is
+        // no genomic filter) so memory stays bounded by a single region instead
+        // of materializing the whole file up front.
+        let needs_split_fields = self
+            .extra_columns
+            .iter()
+            .any(BigBedExtraColumn::needs_split_fields);
+        let stream = futures_util::stream::iter(BigBedRegionStream {
+            reader,
+            schema: self.schema.clone(),
+            projection: self.projection.clone(),
+            regions: self.regions.clone().into_iter(),
+            extra_columns: self.extra_columns.clone(),
+            needs_split_fields,
+            coordinate_system_zero_based: self.coordinate_system_zero_based,
+        });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
             stream,
@@ -250,65 +270,83 @@ struct BigBedRow {
     chrom: String,
     start: u32,
     end: u32,
+    /// Whole trailing field string; populated only when a `rest` column is used.
     rest: String,
+    /// Per-field split of `rest`; populated only when a typed column is used.
     fields: Vec<String>,
 }
 
-fn read_bigbed_batch(
-    file_path: &str,
-    schema: &SchemaRef,
-    projection: Option<&[usize]>,
-    regions: &[BbiScanRegion],
-    extra_columns: &[BigBedExtraColumn],
+/// Lazily yields one [`RecordBatch`] per scan region from an open BigBed reader.
+struct BigBedRegionStream {
+    reader: BigBedRead<ReopenableFile>,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    regions: std::vec::IntoIter<BbiScanRegion>,
+    extra_columns: Vec<BigBedExtraColumn>,
+    needs_split_fields: bool,
     coordinate_system_zero_based: bool,
-) -> Result<RecordBatch> {
-    let mut reader = BigBedRead::open_file(file_path).map_err(|error| {
-        DataFusionError::External(Box::new(std::io::Error::other(format!(
-            "Failed to open BigBed file '{file_path}': {error}"
-        ))))
-    })?;
+}
 
-    let mut rows = Vec::new();
-    for region in regions {
-        let iter = reader
+impl BigBedRegionStream {
+    fn build_region_batch(&mut self, region: &BbiScanRegion) -> Result<RecordBatch> {
+        let iter = self
+            .reader
             .get_interval(&region.chrom, region.start, region.end)
             .map_err(to_external_error)?;
+
+        let mut rows = Vec::new();
         for entry in iter {
             let entry = entry.map_err(to_external_error)?;
-            let start = if coordinate_system_zero_based {
+            let start = if self.coordinate_system_zero_based {
                 entry.start
             } else {
                 entry.start + 1
+            };
+            // Only allocate the split-field view or the `rest` string when a
+            // column actually consumes it; the other is left empty.
+            let fields = if self.needs_split_fields {
+                entry.rest.split('\t').map(ToString::to_string).collect()
+            } else {
+                Vec::new()
             };
             rows.push(BigBedRow {
                 chrom: region.chrom.clone(),
                 start,
                 end: entry.end,
-                fields: entry.rest.split('\t').map(ToString::to_string).collect(),
                 rest: entry.rest,
+                fields,
             });
         }
-    }
 
-    let row_count = rows.len();
-    let full_width = 3 + extra_columns.len();
-    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
-    for index in projected_indices(projection, full_width) {
-        match index {
-            0 => arrays.push(Arc::new(StringArray::from_iter_values(
-                rows.iter().map(|row| row.chrom.as_str()),
-            ))),
-            1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
-                rows.iter().map(|row| row.start),
-            ))),
-            2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
-                rows.iter().map(|row| row.end),
-            ))),
-            index => arrays.push(build_extra_array(&rows, &extra_columns[index - 3])?),
+        let row_count = rows.len();
+        let full_width = 3 + self.extra_columns.len();
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.schema.fields().len());
+        for index in projected_indices(self.projection.as_deref(), full_width) {
+            match index {
+                0 => arrays.push(Arc::new(StringArray::from_iter_values(
+                    rows.iter().map(|row| row.chrom.as_str()),
+                ))),
+                1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                    rows.iter().map(|row| row.start),
+                ))),
+                2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                    rows.iter().map(|row| row.end),
+                ))),
+                index => arrays.push(build_extra_array(&rows, &self.extra_columns[index - 3])?),
+            }
         }
-    }
 
-    build_batch(schema.clone(), arrays, row_count)
+        build_batch(self.schema.clone(), arrays, row_count)
+    }
+}
+
+impl Iterator for BigBedRegionStream {
+    type Item = Result<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let region = self.regions.next()?;
+        Some(self.build_region_batch(&region))
+    }
 }
 
 fn build_extra_array(rows: &[BigBedRow], column: &BigBedExtraColumn) -> Result<ArrayRef> {
@@ -381,7 +419,7 @@ fn bigbed_schema(
 }
 
 fn discover_extra_columns(
-    reader: &mut BigBedRead<bigtools::utils::reopen::ReopenableFile>,
+    reader: &mut BigBedRead<ReopenableFile>,
     schema_mode: BigBedSchemaMode,
 ) -> Vec<BigBedExtraColumn> {
     if schema_mode == BigBedSchemaMode::Rest {
@@ -390,10 +428,11 @@ fn discover_extra_columns(
     let Some(autosql) = reader.autosql().ok().flatten() else {
         return vec![BigBedExtraColumn::Rest];
     };
-    let Ok(mut declarations) = parse_autosql(&autosql) else {
+    let Ok(declarations) = parse_autosql(&autosql) else {
         return vec![BigBedExtraColumn::Rest];
     };
-    let Some(declaration) = declarations.pop() else {
+    // BigBed files declare a single autoSQL table; take the first declaration.
+    let Some(declaration) = declarations.into_iter().next() else {
         return vec![BigBedExtraColumn::Rest];
     };
     if declaration.fields.len() <= 3 {
@@ -402,8 +441,15 @@ fn discover_extra_columns(
 
     let mut columns = Vec::new();
     for (rest_index, field) in declaration.fields.into_iter().skip(3).enumerate() {
+        // Fixed-size array fields (e.g. `int[3]`) are stored as a single raw
+        // token. Keep just that column as text rather than downgrading the
+        // entire typed schema to a single `rest` column.
         if field.field_size.is_some() {
-            return vec![BigBedExtraColumn::Rest];
+            columns.push(BigBedExtraColumn::Utf8 {
+                name: field.name,
+                rest_index,
+            });
+            continue;
         }
         let column = match field.field_type {
             FieldType::String
@@ -428,7 +474,12 @@ fn discover_extra_columns(
                 name: field.name,
                 rest_index,
             },
-            FieldType::Declaration(_, _) => return vec![BigBedExtraColumn::Rest],
+            // Nested declarations have no flat column representation; keep the
+            // raw token as text instead of discarding the whole typed schema.
+            FieldType::Declaration(_, _) => BigBedExtraColumn::Utf8 {
+                name: field.name,
+                rest_index,
+            },
         };
         columns.push(column);
     }

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -1,0 +1,436 @@
+//! BigBed DataFusion table provider.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bigtools::BigBedRead;
+use bigtools::bed::autosql::parse::{FieldType, parse_autosql};
+use datafusion::arrow::array::{
+    ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray, UInt32Array, UInt64Array,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
+use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
+use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
+
+use crate::bigwig::{
+    BbiScanRegion, build_batch, plan_bbi_scan_regions, project_schema, projected_indices,
+    projection_display, region_display, reject_unsupported_scheme, to_external_error,
+};
+
+/// BigBed schema discovery mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BigBedSchemaMode {
+    /// Use supported autoSQL fields and fall back to `rest` when unavailable.
+    Auto,
+    /// Always expose the raw trailing fields in `rest`.
+    Rest,
+}
+
+#[derive(Clone, Debug)]
+enum BigBedExtraColumn {
+    Utf8 { name: String, rest_index: usize },
+    Int64 { name: String, rest_index: usize },
+    UInt64 { name: String, rest_index: usize },
+    Float64 { name: String, rest_index: usize },
+    Rest,
+}
+
+impl BigBedExtraColumn {
+    fn name(&self) -> &str {
+        match self {
+            BigBedExtraColumn::Utf8 { name, .. }
+            | BigBedExtraColumn::Int64 { name, .. }
+            | BigBedExtraColumn::UInt64 { name, .. }
+            | BigBedExtraColumn::Float64 { name, .. } => name,
+            BigBedExtraColumn::Rest => "rest",
+        }
+    }
+
+    fn data_type(&self) -> DataType {
+        match self {
+            BigBedExtraColumn::Utf8 { .. } | BigBedExtraColumn::Rest => DataType::Utf8,
+            BigBedExtraColumn::Int64 { .. } => DataType::Int64,
+            BigBedExtraColumn::UInt64 { .. } => DataType::UInt64,
+            BigBedExtraColumn::Float64 { .. } => DataType::Float64,
+        }
+    }
+}
+
+/// Table provider for local BigBed files.
+#[derive(Clone, Debug)]
+pub struct BigBedTableProvider {
+    file_path: String,
+    schema: SchemaRef,
+    full_schema: SchemaRef,
+    chroms: Vec<(String, u32)>,
+    extra_columns: Vec<BigBedExtraColumn>,
+    coordinate_system_zero_based: bool,
+}
+
+impl BigBedTableProvider {
+    /// Create a BigBed provider for a local file path.
+    pub fn new(
+        file_path: String,
+        coordinate_system_zero_based: bool,
+        schema_mode: BigBedSchemaMode,
+    ) -> Result<Self> {
+        reject_unsupported_scheme(&file_path, "BigBed")?;
+        let mut reader = BigBedRead::open_file(&file_path).map_err(|error| {
+            DataFusionError::External(Box::new(std::io::Error::other(format!(
+                "Failed to open BigBed file '{file_path}': {error}"
+            ))))
+        })?;
+        let chroms = reader
+            .chroms()
+            .iter()
+            .map(|chrom| (chrom.name.clone(), chrom.length))
+            .collect::<Vec<_>>();
+        let extra_columns = discover_extra_columns(&mut reader, schema_mode);
+        let full_schema = bigbed_schema(coordinate_system_zero_based, &extra_columns);
+        Ok(Self {
+            file_path,
+            schema: full_schema.clone(),
+            full_schema,
+            chroms,
+            extra_columns,
+            coordinate_system_zero_based,
+        })
+    }
+}
+
+#[async_trait]
+impl TableProvider for BigBedTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|expr| {
+                if is_genomic_coordinate_filter(expr)
+                    || can_push_down_record_filter(expr, &self.full_schema)
+                {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let schema = project_schema(&self.full_schema, projection);
+        let regions =
+            plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
+        Ok(Arc::new(BigBedExec {
+            file_path: self.file_path.clone(),
+            schema: schema.clone(),
+            projection: projection.cloned(),
+            regions,
+            extra_columns: self.extra_columns.clone(),
+            coordinate_system_zero_based: self.coordinate_system_zero_based,
+            cache: PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ),
+        }))
+    }
+}
+
+/// Physical execution plan for BigBed scans.
+pub struct BigBedExec {
+    file_path: String,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    regions: Vec<BbiScanRegion>,
+    extra_columns: Vec<BigBedExtraColumn>,
+    coordinate_system_zero_based: bool,
+    cache: PlanProperties,
+}
+
+impl Debug for BigBedExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BigBedExec")
+            .field("projection", &self.projection)
+            .finish()
+    }
+}
+
+impl DisplayAs for BigBedExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BigBedExec: projection=[{}], regions=[{}]",
+            projection_display(&self.schema),
+            region_display(&self.regions)
+        )
+    }
+}
+
+impl ExecutionPlan for BigBedExec {
+    fn name(&self) -> &str {
+        "BigBedExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let batch = read_bigbed_batch(
+            &self.file_path,
+            &self.schema,
+            self.projection.as_deref(),
+            &self.regions,
+            &self.extra_columns,
+            self.coordinate_system_zero_based,
+        )?;
+        let stream = futures_util::stream::iter(vec![Ok(batch)]);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema.clone(),
+            stream,
+        )))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BigBedRow {
+    chrom: String,
+    start: u32,
+    end: u32,
+    rest: String,
+    fields: Vec<String>,
+}
+
+fn read_bigbed_batch(
+    file_path: &str,
+    schema: &SchemaRef,
+    projection: Option<&[usize]>,
+    regions: &[BbiScanRegion],
+    extra_columns: &[BigBedExtraColumn],
+    coordinate_system_zero_based: bool,
+) -> Result<RecordBatch> {
+    let mut reader = BigBedRead::open_file(file_path).map_err(|error| {
+        DataFusionError::External(Box::new(std::io::Error::other(format!(
+            "Failed to open BigBed file '{file_path}': {error}"
+        ))))
+    })?;
+
+    let mut rows = Vec::new();
+    for region in regions {
+        let iter = reader
+            .get_interval(&region.chrom, region.start, region.end)
+            .map_err(to_external_error)?;
+        for entry in iter {
+            let entry = entry.map_err(to_external_error)?;
+            let start = if coordinate_system_zero_based {
+                entry.start
+            } else {
+                entry.start + 1
+            };
+            rows.push(BigBedRow {
+                chrom: region.chrom.clone(),
+                start,
+                end: entry.end,
+                fields: entry.rest.split('\t').map(ToString::to_string).collect(),
+                rest: entry.rest,
+            });
+        }
+    }
+
+    let row_count = rows.len();
+    let full_width = 3 + extra_columns.len();
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
+    for index in projected_indices(projection, full_width) {
+        match index {
+            0 => arrays.push(Arc::new(StringArray::from_iter_values(
+                rows.iter().map(|row| row.chrom.as_str()),
+            ))),
+            1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                rows.iter().map(|row| row.start),
+            ))),
+            2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                rows.iter().map(|row| row.end),
+            ))),
+            index => arrays.push(build_extra_array(&rows, &extra_columns[index - 3])?),
+        }
+    }
+
+    build_batch(schema.clone(), arrays, row_count)
+}
+
+fn build_extra_array(rows: &[BigBedRow], column: &BigBedExtraColumn) -> Result<ArrayRef> {
+    match column {
+        BigBedExtraColumn::Utf8 { rest_index, .. } => Ok(Arc::new(StringArray::from(
+            rows.iter()
+                .map(|row| row.fields.get(*rest_index).map(String::as_str))
+                .collect::<Vec<_>>(),
+        ))),
+        BigBedExtraColumn::Rest => Ok(Arc::new(StringArray::from_iter_values(
+            rows.iter().map(|row| row.rest.as_str()),
+        ))),
+        BigBedExtraColumn::Int64 { rest_index, name } => Ok(Arc::new(Int64Array::from(
+            rows.iter()
+                .map(|row| parse_optional::<i64>(row.fields.get(*rest_index), name))
+                .collect::<Result<Vec<_>>>()?,
+        ))),
+        BigBedExtraColumn::UInt64 { rest_index, name } => Ok(Arc::new(UInt64Array::from(
+            rows.iter()
+                .map(|row| parse_optional::<u64>(row.fields.get(*rest_index), name))
+                .collect::<Result<Vec<_>>>()?,
+        ))),
+        BigBedExtraColumn::Float64 { rest_index, name } => Ok(Arc::new(Float64Array::from(
+            rows.iter()
+                .map(|row| parse_optional::<f64>(row.fields.get(*rest_index), name))
+                .collect::<Result<Vec<_>>>()?,
+        ))),
+    }
+}
+
+fn parse_optional<T: std::str::FromStr>(
+    value: Option<&String>,
+    column_name: &str,
+) -> Result<Option<T>>
+where
+    T::Err: std::fmt::Display,
+{
+    value
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value.parse::<T>().map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "Failed to parse BigBed column '{column_name}' value '{value}': {error}"
+                ))
+            })
+        })
+        .transpose()
+}
+
+fn bigbed_schema(
+    coordinate_system_zero_based: bool,
+    extra_columns: &[BigBedExtraColumn],
+) -> SchemaRef {
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        COORDINATE_SYSTEM_METADATA_KEY.to_string(),
+        coordinate_system_zero_based.to_string(),
+    );
+    let mut fields = vec![
+        Field::new("chrom", DataType::Utf8, false),
+        Field::new("start", DataType::UInt32, false),
+        Field::new("end", DataType::UInt32, false),
+    ];
+    fields.extend(
+        extra_columns
+            .iter()
+            .map(|column| Field::new(column.name(), column.data_type(), true)),
+    );
+    Arc::new(Schema::new_with_metadata(fields, metadata))
+}
+
+fn discover_extra_columns(
+    reader: &mut BigBedRead<bigtools::utils::reopen::ReopenableFile>,
+    schema_mode: BigBedSchemaMode,
+) -> Vec<BigBedExtraColumn> {
+    if schema_mode == BigBedSchemaMode::Rest {
+        return vec![BigBedExtraColumn::Rest];
+    }
+    let Some(autosql) = reader.autosql().ok().flatten() else {
+        return vec![BigBedExtraColumn::Rest];
+    };
+    let Ok(mut declarations) = parse_autosql(&autosql) else {
+        return vec![BigBedExtraColumn::Rest];
+    };
+    let Some(declaration) = declarations.pop() else {
+        return vec![BigBedExtraColumn::Rest];
+    };
+    if declaration.fields.len() <= 3 {
+        return Vec::new();
+    }
+
+    let mut columns = Vec::new();
+    for (rest_index, field) in declaration.fields.into_iter().skip(3).enumerate() {
+        if field.field_size.is_some() {
+            return vec![BigBedExtraColumn::Rest];
+        }
+        let column = match field.field_type {
+            FieldType::String
+            | FieldType::Lstring
+            | FieldType::Char
+            | FieldType::Enum(_)
+            | FieldType::Set(_) => BigBedExtraColumn::Utf8 {
+                name: field.name,
+                rest_index,
+            },
+            FieldType::Int | FieldType::Short | FieldType::Byte | FieldType::Bigint => {
+                BigBedExtraColumn::Int64 {
+                    name: field.name,
+                    rest_index,
+                }
+            }
+            FieldType::Uint | FieldType::Ushort | FieldType::Ubyte => BigBedExtraColumn::UInt64 {
+                name: field.name,
+                rest_index,
+            },
+            FieldType::Float | FieldType::Double => BigBedExtraColumn::Float64 {
+                name: field.name,
+                rest_index,
+            },
+            FieldType::Declaration(_, _) => return vec![BigBedExtraColumn::Rest],
+        };
+        columns.push(column);
+    }
+    columns
+}

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -6,9 +6,9 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bigtools::BigBedRead;
 use bigtools::bed::autosql::parse::{FieldType, parse_autosql};
 use bigtools::utils::reopen::ReopenableFile;
+use bigtools::{BigBedIntervalIter, BigBedRead};
 use datafusion::arrow::array::{
     ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray, UInt32Array, UInt64Array,
 };
@@ -27,8 +27,8 @@ use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
 use crate::common::{
-    BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions, project_schema,
-    projected_indices, projection_display, region_display, to_external_error,
+    BBI_BATCH_ROWS, BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions,
+    project_schema, projected_indices, projection_display, region_display, to_external_error,
 };
 
 /// BigBed schema discovery mode.
@@ -236,27 +236,22 @@ impl ExecutionPlan for BigBedExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let reader = BigBedRead::open_file(&self.file_path).map_err(|error| {
-            DataFusionError::External(Box::new(std::io::Error::other(format!(
-                "Failed to open BigBed file '{}': {error}",
-                self.file_path
-            ))))
-        })?;
-        // Emit one RecordBatch per scan region (one per chromosome when there is
-        // no genomic filter) so memory stays bounded by a single region instead
-        // of materializing the whole file up front.
+        // The stream opens a reader per region and pulls intervals in fixed-size
+        // chunks, so peak memory stays bounded by one batch (never a whole
+        // chromosome) and LIMIT/COUNT queries can stop early.
         let needs_split_fields = self
             .extra_columns
             .iter()
             .any(BigBedExtraColumn::needs_split_fields);
         let stream = futures_util::stream::iter(BigBedRegionStream {
-            reader,
+            file_path: self.file_path.clone(),
             schema: self.schema.clone(),
             projection: self.projection.clone(),
             regions: self.regions.clone().into_iter(),
             extra_columns: self.extra_columns.clone(),
             needs_split_fields,
             coordinate_system_zero_based: self.coordinate_system_zero_based,
+            current: None,
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
@@ -276,48 +271,51 @@ struct BigBedRow {
     fields: Vec<String>,
 }
 
-/// Lazily yields one [`RecordBatch`] per scan region from an open BigBed reader.
+/// An open interval iterator for the region currently being streamed.
+struct CurrentRegion {
+    chrom: String,
+    iter: BigBedIntervalIter<ReopenableFile, BigBedRead<ReopenableFile>>,
+}
+
+/// Lazily yields fixed-size [`RecordBatch`]es across all scan regions, opening a
+/// fresh reader per region and never buffering more than one batch at a time.
 struct BigBedRegionStream {
-    reader: BigBedRead<ReopenableFile>,
+    file_path: String,
     schema: SchemaRef,
     projection: Option<Vec<usize>>,
     regions: std::vec::IntoIter<BbiScanRegion>,
     extra_columns: Vec<BigBedExtraColumn>,
     needs_split_fields: bool,
     coordinate_system_zero_based: bool,
+    current: Option<CurrentRegion>,
 }
 
 impl BigBedRegionStream {
-    fn build_region_batch(&mut self, region: &BbiScanRegion) -> Result<RecordBatch> {
-        let iter = self
-            .reader
-            .get_interval(&region.chrom, region.start, region.end)
-            .map_err(to_external_error)?;
-
-        let mut rows = Vec::new();
-        for entry in iter {
-            let entry = entry.map_err(to_external_error)?;
-            let start = if self.coordinate_system_zero_based {
-                entry.start
-            } else {
-                entry.start + 1
-            };
-            // Only allocate the split-field view or the `rest` string when a
-            // column actually consumes it; the other is left empty.
-            let fields = if self.needs_split_fields {
-                entry.rest.split('\t').map(ToString::to_string).collect()
-            } else {
-                Vec::new()
-            };
-            rows.push(BigBedRow {
-                chrom: region.chrom.clone(),
-                start,
-                end: entry.end,
-                rest: entry.rest,
-                fields,
-            });
+    /// Open the next region's interval iterator, or return `None` when all
+    /// regions are exhausted.
+    fn open_next_region(&mut self) -> Option<Result<CurrentRegion>> {
+        let region = self.regions.next()?;
+        let reader = match BigBedRead::open_file(&self.file_path) {
+            Ok(reader) => reader,
+            Err(error) => {
+                return Some(Err(DataFusionError::External(Box::new(
+                    std::io::Error::other(format!(
+                        "Failed to open BigBed file '{}': {error}",
+                        self.file_path
+                    )),
+                ))));
+            }
+        };
+        match reader.get_interval_move(&region.chrom, region.start, region.end) {
+            Ok(iter) => Some(Ok(CurrentRegion {
+                chrom: region.chrom,
+                iter,
+            })),
+            Err(error) => Some(Err(to_external_error(error))),
         }
+    }
 
+    fn build_batch(&self, rows: &[BigBedRow]) -> Result<RecordBatch> {
         let row_count = rows.len();
         let full_width = 3 + self.extra_columns.len();
         let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.schema.fields().len());
@@ -332,10 +330,9 @@ impl BigBedRegionStream {
                 2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
                     rows.iter().map(|row| row.end),
                 ))),
-                index => arrays.push(build_extra_array(&rows, &self.extra_columns[index - 3])?),
+                index => arrays.push(build_extra_array(rows, &self.extra_columns[index - 3])?),
             }
         }
-
         build_batch(self.schema.clone(), arrays, row_count)
     }
 }
@@ -344,11 +341,62 @@ impl Iterator for BigBedRegionStream {
     type Item = Result<RecordBatch>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let region = self.regions.next()?;
-        Some(self.build_region_batch(&region))
+        loop {
+            if self.current.is_none() {
+                match self.open_next_region()? {
+                    Ok(region) => self.current = Some(region),
+                    Err(error) => return Some(Err(error)),
+                }
+            }
+
+            let current = self.current.as_mut().expect("current region is set");
+            let mut rows: Vec<BigBedRow> = Vec::with_capacity(BBI_BATCH_ROWS);
+            for entry in current.iter.by_ref() {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(error) => return Some(Err(to_external_error(error))),
+                };
+                let start = if self.coordinate_system_zero_based {
+                    entry.start
+                } else {
+                    entry.start + 1
+                };
+                // Only allocate the split-field view or the `rest` string when a
+                // column actually consumes it; the other is left empty.
+                let fields = if self.needs_split_fields {
+                    entry.rest.split('\t').map(ToString::to_string).collect()
+                } else {
+                    Vec::new()
+                };
+                rows.push(BigBedRow {
+                    chrom: current.chrom.clone(),
+                    start,
+                    end: entry.end,
+                    rest: entry.rest,
+                    fields,
+                });
+                if rows.len() >= BBI_BATCH_ROWS {
+                    break;
+                }
+            }
+
+            if rows.is_empty() {
+                // Region fully drained; advance to the next one.
+                self.current = None;
+                continue;
+            }
+
+            return Some(self.build_batch(&rows));
+        }
     }
 }
 
+/// Build an Arrow array for one autoSQL-derived extra column.
+///
+/// A row whose trailing field is absent (the record has fewer tab-separated
+/// fields than the autoSQL declaration) yields a null rather than an error:
+/// BED allows optional trailing fields, the columns are declared nullable, and
+/// pushdown is `Inexact` so DataFusion re-applies predicates above the scan.
 fn build_extra_array(rows: &[BigBedRow], column: &BigBedExtraColumn) -> Result<ArrayRef> {
     match column {
         BigBedExtraColumn::Utf8 { rest_index, .. } => Ok(Arc::new(StringArray::from(

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -6,8 +6,8 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bigtools::BigWigRead;
 use bigtools::utils::reopen::ReopenableFile;
+use bigtools::{BigWigIntervalIter, BigWigRead};
 use datafusion::arrow::array::{ArrayRef, Float32Array, RecordBatch, StringArray, UInt32Array};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::{Session, TableProvider};
@@ -24,8 +24,8 @@ use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
 use crate::common::{
-    BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions, project_schema,
-    projected_indices, projection_display, region_display, to_external_error,
+    BBI_BATCH_ROWS, BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions,
+    project_schema, projected_indices, projection_display, region_display, to_external_error,
 };
 
 /// Table provider for local BigWig files.
@@ -179,21 +179,16 @@ impl ExecutionPlan for BigWigExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let reader = BigWigRead::open_file(&self.file_path).map_err(|error| {
-            DataFusionError::External(Box::new(std::io::Error::other(format!(
-                "Failed to open BigWig file '{}': {error}",
-                self.file_path
-            ))))
-        })?;
-        // Emit one RecordBatch per scan region (one per chromosome when there is
-        // no genomic filter) so memory stays bounded by a single region instead
-        // of materializing the whole file up front.
+        // The stream opens a reader per region and pulls intervals in fixed-size
+        // chunks, so peak memory stays bounded by one batch (never a whole
+        // chromosome) and LIMIT/COUNT queries can stop early.
         let stream = futures_util::stream::iter(BigWigRegionStream {
-            reader,
+            file_path: self.file_path.clone(),
             schema: self.schema.clone(),
             projection: self.projection.clone(),
             regions: self.regions.clone().into_iter(),
             coordinate_system_zero_based: self.coordinate_system_zero_based,
+            current: None,
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
@@ -202,39 +197,55 @@ impl ExecutionPlan for BigWigExec {
     }
 }
 
-/// Lazily yields one [`RecordBatch`] per scan region from an open BigWig reader.
+/// An open interval iterator for the region currently being streamed.
+struct CurrentRegion {
+    chrom: String,
+    iter: BigWigIntervalIter<ReopenableFile, BigWigRead<ReopenableFile>>,
+}
+
+/// Lazily yields fixed-size [`RecordBatch`]es across all scan regions, opening a
+/// fresh reader per region and never buffering more than one batch at a time.
 struct BigWigRegionStream {
-    reader: BigWigRead<ReopenableFile>,
+    file_path: String,
     schema: SchemaRef,
     projection: Option<Vec<usize>>,
     regions: std::vec::IntoIter<BbiScanRegion>,
     coordinate_system_zero_based: bool,
+    current: Option<CurrentRegion>,
 }
 
 impl BigWigRegionStream {
-    fn build_region_batch(&mut self, region: &BbiScanRegion) -> Result<RecordBatch> {
-        let iter = self
-            .reader
-            .get_interval(&region.chrom, region.start, region.end)
-            .map_err(to_external_error)?;
-
-        let mut rows = Vec::new();
-        for value in iter {
-            let value = value.map_err(to_external_error)?;
-            let start = if self.coordinate_system_zero_based {
-                value.start
-            } else {
-                value.start + 1
-            };
-            rows.push((start, value.end, value.value));
+    /// Open the next region's interval iterator, or return `None` when all
+    /// regions are exhausted.
+    fn open_next_region(&mut self) -> Option<Result<CurrentRegion>> {
+        let region = self.regions.next()?;
+        let reader = match BigWigRead::open_file(&self.file_path) {
+            Ok(reader) => reader,
+            Err(error) => {
+                return Some(Err(DataFusionError::External(Box::new(
+                    std::io::Error::other(format!(
+                        "Failed to open BigWig file '{}': {error}",
+                        self.file_path
+                    )),
+                ))));
+            }
+        };
+        match reader.get_interval_move(&region.chrom, region.start, region.end) {
+            Ok(iter) => Some(Ok(CurrentRegion {
+                chrom: region.chrom,
+                iter,
+            })),
+            Err(error) => Some(Err(to_external_error(error))),
         }
+    }
 
+    fn build_batch(&self, chrom: &str, rows: &[(u32, u32, f32)]) -> Result<RecordBatch> {
         let row_count = rows.len();
         let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.schema.fields().len());
         for index in projected_indices(self.projection.as_deref(), 4) {
             match index {
                 0 => arrays.push(Arc::new(StringArray::from_iter_values(
-                    std::iter::repeat_n(region.chrom.as_str(), row_count),
+                    std::iter::repeat_n(chrom, row_count),
                 ))),
                 1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
                     rows.iter().map(|row| row.0),
@@ -248,7 +259,6 @@ impl BigWigRegionStream {
                 _ => unreachable!("BigWig projection contains invalid column index"),
             }
         }
-
         build_batch(self.schema.clone(), arrays, row_count)
     }
 }
@@ -257,8 +267,41 @@ impl Iterator for BigWigRegionStream {
     type Item = Result<RecordBatch>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let region = self.regions.next()?;
-        Some(self.build_region_batch(&region))
+        loop {
+            if self.current.is_none() {
+                match self.open_next_region()? {
+                    Ok(region) => self.current = Some(region),
+                    Err(error) => return Some(Err(error)),
+                }
+            }
+
+            let current = self.current.as_mut().expect("current region is set");
+            let mut rows: Vec<(u32, u32, f32)> = Vec::with_capacity(BBI_BATCH_ROWS);
+            for value in current.iter.by_ref() {
+                let value = match value {
+                    Ok(value) => value,
+                    Err(error) => return Some(Err(to_external_error(error))),
+                };
+                let start = if self.coordinate_system_zero_based {
+                    value.start
+                } else {
+                    value.start + 1
+                };
+                rows.push((start, value.end, value.value));
+                if rows.len() >= BBI_BATCH_ROWS {
+                    break;
+                }
+            }
+
+            if rows.is_empty() {
+                // Region fully drained; advance to the next one.
+                self.current = None;
+                continue;
+            }
+
+            let chrom = current.chrom.clone();
+            return Some(self.build_batch(&chrom, &rows));
+        }
     }
 }
 

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -7,9 +7,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bigtools::BigWigRead;
-use datafusion::arrow::array::{
-    ArrayRef, Float32Array, RecordBatch, RecordBatchOptions, StringArray, UInt32Array,
-};
+use bigtools::utils::reopen::ReopenableFile;
+use datafusion::arrow::array::{ArrayRef, Float32Array, RecordBatch, StringArray, UInt32Array};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::{DataFusionError, Result};
@@ -21,25 +20,19 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
-use datafusion_bio_format_core::genomic_filter::{
-    GenomicRegion, extract_genomic_regions, is_genomic_coordinate_filter,
-};
+use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
-/// Native BBI interval query region in 0-based half-open coordinates.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct BbiScanRegion {
-    pub(crate) chrom: String,
-    pub(crate) start: u32,
-    pub(crate) end: u32,
-}
+use crate::common::{
+    BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions, project_schema,
+    projected_indices, projection_display, region_display, to_external_error,
+};
 
 /// Table provider for local BigWig files.
 #[derive(Clone, Debug)]
 pub struct BigWigTableProvider {
     file_path: String,
     schema: SchemaRef,
-    full_schema: SchemaRef,
     chroms: Vec<(String, u32)>,
     coordinate_system_zero_based: bool,
 }
@@ -47,7 +40,7 @@ pub struct BigWigTableProvider {
 impl BigWigTableProvider {
     /// Create a BigWig provider for a local file path.
     pub fn new(file_path: String, coordinate_system_zero_based: bool) -> Result<Self> {
-        reject_unsupported_scheme(&file_path, "BigWig")?;
+        let file_path = normalize_local_path(&file_path, "BigWig")?;
         let reader = BigWigRead::open_file(&file_path).map_err(|error| {
             DataFusionError::External(Box::new(std::io::Error::other(format!(
                 "Failed to open BigWig file '{file_path}': {error}"
@@ -58,11 +51,10 @@ impl BigWigTableProvider {
             .iter()
             .map(|chrom| (chrom.name.clone(), chrom.length))
             .collect::<Vec<_>>();
-        let full_schema = bigwig_schema(coordinate_system_zero_based);
+        let schema = bigwig_schema(coordinate_system_zero_based);
         Ok(Self {
             file_path,
-            schema: full_schema.clone(),
-            full_schema,
+            schema,
             chroms,
             coordinate_system_zero_based,
         })
@@ -91,7 +83,7 @@ impl TableProvider for BigWigTableProvider {
             .iter()
             .map(|expr| {
                 if is_genomic_coordinate_filter(expr)
-                    || can_push_down_record_filter(expr, &self.full_schema)
+                    || can_push_down_record_filter(expr, &self.schema)
                 {
                     TableProviderFilterPushDown::Inexact
                 } else {
@@ -106,9 +98,11 @@ impl TableProvider for BigWigTableProvider {
         _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
+        // `_limit` is intentionally ignored: BBI scans have no cheap row cap, so
+        // DataFusion applies the LIMIT in a `GlobalLimitExec` above this node.
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let schema = project_schema(&self.full_schema, projection);
+        let schema = project_schema(&self.schema, projection);
         let regions =
             plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
         Ok(Arc::new(BigWigExec {
@@ -117,12 +111,12 @@ impl TableProvider for BigWigTableProvider {
             projection: projection.cloned(),
             regions,
             coordinate_system_zero_based: self.coordinate_system_zero_based,
-            cache: PlanProperties::new(
+            cache: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(schema),
                 Partitioning::UnknownPartitioning(1),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
-            ),
+            )),
         }))
     }
 }
@@ -134,7 +128,7 @@ pub struct BigWigExec {
     projection: Option<Vec<usize>>,
     regions: Vec<BbiScanRegion>,
     coordinate_system_zero_based: bool,
-    cache: PlanProperties,
+    cache: Arc<PlanProperties>,
 }
 
 impl Debug for BigWigExec {
@@ -165,7 +159,7 @@ impl ExecutionPlan for BigWigExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.cache
     }
 
@@ -185,18 +179,86 @@ impl ExecutionPlan for BigWigExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let batch = read_bigwig_batch(
-            &self.file_path,
-            &self.schema,
-            self.projection.as_deref(),
-            &self.regions,
-            self.coordinate_system_zero_based,
-        )?;
-        let stream = futures_util::stream::iter(vec![Ok(batch)]);
+        let reader = BigWigRead::open_file(&self.file_path).map_err(|error| {
+            DataFusionError::External(Box::new(std::io::Error::other(format!(
+                "Failed to open BigWig file '{}': {error}",
+                self.file_path
+            ))))
+        })?;
+        // Emit one RecordBatch per scan region (one per chromosome when there is
+        // no genomic filter) so memory stays bounded by a single region instead
+        // of materializing the whole file up front.
+        let stream = futures_util::stream::iter(BigWigRegionStream {
+            reader,
+            schema: self.schema.clone(),
+            projection: self.projection.clone(),
+            regions: self.regions.clone().into_iter(),
+            coordinate_system_zero_based: self.coordinate_system_zero_based,
+        });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
             stream,
         )))
+    }
+}
+
+/// Lazily yields one [`RecordBatch`] per scan region from an open BigWig reader.
+struct BigWigRegionStream {
+    reader: BigWigRead<ReopenableFile>,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    regions: std::vec::IntoIter<BbiScanRegion>,
+    coordinate_system_zero_based: bool,
+}
+
+impl BigWigRegionStream {
+    fn build_region_batch(&mut self, region: &BbiScanRegion) -> Result<RecordBatch> {
+        let iter = self
+            .reader
+            .get_interval(&region.chrom, region.start, region.end)
+            .map_err(to_external_error)?;
+
+        let mut rows = Vec::new();
+        for value in iter {
+            let value = value.map_err(to_external_error)?;
+            let start = if self.coordinate_system_zero_based {
+                value.start
+            } else {
+                value.start + 1
+            };
+            rows.push((start, value.end, value.value));
+        }
+
+        let row_count = rows.len();
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.schema.fields().len());
+        for index in projected_indices(self.projection.as_deref(), 4) {
+            match index {
+                0 => arrays.push(Arc::new(StringArray::from_iter_values(
+                    std::iter::repeat_n(region.chrom.as_str(), row_count),
+                ))),
+                1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                    rows.iter().map(|row| row.0),
+                ))),
+                2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                    rows.iter().map(|row| row.1),
+                ))),
+                3 => arrays.push(Arc::new(Float32Array::from_iter_values(
+                    rows.iter().map(|row| row.2),
+                ))),
+                _ => unreachable!("BigWig projection contains invalid column index"),
+            }
+        }
+
+        build_batch(self.schema.clone(), arrays, row_count)
+    }
+}
+
+impl Iterator for BigWigRegionStream {
+    type Item = Result<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let region = self.regions.next()?;
+        Some(self.build_region_batch(&region))
     }
 }
 
@@ -215,174 +277,4 @@ fn bigwig_schema(coordinate_system_zero_based: bool) -> SchemaRef {
         ],
         metadata,
     ))
-}
-
-fn read_bigwig_batch(
-    file_path: &str,
-    schema: &SchemaRef,
-    projection: Option<&[usize]>,
-    regions: &[BbiScanRegion],
-    coordinate_system_zero_based: bool,
-) -> Result<RecordBatch> {
-    let mut reader = BigWigRead::open_file(file_path).map_err(|error| {
-        DataFusionError::External(Box::new(std::io::Error::other(format!(
-            "Failed to open BigWig file '{file_path}': {error}"
-        ))))
-    })?;
-
-    let mut rows = Vec::new();
-    for region in regions {
-        let iter = reader
-            .get_interval(&region.chrom, region.start, region.end)
-            .map_err(to_external_error)?;
-        for value in iter {
-            let value = value.map_err(to_external_error)?;
-            let start = if coordinate_system_zero_based {
-                value.start
-            } else {
-                value.start + 1
-            };
-            rows.push((region.chrom.clone(), start, value.end, value.value));
-        }
-    }
-
-    let row_count = rows.len();
-    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
-    for index in projected_indices(projection, 4) {
-        match index {
-            0 => arrays.push(Arc::new(StringArray::from_iter_values(
-                rows.iter().map(|row| row.0.as_str()),
-            ))),
-            1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
-                rows.iter().map(|row| row.1),
-            ))),
-            2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
-                rows.iter().map(|row| row.2),
-            ))),
-            3 => arrays.push(Arc::new(Float32Array::from_iter_values(
-                rows.iter().map(|row| row.3),
-            ))),
-            _ => unreachable!("BigWig projection contains invalid column index"),
-        }
-    }
-
-    build_batch(schema.clone(), arrays, row_count)
-}
-
-pub(crate) fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
-    match projection {
-        Some(indices) => Arc::new(Schema::new_with_metadata(
-            indices
-                .iter()
-                .map(|&index| schema.field(index).clone())
-                .collect::<Vec<_>>(),
-            schema.metadata().clone(),
-        )),
-        None => schema.clone(),
-    }
-}
-
-pub(crate) fn projected_indices(projection: Option<&[usize]>, width: usize) -> Vec<usize> {
-    projection
-        .map(|indices| indices.to_vec())
-        .unwrap_or_else(|| (0..width).collect())
-}
-
-pub(crate) fn build_batch(
-    schema: SchemaRef,
-    arrays: Vec<ArrayRef>,
-    row_count: usize,
-) -> Result<RecordBatch> {
-    let options = RecordBatchOptions::new().with_row_count(Some(row_count));
-    RecordBatch::try_new_with_options(schema, arrays, &options)
-        .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))
-}
-
-pub(crate) fn to_external_error(
-    error: impl std::error::Error + Send + Sync + 'static,
-) -> DataFusionError {
-    DataFusionError::External(Box::new(error))
-}
-
-pub(crate) fn projection_display(schema: &SchemaRef) -> String {
-    if schema.fields().is_empty() {
-        String::new()
-    } else {
-        schema
-            .fields()
-            .iter()
-            .map(|field| field.name().as_str())
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-}
-
-pub(crate) fn plan_bbi_scan_regions(
-    filters: &[Expr],
-    chroms: &[(String, u32)],
-    coordinate_system_zero_based: bool,
-) -> Vec<BbiScanRegion> {
-    let analysis = extract_genomic_regions(filters, coordinate_system_zero_based);
-    if analysis.unsatisfiable {
-        return Vec::new();
-    }
-
-    let source_regions = if analysis.regions.is_empty() {
-        chroms
-            .iter()
-            .map(|(chrom, _)| GenomicRegion {
-                chrom: chrom.clone(),
-                start: None,
-                end: None,
-                unmapped_tail: false,
-            })
-            .collect::<Vec<_>>()
-    } else {
-        analysis.regions
-    };
-
-    source_regions
-        .into_iter()
-        .filter_map(|region| convert_genomic_region_to_bbi(region, chroms))
-        .collect()
-}
-
-fn convert_genomic_region_to_bbi(
-    region: GenomicRegion,
-    chroms: &[(String, u32)],
-) -> Option<BbiScanRegion> {
-    let length = chroms
-        .iter()
-        .find_map(|(chrom, length)| (chrom == &region.chrom).then_some(*length))?;
-    let start = region
-        .start
-        .map(|start| start.saturating_sub(1).min(length as u64) as u32)
-        .unwrap_or(0);
-    let end = region
-        .end
-        .map(|end| end.min(length as u64) as u32)
-        .unwrap_or(length);
-
-    (start < end).then_some(BbiScanRegion {
-        chrom: region.chrom,
-        start,
-        end,
-    })
-}
-
-pub(crate) fn region_display(regions: &[BbiScanRegion]) -> String {
-    regions
-        .iter()
-        .map(|region| format!("{}:{}-{}", region.chrom, region.start, region.end))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-pub(crate) fn reject_unsupported_scheme(path: &str, format_name: &str) -> Result<()> {
-    if path.contains("://") && !path.starts_with("file://") {
-        return Err(DataFusionError::NotImplemented(format!(
-            "{format_name} only supports local filesystem paths in this version"
-        )));
-    }
-    Ok(())
 }

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -1,0 +1,388 @@
+//! BigWig DataFusion table provider.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bigtools::BigWigRead;
+use datafusion::arrow::array::{
+    ArrayRef, Float32Array, RecordBatch, RecordBatchOptions, StringArray, UInt32Array,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
+use datafusion_bio_format_core::genomic_filter::{
+    GenomicRegion, extract_genomic_regions, is_genomic_coordinate_filter,
+};
+use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
+
+/// Native BBI interval query region in 0-based half-open coordinates.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BbiScanRegion {
+    pub(crate) chrom: String,
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
+
+/// Table provider for local BigWig files.
+#[derive(Clone, Debug)]
+pub struct BigWigTableProvider {
+    file_path: String,
+    schema: SchemaRef,
+    full_schema: SchemaRef,
+    chroms: Vec<(String, u32)>,
+    coordinate_system_zero_based: bool,
+}
+
+impl BigWigTableProvider {
+    /// Create a BigWig provider for a local file path.
+    pub fn new(file_path: String, coordinate_system_zero_based: bool) -> Result<Self> {
+        reject_unsupported_scheme(&file_path, "BigWig")?;
+        let reader = BigWigRead::open_file(&file_path).map_err(|error| {
+            DataFusionError::External(Box::new(std::io::Error::other(format!(
+                "Failed to open BigWig file '{file_path}': {error}"
+            ))))
+        })?;
+        let chroms = reader
+            .chroms()
+            .iter()
+            .map(|chrom| (chrom.name.clone(), chrom.length))
+            .collect::<Vec<_>>();
+        let full_schema = bigwig_schema(coordinate_system_zero_based);
+        Ok(Self {
+            file_path,
+            schema: full_schema.clone(),
+            full_schema,
+            chroms,
+            coordinate_system_zero_based,
+        })
+    }
+}
+
+#[async_trait]
+impl TableProvider for BigWigTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|expr| {
+                if is_genomic_coordinate_filter(expr)
+                    || can_push_down_record_filter(expr, &self.full_schema)
+                {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let schema = project_schema(&self.full_schema, projection);
+        let regions =
+            plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
+        Ok(Arc::new(BigWigExec {
+            file_path: self.file_path.clone(),
+            schema: schema.clone(),
+            projection: projection.cloned(),
+            regions,
+            coordinate_system_zero_based: self.coordinate_system_zero_based,
+            cache: PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ),
+        }))
+    }
+}
+
+/// Physical execution plan for BigWig scans.
+pub struct BigWigExec {
+    file_path: String,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    regions: Vec<BbiScanRegion>,
+    coordinate_system_zero_based: bool,
+    cache: PlanProperties,
+}
+
+impl Debug for BigWigExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BigWigExec")
+            .field("projection", &self.projection)
+            .finish()
+    }
+}
+
+impl DisplayAs for BigWigExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BigWigExec: projection=[{}], regions=[{}]",
+            projection_display(&self.schema),
+            region_display(&self.regions)
+        )
+    }
+}
+
+impl ExecutionPlan for BigWigExec {
+    fn name(&self) -> &str {
+        "BigWigExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let batch = read_bigwig_batch(
+            &self.file_path,
+            &self.schema,
+            self.projection.as_deref(),
+            &self.regions,
+            self.coordinate_system_zero_based,
+        )?;
+        let stream = futures_util::stream::iter(vec![Ok(batch)]);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema.clone(),
+            stream,
+        )))
+    }
+}
+
+fn bigwig_schema(coordinate_system_zero_based: bool) -> SchemaRef {
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        COORDINATE_SYSTEM_METADATA_KEY.to_string(),
+        coordinate_system_zero_based.to_string(),
+    );
+    Arc::new(Schema::new_with_metadata(
+        vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("end", DataType::UInt32, false),
+            Field::new("value", DataType::Float32, false),
+        ],
+        metadata,
+    ))
+}
+
+fn read_bigwig_batch(
+    file_path: &str,
+    schema: &SchemaRef,
+    projection: Option<&[usize]>,
+    regions: &[BbiScanRegion],
+    coordinate_system_zero_based: bool,
+) -> Result<RecordBatch> {
+    let mut reader = BigWigRead::open_file(file_path).map_err(|error| {
+        DataFusionError::External(Box::new(std::io::Error::other(format!(
+            "Failed to open BigWig file '{file_path}': {error}"
+        ))))
+    })?;
+
+    let mut rows = Vec::new();
+    for region in regions {
+        let iter = reader
+            .get_interval(&region.chrom, region.start, region.end)
+            .map_err(to_external_error)?;
+        for value in iter {
+            let value = value.map_err(to_external_error)?;
+            let start = if coordinate_system_zero_based {
+                value.start
+            } else {
+                value.start + 1
+            };
+            rows.push((region.chrom.clone(), start, value.end, value.value));
+        }
+    }
+
+    let row_count = rows.len();
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
+    for index in projected_indices(projection, 4) {
+        match index {
+            0 => arrays.push(Arc::new(StringArray::from_iter_values(
+                rows.iter().map(|row| row.0.as_str()),
+            ))),
+            1 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                rows.iter().map(|row| row.1),
+            ))),
+            2 => arrays.push(Arc::new(UInt32Array::from_iter_values(
+                rows.iter().map(|row| row.2),
+            ))),
+            3 => arrays.push(Arc::new(Float32Array::from_iter_values(
+                rows.iter().map(|row| row.3),
+            ))),
+            _ => unreachable!("BigWig projection contains invalid column index"),
+        }
+    }
+
+    build_batch(schema.clone(), arrays, row_count)
+}
+
+pub(crate) fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
+    match projection {
+        Some(indices) => Arc::new(Schema::new_with_metadata(
+            indices
+                .iter()
+                .map(|&index| schema.field(index).clone())
+                .collect::<Vec<_>>(),
+            schema.metadata().clone(),
+        )),
+        None => schema.clone(),
+    }
+}
+
+pub(crate) fn projected_indices(projection: Option<&[usize]>, width: usize) -> Vec<usize> {
+    projection
+        .map(|indices| indices.to_vec())
+        .unwrap_or_else(|| (0..width).collect())
+}
+
+pub(crate) fn build_batch(
+    schema: SchemaRef,
+    arrays: Vec<ArrayRef>,
+    row_count: usize,
+) -> Result<RecordBatch> {
+    let options = RecordBatchOptions::new().with_row_count(Some(row_count));
+    RecordBatch::try_new_with_options(schema, arrays, &options)
+        .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))
+}
+
+pub(crate) fn to_external_error(
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(error))
+}
+
+pub(crate) fn projection_display(schema: &SchemaRef) -> String {
+    if schema.fields().is_empty() {
+        String::new()
+    } else {
+        schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+pub(crate) fn plan_bbi_scan_regions(
+    filters: &[Expr],
+    chroms: &[(String, u32)],
+    coordinate_system_zero_based: bool,
+) -> Vec<BbiScanRegion> {
+    let analysis = extract_genomic_regions(filters, coordinate_system_zero_based);
+    if analysis.unsatisfiable {
+        return Vec::new();
+    }
+
+    let source_regions = if analysis.regions.is_empty() {
+        chroms
+            .iter()
+            .map(|(chrom, _)| GenomicRegion {
+                chrom: chrom.clone(),
+                start: None,
+                end: None,
+                unmapped_tail: false,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        analysis.regions
+    };
+
+    source_regions
+        .into_iter()
+        .filter_map(|region| convert_genomic_region_to_bbi(region, chroms))
+        .collect()
+}
+
+fn convert_genomic_region_to_bbi(
+    region: GenomicRegion,
+    chroms: &[(String, u32)],
+) -> Option<BbiScanRegion> {
+    let length = chroms
+        .iter()
+        .find_map(|(chrom, length)| (chrom == &region.chrom).then_some(*length))?;
+    let start = region
+        .start
+        .map(|start| start.saturating_sub(1).min(length as u64) as u32)
+        .unwrap_or(0);
+    let end = region
+        .end
+        .map(|end| end.min(length as u64) as u32)
+        .unwrap_or(length);
+
+    (start < end).then_some(BbiScanRegion {
+        chrom: region.chrom,
+        start,
+        end,
+    })
+}
+
+pub(crate) fn region_display(regions: &[BbiScanRegion]) -> String {
+    regions
+        .iter()
+        .map(|region| format!("{}:{}-{}", region.chrom, region.start, region.end))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub(crate) fn reject_unsupported_scheme(path: &str, format_name: &str) -> Result<()> {
+    if path.contains("://") && !path.starts_with("file://") {
+        return Err(DataFusionError::NotImplemented(format!(
+            "{format_name} only supports local filesystem paths in this version"
+        )));
+    }
+    Ok(())
+}

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -13,6 +13,13 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::logical_expr::Expr;
 use datafusion_bio_format_core::genomic_filter::{GenomicRegion, extract_genomic_regions};
 
+/// Maximum number of rows emitted per [`RecordBatch`] while streaming a region.
+///
+/// Region iterators are pulled in chunks of this size so peak memory stays
+/// bounded (a whole chromosome is never buffered) and `LIMIT`/`COUNT` queries
+/// can stop early instead of reading the entire region.
+pub(crate) const BBI_BATCH_ROWS: usize = 8192;
+
 /// Native BBI interval query region in 0-based half-open coordinates.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BbiScanRegion {
@@ -142,9 +149,22 @@ pub(crate) fn region_display(regions: &[BbiScanRegion]) -> String {
 /// `BigWigRead`/`BigBedRead` open plain paths rather than URIs.
 pub(crate) fn normalize_local_path(path: &str, format_name: &str) -> Result<String> {
     if let Some(rest) = path.strip_prefix("file://") {
-        // Accept `file:///abs/path` and the optional `file://localhost/abs/path`
-        // authority form, both of which map to a local filesystem path.
-        let local = rest.strip_prefix("localhost").unwrap_or(rest);
+        // Per RFC 8089 the authority must be empty or `localhost` for a local
+        // path: `file:///abs/path` or `file://localhost/abs/path`. A non-empty,
+        // non-`localhost` authority names a remote host and is unsupported.
+        let local = if rest.starts_with('/') {
+            rest
+        } else if let Some(after_host) = rest.strip_prefix("localhost") {
+            // Keep `after_host`'s leading slash so the result stays absolute.
+            // Reject `localhostfoo/...` (authority that merely starts with it).
+            if after_host.is_empty() || after_host.starts_with('/') {
+                after_host
+            } else {
+                return Err(remote_host_error(format_name));
+            }
+        } else {
+            return Err(remote_host_error(format_name));
+        };
         return Ok(local.to_string());
     }
     if path.contains("://") {
@@ -153,4 +173,10 @@ pub(crate) fn normalize_local_path(path: &str, format_name: &str) -> Result<Stri
         )));
     }
     Ok(path.to_string())
+}
+
+fn remote_host_error(format_name: &str) -> DataFusionError {
+    DataFusionError::NotImplemented(format!(
+        "{format_name} does not support remote file:// URIs with a host authority"
+    ))
 }

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -1,0 +1,156 @@
+//! Shared helpers for the BigWig and BigBed table providers.
+//!
+//! These utilities are format-agnostic (schema projection, batch construction,
+//! genomic-region planning, path validation) and are reused by both
+//! [`crate::bigwig`] and [`crate::bigbed`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::logical_expr::Expr;
+use datafusion_bio_format_core::genomic_filter::{GenomicRegion, extract_genomic_regions};
+
+/// Native BBI interval query region in 0-based half-open coordinates.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BbiScanRegion {
+    pub(crate) chrom: String,
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
+
+pub(crate) fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
+    match projection {
+        Some(indices) => Arc::new(Schema::new_with_metadata(
+            indices
+                .iter()
+                .map(|&index| schema.field(index).clone())
+                .collect::<Vec<_>>(),
+            schema.metadata().clone(),
+        )),
+        None => schema.clone(),
+    }
+}
+
+pub(crate) fn projected_indices(projection: Option<&[usize]>, width: usize) -> Vec<usize> {
+    projection
+        .map(|indices| indices.to_vec())
+        .unwrap_or_else(|| (0..width).collect())
+}
+
+pub(crate) fn build_batch(
+    schema: SchemaRef,
+    arrays: Vec<ArrayRef>,
+    row_count: usize,
+) -> Result<RecordBatch> {
+    let options = RecordBatchOptions::new().with_row_count(Some(row_count));
+    RecordBatch::try_new_with_options(schema, arrays, &options)
+        .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))
+}
+
+pub(crate) fn to_external_error(
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(error))
+}
+
+pub(crate) fn projection_display(schema: &SchemaRef) -> String {
+    if schema.fields().is_empty() {
+        String::new()
+    } else {
+        schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+pub(crate) fn plan_bbi_scan_regions(
+    filters: &[Expr],
+    chroms: &[(String, u32)],
+    coordinate_system_zero_based: bool,
+) -> Vec<BbiScanRegion> {
+    let analysis = extract_genomic_regions(filters, coordinate_system_zero_based);
+    if analysis.unsatisfiable {
+        return Vec::new();
+    }
+
+    let source_regions = if analysis.regions.is_empty() {
+        chroms
+            .iter()
+            .map(|(chrom, _)| GenomicRegion {
+                chrom: chrom.clone(),
+                start: None,
+                end: None,
+                unmapped_tail: false,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        analysis.regions
+    };
+
+    // O(1) chromosome-length lookup; the `chroms` vec still drives ordering of
+    // the no-filter, whole-genome expansion above.
+    let chrom_lengths: HashMap<&str, u32> = chroms
+        .iter()
+        .map(|(chrom, len)| (chrom.as_str(), *len))
+        .collect();
+
+    source_regions
+        .into_iter()
+        .filter_map(|region| convert_genomic_region_to_bbi(region, &chrom_lengths))
+        .collect()
+}
+
+fn convert_genomic_region_to_bbi(
+    region: GenomicRegion,
+    chrom_lengths: &HashMap<&str, u32>,
+) -> Option<BbiScanRegion> {
+    let length = *chrom_lengths.get(region.chrom.as_str())?;
+    let start = region
+        .start
+        .map(|start| start.saturating_sub(1).min(length as u64) as u32)
+        .unwrap_or(0);
+    let end = region
+        .end
+        .map(|end| end.min(length as u64) as u32)
+        .unwrap_or(length);
+
+    (start < end).then_some(BbiScanRegion {
+        chrom: region.chrom,
+        start,
+        end,
+    })
+}
+
+pub(crate) fn region_display(regions: &[BbiScanRegion]) -> String {
+    regions
+        .iter()
+        .map(|region| format!("{}:{}-{}", region.chrom, region.start, region.end))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Validate a user-supplied path for the local-only BBI providers.
+///
+/// Remote URI schemes (`s3://`, `gs://`, ...) are rejected with a clear error.
+/// A `file://` URI is accepted and normalized to a bare filesystem path, since
+/// `BigWigRead`/`BigBedRead` open plain paths rather than URIs.
+pub(crate) fn normalize_local_path(path: &str, format_name: &str) -> Result<String> {
+    if let Some(rest) = path.strip_prefix("file://") {
+        // Accept `file:///abs/path` and the optional `file://localhost/abs/path`
+        // authority form, both of which map to a local filesystem path.
+        let local = rest.strip_prefix("localhost").unwrap_or(rest);
+        return Ok(local.to_string());
+    }
+    if path.contains("://") {
+        return Err(DataFusionError::NotImplemented(format!(
+            "{format_name} only supports local filesystem paths in this version"
+        )));
+    }
+    Ok(path.to_string())
+}

--- a/datafusion/bio-format-bbi/src/lib.rs
+++ b/datafusion/bio-format-bbi/src/lib.rs
@@ -1,0 +1,8 @@
+//! BigWig and BigBed file format support for Apache DataFusion.
+
+#![warn(missing_docs)]
+
+/// BigBed table provider.
+pub mod bigbed;
+/// BigWig table provider.
+pub mod bigwig;

--- a/datafusion/bio-format-bbi/src/lib.rs
+++ b/datafusion/bio-format-bbi/src/lib.rs
@@ -6,3 +6,4 @@
 pub mod bigbed;
 /// BigWig table provider.
 pub mod bigwig;
+mod common;

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -7,6 +7,8 @@ use bigtools::bed::bedparser::BedFileStream;
 use bigtools::beddata::BedParserStreamingIterator;
 use bigtools::{BigBedWrite, BigWigWrite};
 use datafusion::arrow::array::{Float32Array, StringArray, UInt32Array, UInt64Array};
+use datafusion::catalog::TableProvider;
+use datafusion::physical_plan::common::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::*;
 use datafusion_bio_format_bbi::bigbed::{BigBedSchemaMode, BigBedTableProvider};
@@ -326,6 +328,86 @@ async fn accepts_file_uri_paths() -> TestResult<()> {
     assert_eq!(rows, 3);
 
     Ok(())
+}
+
+fn write_large_bigwig_fixture(intervals: u32) -> TestResult<NamedTempFile> {
+    std::thread::spawn(move || write_large_bigwig_fixture_inner(intervals))
+        .join()
+        .unwrap()
+}
+
+fn write_large_bigwig_fixture_inner(intervals: u32) -> TestResult<NamedTempFile> {
+    let mut bedgraph = NamedTempFile::new()?;
+    for i in 0..intervals {
+        // Non-overlapping 1bp intervals at positions 0, 2, 4, ...
+        writeln!(bedgraph, "chr1\t{}\t{}\t{}", i * 2, i * 2 + 1, i as f32)?;
+    }
+    bedgraph.flush()?;
+
+    let sizes = HashMap::from([("chr1".to_string(), intervals * 2 + 10)]);
+    let bigwig = NamedTempFile::new()?;
+    let out = BigWigWrite::create_file(bigwig.path(), sizes)?;
+    let input = File::open(bedgraph.path())?;
+    let data = BedParserStreamingIterator::from_bedgraph_file(input, false);
+    out.write(data, runtime())?;
+    Ok(bigwig)
+}
+
+#[tokio::test]
+async fn streams_large_region_in_fixed_size_batches() -> TestResult<()> {
+    // More intervals than one batch holds, so a single (unfiltered) chromosome
+    // region must be emitted as several fixed-size batches rather than buffered
+    // whole.
+    let intervals = 20_000u32;
+    let fixture = write_large_bigwig_fixture(intervals)?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    let state = ctx.state();
+    let plan = table.scan(&state, None, &[], None).await?;
+    let stream = plan.execute(0, ctx.task_ctx())?;
+    let batches = collect(stream).await?;
+
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, intervals as usize);
+    assert!(
+        batches.len() >= 2,
+        "expected multiple fixed-size batches, got {}",
+        batches.len()
+    );
+    assert!(
+        batches.iter().all(|b| b.num_rows() <= 8192),
+        "no batch should exceed the chunk size"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn accepts_file_localhost_uri_paths() -> TestResult<()> {
+    let fixture = write_bigwig_fixture()?;
+    let uri = format!("file://localhost{}", fixture.path().to_string_lossy());
+    let table = BigWigTableProvider::new(uri, true)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let df = ctx.sql("SELECT chrom FROM bw").await?;
+    let batches = df.collect().await?;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 3);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_remote_host_file_uri() {
+    let result = BigWigTableProvider::new("file://example.com/data/file.bw".to_string(), true);
+    let error = result.expect_err("remote file:// host authority must be rejected");
+    assert!(
+        error.to_string().contains("remote file:// URIs"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test]

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -274,6 +274,80 @@ async fn filters_bigbed_by_genomic_region() -> TestResult<()> {
 }
 
 #[tokio::test]
+async fn rest_mode_exposes_single_rest_column() -> TestResult<()> {
+    let fixture = write_bigbed_fixture()?;
+    let table = BigBedTableProvider::new(
+        fixture.path().to_string_lossy().to_string(),
+        true,
+        BigBedSchemaMode::Rest,
+    )?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bb", Arc::new(table))?;
+
+    let df = ctx
+        .sql("SELECT chrom, start, \"end\", rest FROM bb ORDER BY chrom, start")
+        .await?;
+    let batches = df.collect().await?;
+
+    let columns = batches[0]
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().clone())
+        .collect::<Vec<_>>();
+    assert_eq!(columns, vec!["chrom", "start", "end", "rest"]);
+
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 3);
+
+    let rest = batches[0]
+        .column(3)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(rest.value(0), "gene1\t42");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn accepts_file_uri_paths() -> TestResult<()> {
+    let fixture = write_bigwig_fixture()?;
+    let uri = format!("file://{}", fixture.path().to_string_lossy());
+    let table = BigWigTableProvider::new(uri, true)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let df = ctx.sql("SELECT chrom FROM bw").await?;
+    let batches = df.collect().await?;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 3);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pushes_bigbed_projection_into_exec() -> TestResult<()> {
+    let fixture = write_bigbed_fixture()?;
+    let table = BigBedTableProvider::new(
+        fixture.path().to_string_lossy().to_string(),
+        true,
+        BigBedSchemaMode::Auto,
+    )?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bb", Arc::new(table))?;
+
+    let df = ctx.sql("SELECT chrom, start FROM bb").await?;
+    let plan = df.create_physical_plan().await?;
+    assert_plan_projection(&plan, "BigBedExec", &["chrom", "start"]);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn pushes_bigbed_genomic_filter_into_scan_regions() -> TestResult<()> {
     let fixture = write_bigbed_fixture()?;
     let table = BigBedTableProvider::new(

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -1,0 +1,308 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::sync::Arc;
+
+use bigtools::bed::bedparser::BedFileStream;
+use bigtools::beddata::BedParserStreamingIterator;
+use bigtools::{BigBedWrite, BigWigWrite};
+use datafusion::arrow::array::{Float32Array, StringArray, UInt32Array, UInt64Array};
+use datafusion::physical_plan::display::DisplayableExecutionPlan;
+use datafusion::prelude::*;
+use datafusion_bio_format_bbi::bigbed::{BigBedSchemaMode, BigBedTableProvider};
+use datafusion_bio_format_bbi::bigwig::BigWigTableProvider;
+use datafusion_bio_format_core::test_utils::assert_plan_projection;
+use tempfile::NamedTempFile;
+use tokio::runtime;
+
+fn runtime() -> runtime::Runtime {
+    runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .build()
+        .expect("failed to build test runtime")
+}
+
+fn chrom_sizes() -> HashMap<String, u32> {
+    HashMap::from([("chr1".to_string(), 100), ("chr2".to_string(), 100)])
+}
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+fn write_bigwig_fixture() -> TestResult<NamedTempFile> {
+    std::thread::spawn(write_bigwig_fixture_inner)
+        .join()
+        .unwrap()
+}
+
+fn write_bigwig_fixture_inner() -> TestResult<NamedTempFile> {
+    let mut bedgraph = NamedTempFile::new()?;
+    writeln!(bedgraph, "chr1\t0\t10\t1.5")?;
+    writeln!(bedgraph, "chr1\t20\t30\t2.5")?;
+    writeln!(bedgraph, "chr2\t5\t12\t3.5")?;
+    bedgraph.flush()?;
+
+    let bigwig = NamedTempFile::new()?;
+    let out = BigWigWrite::create_file(bigwig.path(), chrom_sizes())?;
+    let input = File::open(bedgraph.path())?;
+    let data = BedParserStreamingIterator::from_bedgraph_file(input, false);
+    out.write(data, runtime())?;
+    Ok(bigwig)
+}
+
+fn write_bigbed_fixture() -> TestResult<NamedTempFile> {
+    std::thread::spawn(write_bigbed_fixture_inner)
+        .join()
+        .unwrap()
+}
+
+fn write_bigbed_fixture_inner() -> TestResult<NamedTempFile> {
+    let mut bed = NamedTempFile::new()?;
+    writeln!(bed, "chr1\t0\t10\tgene1\t42")?;
+    writeln!(bed, "chr1\t20\t30\tgene2\t84")?;
+    writeln!(bed, "chr2\t5\t12\tgene3\t126")?;
+    bed.flush()?;
+
+    let bigbed = NamedTempFile::new()?;
+    let mut out = BigBedWrite::create_file(bigbed.path(), chrom_sizes())?;
+    let first_rest = {
+        use bigtools::bed::bedparser::StreamingBedValues;
+        let input = File::open(bed.path())?;
+        let mut vals = BedFileStream::from_bed_file(input);
+        vals.next().unwrap()?.1.rest
+    };
+    out.autosql = Some(bigtools::bed::autosql::bed_autosql(&first_rest));
+    out.options.compress = false;
+    let input = File::open(bed.path())?;
+    let data = BedParserStreamingIterator::from_bed_file(input, false);
+    out.write(data, runtime())?;
+    Ok(bigbed)
+}
+
+#[tokio::test]
+async fn scans_bigwig_as_interval_signal_rows() -> TestResult<()> {
+    let fixture = write_bigwig_fixture()?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let df = ctx
+        .sql("SELECT chrom, start, \"end\", value FROM bw ORDER BY chrom, start")
+        .await?;
+    let batches = df.collect().await?;
+
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    assert_eq!(batch.num_rows(), 3);
+    assert_eq!(
+        batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name())
+            .collect::<Vec<_>>(),
+        vec!["chrom", "start", "end", "value"]
+    );
+
+    let chrom = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let start = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    let end = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    let value = batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .unwrap();
+
+    assert_eq!(chrom.value(0), "chr1");
+    assert_eq!(start.value(0), 0);
+    assert_eq!(end.value(0), 10);
+    assert_eq!(value.value(0), 1.5);
+    assert_eq!(chrom.value(2), "chr2");
+    assert_eq!(start.value(2), 5);
+    assert_eq!(value.value(2), 3.5);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pushes_bigwig_projection_into_exec() -> TestResult<()> {
+    let fixture = write_bigwig_fixture()?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let df = ctx.sql("SELECT chrom, start FROM bw").await?;
+    let plan = df.create_physical_plan().await?;
+    assert_plan_projection(&plan, "BigWigExec", &["chrom", "start"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pushes_bigwig_genomic_filter_into_scan_regions() -> TestResult<()> {
+    let fixture = write_bigwig_fixture()?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let df = ctx
+        .sql("SELECT chrom, start FROM bw WHERE chrom = 'chr2' AND start < 10")
+        .await?;
+    let plan = df.create_physical_plan().await?;
+    let plan_text = DisplayableExecutionPlan::new(plan.as_ref())
+        .indent(false)
+        .to_string();
+
+    assert!(
+        plan_text.contains("BigWigExec"),
+        "expected BigWigExec in plan:\n{plan_text}"
+    );
+    assert!(
+        plan_text.contains("regions=[chr2:0-10]"),
+        "expected chr2 interval pruning in plan:\n{plan_text}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scans_bigbed_autosql_columns() -> TestResult<()> {
+    let fixture = write_bigbed_fixture()?;
+    let table = BigBedTableProvider::new(
+        fixture.path().to_string_lossy().to_string(),
+        true,
+        BigBedSchemaMode::Auto,
+    )?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bb", Arc::new(table))?;
+
+    let df = ctx
+        .sql("SELECT chrom, start, \"end\", name, score FROM bb ORDER BY chrom, start")
+        .await?;
+    let batches = df.collect().await?;
+
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    assert_eq!(batch.num_rows(), 3);
+    assert_eq!(
+        batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name())
+            .collect::<Vec<_>>(),
+        vec!["chrom", "start", "end", "name", "score"]
+    );
+
+    let chrom = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let start = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    let name = batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let score = batch
+        .column(4)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap();
+
+    assert_eq!(chrom.value(0), "chr1");
+    assert_eq!(start.value(0), 0);
+    assert_eq!(name.value(0), "gene1");
+    assert_eq!(score.value(2), 126);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn filters_bigbed_by_genomic_region() -> TestResult<()> {
+    let fixture = write_bigbed_fixture()?;
+    let table = BigBedTableProvider::new(
+        fixture.path().to_string_lossy().to_string(),
+        true,
+        BigBedSchemaMode::Auto,
+    )?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bb", Arc::new(table))?;
+
+    let df = ctx
+        .sql("SELECT chrom, start, \"end\", name FROM bb WHERE chrom = 'chr2' AND start < 10")
+        .await?;
+    let batches = df.collect().await?;
+
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    let batch = &batches[0];
+    let chrom = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let name = batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(chrom.value(0), "chr2");
+    assert_eq!(name.value(0), "gene3");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pushes_bigbed_genomic_filter_into_scan_regions() -> TestResult<()> {
+    let fixture = write_bigbed_fixture()?;
+    let table = BigBedTableProvider::new(
+        fixture.path().to_string_lossy().to_string(),
+        true,
+        BigBedSchemaMode::Auto,
+    )?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bb", Arc::new(table))?;
+
+    let df = ctx
+        .sql(
+            "SELECT chrom, start, name FROM bb WHERE chrom = 'chr1' AND start >= 20 AND start < 30",
+        )
+        .await?;
+    let plan = df.create_physical_plan().await?;
+    let plan_text = DisplayableExecutionPlan::new(plan.as_ref())
+        .indent(false)
+        .to_string();
+
+    assert!(
+        plan_text.contains("BigBedExec"),
+        "expected BigBedExec in plan:\n{plan_text}"
+    );
+    assert!(
+        plan_text.contains("regions=[chr1:20-30]"),
+        "expected chr1 interval pruning in plan:\n{plan_text}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `datafusion-bio-format-bbi` provider crate for BigWig and BigBed local scans
- support projection pushdown and genomic-region pruning for `chrom`, `start`, and `end`
- parse BigBed autoSQL columns with a `rest` fallback mode and add focused provider tests

## Dependency notes
- temporarily pins `bigtools` to `biodatageeks/bigtools` commit `c18d9a386bdb80583bfea50ae95aa234ce5f320c`
- upstream bigtools PR: https://github.com/jackh726/bigtools/pull/99

## Test Plan
- `cargo fmt --check`
- `cargo test -p datafusion-bio-format-bbi --test provider_test`
- `git diff --check`
