### PR TITLE
feat: Complete raw-free VEP transcript schema

### DIFF
--- a/datafusion/bio-format-ensembl-cache/README.md
+++ b/datafusion/bio-format-ensembl-cache/README.md
@@ -101,6 +101,12 @@ of transcripts that would otherwise have no exon entries.
 | `gene_hgnc_id` | Utf8 | yes | HGNC ID parsed from the raw VEP object, with no export-time propagation/backfill |
 | `gene_hgnc_id_native` | Utf8 | yes | Stable copy of the native raw-object HGNC ID. In exported cache files it is identical to `gene_hgnc_id`; downstream annotation engines can preserve it if they later overwrite `gene_hgnc_id` |
 | `refseq_id` | Utf8 | yes | RefSeq transcript ID |
+| `display_xref_id` | Utf8 | yes | Transcript display xref display ID, from `display_xref.display_id` |
+| `source_cache` | Utf8 | yes | Raw VEP `_source_cache` value, preserved without normalization |
+| `refseq_match` | Utf8 | yes | Unique transcript attribute codes starting with `rseq`, in encounter order, joined by `&` |
+| `refseq_edits` | `List<Struct<start:Int64, end:Int64, replacement_len:Int64?, skip_refseq_offset:Boolean>>` | yes | Parsed `_rna_edit` metadata for RefSeq offset and edited-sequence behavior |
+| `is_gencode_basic` | Boolean | no | True when transcript attributes contain `gencode_basic`; false otherwise |
+| `is_gencode_primary` | Boolean | no | True when transcript attributes contain `gencode_primary`; false otherwise |
 | `cds_start` | Int64 | yes | CDS genomic start |
 | `cds_end` | Int64 | yes | CDS genomic end |
 | `cdna_coding_start` | Int64 | yes | cDNA coding start offset |
@@ -303,9 +309,15 @@ Transcript, exon, and translation schemas support projection pushdown. When VEP-
 columns (e.g. `exons`, `cdna_seq`, `peptide_seq`, `mature_mirna_regions`,
 `cdna_mapper_segments`, `spliced_seq`, `translation_seq`, `cds_sequence`,
 `translation_seq_canonical`, `cds_sequence_canonical`,
-`protein_features`, `sift_predictions`, `polyphen_predictions`) are not
+`display_xref_id`, `source_cache`, `refseq_match`, `refseq_edits`,
+`is_gencode_basic`, `is_gencode_primary`, `protein_features`,
+`sift_predictions`, `polyphen_predictions`) are not
 selected in a query, the parser skips extracting those fields, significantly
 reducing parse overhead.
+
+Downstream annotation queries can use the promoted transcript columns needed by
+VEP consequence logic without selecting `raw_object_json`; that column remains
+available for traceability and debugging.
 
 ## Parallel Scanning
 

--- a/datafusion/bio-format-ensembl-cache/src/schema.rs
+++ b/datafusion/bio-format-ensembl-cache/src/schema.rs
@@ -34,6 +34,18 @@ pub(crate) fn cdna_mapper_segment_list_data_type() -> DataType {
     DataType::List(Arc::new(Field::new("item", DataType::Struct(fields), true)))
 }
 
+/// Returns the Arrow `DataType` for RefSeq RNA edit metadata:
+/// `List<Struct<start:Int64, end:Int64, replacement_len:Int64?, skip_refseq_offset:Boolean>>`.
+pub(crate) fn refseq_edit_list_data_type() -> DataType {
+    let fields = Fields::from(vec![
+        Field::new("start", DataType::Int64, false),
+        Field::new("end", DataType::Int64, false),
+        Field::new("replacement_len", DataType::Int64, true),
+        Field::new("skip_refseq_offset", DataType::Boolean, false),
+    ]);
+    DataType::List(Arc::new(Field::new("item", DataType::Struct(fields), true)))
+}
+
 /// Returns the Arrow `DataType` for protein features:
 /// `List<Struct<analysis:Utf8, hseqname:Utf8, start:Int64, end:Int64>>`.
 pub(crate) fn protein_feature_list_data_type() -> DataType {
@@ -180,6 +192,12 @@ pub(crate) fn transcript_schema(
         Field::new("gene_hgnc_id", DataType::Utf8, true),
         Field::new("gene_hgnc_id_native", DataType::Utf8, true),
         Field::new("refseq_id", DataType::Utf8, true),
+        Field::new("display_xref_id", DataType::Utf8, true),
+        Field::new("source_cache", DataType::Utf8, true),
+        Field::new("refseq_match", DataType::Utf8, true),
+        Field::new("refseq_edits", refseq_edit_list_data_type(), true),
+        Field::new("is_gencode_basic", DataType::Boolean, false),
+        Field::new("is_gencode_primary", DataType::Boolean, false),
         Field::new("cds_start", DataType::Int64, true),
         Field::new("cds_end", DataType::Int64, true),
         Field::new("cdna_coding_start", DataType::Int64, true),

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -842,7 +842,7 @@ fn parse_transcript_attributes_json(
             "gencode_primary" => {
                 out.is_gencode_primary = true;
             }
-            "_rna_edit" => {
+            _ if code.starts_with("_rna_edit") => {
                 if check_rna_edits && !out.has_non_polya_rna_edit && is_non_polya_rna_edit(value) {
                     out.has_non_polya_rna_edit = true;
                 }
@@ -920,7 +920,7 @@ fn parse_transcript_attributes_storable(
             "gencode_primary" => {
                 out.is_gencode_primary = true;
             }
-            "_rna_edit" => {
+            code if code.starts_with("_rna_edit") => {
                 if check_rna_edits && !out.has_non_polya_rna_edit && is_non_polya_rna_edit(&value) {
                     out.has_non_polya_rna_edit = true;
                 }
@@ -3027,6 +3027,7 @@ mod tests {
                 { "code": "gencode_primary", "value": "1" },
                 { "code": "_rna_edit", "value": "10 12 AAA" },
                 { "code": "_rna_edit", "value": "1 2 GG", "description": "op=X" },
+                { "code": "_rna_edit_foo", "value": "4 4 C" },
                 { "code": "_rna_edit", "value": "7 9" }
             ]
         });
@@ -3047,6 +3048,12 @@ mod tests {
                     start: 1,
                     end: 2,
                     replacement_len: Some(2),
+                    skip_refseq_offset: true,
+                },
+                RefseqEdit {
+                    start: 4,
+                    end: 4,
+                    replacement_len: Some(1),
                     skip_refseq_offset: true,
                 },
                 RefseqEdit {
@@ -3091,6 +3098,7 @@ mod tests {
                 attr("gencode_primary", "1", None),
                 attr("_rna_edit", "10 12 AAA", None),
                 attr("_rna_edit", "1 2 GG", Some("op=X")),
+                attr("_rna_edit_1", "4 4 C", None),
                 attr("_rna_edit", "7 9", None),
             ])),
         );
@@ -3110,6 +3118,12 @@ mod tests {
                     start: 1,
                     end: 2,
                     replacement_len: Some(2),
+                    skip_refseq_offset: true,
+                },
+                RefseqEdit {
+                    start: 4,
+                    end: 4,
+                    replacement_len: Some(1),
                     skip_refseq_offset: true,
                 },
                 RefseqEdit {

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -1412,8 +1412,8 @@ pub(crate) fn parse_transcript_line_into(
     if col_idx.gene_hgnc_id.is_some() || col_idx.gene_hgnc_id_native.is_some() {
         let native_value = json_str(
             object
-                .get("_gene_hgnc_id")
-                .or_else(|| object.get("gene_hgnc_id")),
+                .get("gene_hgnc_id")
+                .or_else(|| object.get("_gene_hgnc_id")),
         );
         if let Some(idx) = col_idx.gene_hgnc_id {
             batch.set_opt_utf8_owned(idx, native_value.as_ref());
@@ -1969,8 +1969,8 @@ fn append_transcript_storable_row_into(
     if col_idx.gene_hgnc_id.is_some() || col_idx.gene_hgnc_id_native.is_some() {
         let native_value = sv_str(
             object
-                .get("_gene_hgnc_id")
-                .or_else(|| object.get("gene_hgnc_id")),
+                .get("gene_hgnc_id")
+                .or_else(|| object.get("_gene_hgnc_id")),
         );
         if let Some(idx) = col_idx.gene_hgnc_id {
             batch.set_opt_utf8_owned(idx, native_value.as_ref());
@@ -2768,46 +2768,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_transcript_line_prefers_underscored_gene_hgnc_id() {
-        let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
-        let payload = json!({
-            "stable_id": "ENST000191",
-            "strand": 1,
-            "biotype": "protein_coding",
-            "_gene_hgnc_id": "HGNC:native",
-            "gene_hgnc_id": "HGNC:fallback"
-        });
-        let line = format!(
-            "1\t100\t200\tJSON:{}",
-            serde_json::to_string(&payload).unwrap()
-        );
-
-        let written = parse_transcript_line_into(
-            &line,
-            "/tmp/transcript.txt",
-            &cache_info,
-            &SimplePredicate::default(),
-            false,
-            &mut batch,
-            &col_idx,
-            &provenance,
-        )
-        .unwrap();
-
-        assert!(written);
-
-        let batch = batch.finish().unwrap();
-        assert_eq!(
-            batch_utf8_value(&batch, "gene_hgnc_id").as_deref(),
-            Some("HGNC:native")
-        );
-        assert_eq!(
-            batch_utf8_value(&batch, "gene_hgnc_id_native").as_deref(),
-            Some("HGNC:native")
-        );
-    }
-
-    #[test]
     fn append_transcript_storable_row_promotes_issue_190_fields() {
         let (mut batch, col_idx, provenance, _) = transcript_test_components("storable");
         let mut display_xref = HashMap::new();
@@ -2886,57 +2846,6 @@ mod tests {
         );
         assert_eq!(batch_bool_value(&batch, "is_gencode_basic"), Some(false));
         assert_eq!(batch_bool_value(&batch, "is_gencode_primary"), Some(true));
-    }
-
-    #[test]
-    fn append_transcript_storable_row_prefers_underscored_gene_hgnc_id() {
-        let (mut batch, col_idx, provenance, _) = transcript_test_components("storable");
-        let mut object = HashMap::new();
-        object.insert(
-            "biotype".to_string(),
-            SValue::String(Arc::from("protein_coding")),
-        );
-        object.insert(
-            "_gene_hgnc_id".to_string(),
-            SValue::String(Arc::from("HGNC:native")),
-        );
-        object.insert(
-            "gene_hgnc_id".to_string(),
-            SValue::String(Arc::from("HGNC:fallback")),
-        );
-
-        let payload = SValue::Hash(Arc::new(object.clone()));
-        let core = TranscriptRowCore {
-            chrom: "1".to_string(),
-            start: 100,
-            end: 200,
-            source_start: 100,
-            source_end: 200,
-            strand: 1,
-            stable_id: "ENST000191".to_string(),
-        };
-
-        append_transcript_storable_row_into(
-            &payload,
-            &object,
-            core,
-            false,
-            "/tmp/transcript.storable.gz",
-            &mut batch,
-            &col_idx,
-            &provenance,
-        )
-        .unwrap();
-
-        let batch = batch.finish().unwrap();
-        assert_eq!(
-            batch_utf8_value(&batch, "gene_hgnc_id").as_deref(),
-            Some("HGNC:native")
-        );
-        assert_eq!(
-            batch_utf8_value(&batch, "gene_hgnc_id_native").as_deref(),
-            Some("HGNC:native")
-        );
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -10,8 +10,9 @@ use crate::filter::SimplePredicate;
 use crate::info::CacheInfo;
 use crate::util::ProvenanceWriter;
 use crate::util::{
-    BatchBuilder, ColumnMap, canonical_json_string, json_bool, json_i32, json_i64, json_str,
-    normalize_genomic_end, normalize_genomic_start, open_binary_reader, parse_i64, stable_hash,
+    BatchBuilder, ColumnMap, RefseqEditTuple, canonical_json_string, json_bool, json_i32, json_i64,
+    json_str, normalize_genomic_end, normalize_genomic_start, open_binary_reader, parse_i64,
+    stable_hash,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -38,6 +39,12 @@ pub(crate) struct TranscriptColumnIndices {
     gene_hgnc_id: Option<usize>,
     gene_hgnc_id_native: Option<usize>,
     refseq_id: Option<usize>,
+    display_xref_id: Option<usize>,
+    source_cache: Option<usize>,
+    refseq_match: Option<usize>,
+    refseq_edits: Option<usize>,
+    is_gencode_basic: Option<usize>,
+    is_gencode_primary: Option<usize>,
     coding_region_start: Option<usize>,
     coding_region_end: Option<usize>,
     cdna_coding_start: Option<usize>,
@@ -107,12 +114,20 @@ impl TranscriptColumnIndices {
         let ncrna_structure = col_map.get("ncrna_structure");
         let has_non_polya_rna_edit = col_map.get("has_non_polya_rna_edit");
         let flags_str = col_map.get("flags_str");
+        let refseq_match = col_map.get("refseq_match");
+        let refseq_edits = col_map.get("refseq_edits");
+        let is_gencode_basic = col_map.get("is_gencode_basic");
+        let is_gencode_primary = col_map.get("is_gencode_primary");
         let transcript_attributes_projected = cds_start_nf.is_some()
             || cds_end_nf.is_some()
             || mature_mirna_regions.is_some()
             || ncrna_structure.is_some()
             || has_non_polya_rna_edit.is_some()
-            || flags_str.is_some();
+            || flags_str.is_some()
+            || refseq_match.is_some()
+            || refseq_edits.is_some()
+            || is_gencode_basic.is_some()
+            || is_gencode_primary.is_some();
 
         let cdna_mapper_segments = col_map.get("cdna_mapper_segments");
         let cdna_mapper_projected = cdna_mapper_segments.is_some();
@@ -134,6 +149,12 @@ impl TranscriptColumnIndices {
             gene_hgnc_id: col_map.get("gene_hgnc_id"),
             gene_hgnc_id_native: col_map.get("gene_hgnc_id_native"),
             refseq_id: col_map.get("refseq_id"),
+            display_xref_id: col_map.get("display_xref_id"),
+            source_cache: col_map.get("source_cache"),
+            refseq_match,
+            refseq_edits,
+            is_gencode_basic,
+            is_gencode_primary,
             coding_region_start: col_map.get("cds_start"),
             coding_region_end: col_map.get("cds_end"),
             cdna_coding_start: col_map.get("cdna_coding_start"),
@@ -531,6 +552,39 @@ fn sv_first_bool(
     keys.iter().find_map(|key| sv_bool(object.get(*key)))
 }
 
+fn json_display_xref_id(object: &serde_json::Map<String, Value>) -> Option<String> {
+    object
+        .get("display_xref")
+        .and_then(unwrap_blessed_object_optional)
+        .and_then(|display_xref| json_str(display_xref.get("display_id")))
+        .or_else(|| json_str(object.get("display_xref_id")))
+        .filter(|value| value != "-")
+}
+
+fn json_source_cache(object: &serde_json::Map<String, Value>) -> Option<String> {
+    match object.get("_source_cache") {
+        Some(Value::String(value)) if !value.is_empty() && value != "-" => Some(value.clone()),
+        Some(Value::Number(value)) => Some(value.to_string()),
+        Some(Value::Bool(value)) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn refseq_edit_tuples(attrs: &TranscriptAttributes) -> Vec<RefseqEditTuple> {
+    attrs
+        .refseq_edits
+        .iter()
+        .map(|edit| {
+            (
+                edit.start,
+                edit.end,
+                edit.replacement_len,
+                edit.skip_refseq_offset,
+            )
+        })
+        .collect()
+}
+
 /// Parse TSL attribute value like "tsl1" → 1, "tsl5" → 5, or plain "1" → 1.
 /// Also handles extended format "tsl2 (assigned to previous version 1)".
 fn parse_tsl_value(value: &str) -> Option<i32> {
@@ -708,7 +762,6 @@ fn sort_refseq_edits(edits: &mut [RefseqEdit]) {
     });
 }
 
-#[allow(dead_code)]
 fn build_refseq_match(attrs: &TranscriptAttributes) -> Option<String> {
     if attrs.refseq_match_codes.is_empty() {
         None
@@ -1259,6 +1312,14 @@ pub(crate) fn parse_transcript_line_into(
             .filter(|v| v != "-");
         batch.set_opt_utf8_owned(idx, refseq_id.as_ref());
     }
+    if let Some(idx) = col_idx.display_xref_id {
+        let value = json_display_xref_id(object);
+        batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
+    if let Some(idx) = col_idx.source_cache {
+        let value = json_source_cache(object);
+        batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
     // coding_region_start/end: read from object first; if null, derive from
     // cdna_coding_start/end + exon array (same derivation as storable path).
     let cdna_coding_start_val = json_i64(object.get("cdna_coding_start"));
@@ -1532,6 +1593,20 @@ pub(crate) fn parse_transcript_line_into(
             let value = build_flags_str(&attributes);
             batch.set_opt_utf8_owned(idx, value.as_ref());
         }
+        if let Some(idx) = col_idx.refseq_match {
+            let value = build_refseq_match(&attributes);
+            batch.set_opt_utf8_owned(idx, value.as_ref());
+        }
+        if let Some(idx) = col_idx.refseq_edits {
+            let edits = refseq_edit_tuples(&attributes);
+            batch.set_refseq_edit_list(idx, (!edits.is_empty()).then_some(edits.as_slice()));
+        }
+        if let Some(idx) = col_idx.is_gencode_basic {
+            batch.set_opt_bool(idx, Some(attributes.is_gencode_basic));
+        }
+        if let Some(idx) = col_idx.is_gencode_primary {
+            batch.set_opt_bool(idx, Some(attributes.is_gencode_primary));
+        }
     }
 
     // Only compute canonical JSON + hash if projected
@@ -1793,6 +1868,12 @@ fn append_transcript_storable_row_into(
         let value =
             sv_str(object.get("refseq_id").or_else(|| object.get("_refseq"))).filter(|v| v != "-");
         batch.set_opt_utf8_owned(idx, value.as_ref());
+    }
+    if let Some(idx) = col_idx.display_xref_id {
+        batch.set_null(idx);
+    }
+    if let Some(idx) = col_idx.source_cache {
+        batch.set_null(idx);
     }
     // coding_region_start/end: read from object first; if undef (common in
     // storable binary), derive from cdna_coding_start/end + exon array.
@@ -2077,6 +2158,18 @@ fn append_transcript_storable_row_into(
             let value = build_flags_str(&attributes);
             batch.set_opt_utf8_owned(idx, value.as_ref());
         }
+        if let Some(idx) = col_idx.refseq_match {
+            batch.set_null(idx);
+        }
+        if let Some(idx) = col_idx.refseq_edits {
+            batch.set_refseq_edit_list(idx, None);
+        }
+        if let Some(idx) = col_idx.is_gencode_basic {
+            batch.set_opt_bool(idx, Some(false));
+        }
+        if let Some(idx) = col_idx.is_gencode_primary {
+            batch.set_opt_bool(idx, Some(false));
+        }
     }
 
     // Only compute canonical JSON + hash if projected
@@ -2128,8 +2221,10 @@ mod tests {
     use crate::filter::SimplePredicate;
     use crate::info::CacheInfo;
     use crate::schema::transcript_schema;
-    use crate::util::{BatchBuilder, ColumnMap, ProvenanceWriter};
-    use datafusion::arrow::array::{Array, Int64Array, StringArray};
+    use crate::util::{BatchBuilder, ColumnMap, ProvenanceWriter, RefseqEditTuple};
+    use datafusion::arrow::array::{
+        Array, BooleanArray, Int64Array, ListArray, StringArray, StructArray,
+    };
     use serde_json::json;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -2212,6 +2307,90 @@ mod tests {
         } else {
             Some(values.value(0))
         }
+    }
+
+    fn batch_bool_value(
+        batch: &datafusion::arrow::record_batch::RecordBatch,
+        col: &str,
+    ) -> Option<bool> {
+        let (idx, _) = batch
+            .schema()
+            .column_with_name(col)
+            .unwrap_or_else(|| panic!("missing column: {col}"));
+        let values = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap_or_else(|| panic!("expected Boolean column: {col}"));
+        if values.is_null(0) {
+            None
+        } else {
+            Some(values.value(0))
+        }
+    }
+
+    fn batch_refseq_edit_values(
+        batch: &datafusion::arrow::record_batch::RecordBatch,
+    ) -> Option<Vec<RefseqEditTuple>> {
+        let (idx, _) = batch
+            .schema()
+            .column_with_name("refseq_edits")
+            .expect("missing refseq_edits column");
+        let list_array = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("expected ListArray for refseq_edits");
+        if list_array.is_null(0) {
+            return None;
+        }
+
+        let values = list_array.value(0);
+        let edits = values
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("expected StructArray for refseq_edits values");
+        let starts = edits
+            .column_by_name("start")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let ends = edits
+            .column_by_name("end")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let replacement_lens = edits
+            .column_by_name("replacement_len")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let skip_refseq_offsets = edits
+            .column_by_name("skip_refseq_offset")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+
+        Some(
+            (0..edits.len())
+                .map(|row| {
+                    (
+                        starts.value(row),
+                        ends.value(row),
+                        if replacement_lens.is_null(row) {
+                            None
+                        } else {
+                            Some(replacement_lens.value(row))
+                        },
+                        skip_refseq_offsets.value(row),
+                    )
+                })
+                .collect(),
+        )
     }
 
     fn storable_bioseq(seq: &str) -> SValue {
@@ -2351,6 +2530,65 @@ mod tests {
 
         let batch = batch.finish().unwrap();
         assert_eq!(batch_i64_value(&batch, "db_id"), Some(4242));
+    }
+
+    #[test]
+    fn parse_transcript_line_promotes_issue_190_fields() {
+        let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
+        let payload = json!({
+            "stable_id": "ENST000190",
+            "strand": 1,
+            "biotype": "protein_coding",
+            "_source_cache": "BestRefSeq",
+            "display_xref": {
+                "__class": "Bio::EnsEMBL::DBEntry",
+                "__value": { "display_id": "NM_000001.2" }
+            },
+            "attributes": [
+                { "code": "rseq_mrna_match", "value": "1" },
+                { "code": "rseq_cds_match", "value": "1" },
+                { "code": "gencode_basic", "value": "1" },
+                { "code": "_rna_edit", "value": "10 12 AAA" }
+            ]
+        });
+        let line = format!(
+            "1\t100\t200\tJSON:{}",
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let written = parse_transcript_line_into(
+            &line,
+            "/tmp/transcript.txt",
+            &cache_info,
+            &SimplePredicate::default(),
+            false,
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        assert!(written);
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "display_xref_id").as_deref(),
+            Some("NM_000001.2")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "source_cache").as_deref(),
+            Some("BestRefSeq")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "refseq_match").as_deref(),
+            Some("rseq_mrna_match&rseq_cds_match")
+        );
+        assert_eq!(
+            batch_refseq_edit_values(&batch),
+            Some(vec![(10, 12, Some(3), true)])
+        );
+        assert_eq!(batch_bool_value(&batch, "is_gencode_basic"), Some(true));
+        assert_eq!(batch_bool_value(&batch, "is_gencode_primary"), Some(false));
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -179,6 +179,14 @@ impl TranscriptColumnIndices {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RefseqEdit {
+    start: i64,
+    end: i64,
+    replacement_len: Option<i64>,
+    skip_refseq_offset: bool,
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct TranscriptAttributes {
     cds_start_nf: bool,
@@ -190,6 +198,10 @@ struct TranscriptAttributes {
     /// Raw ncRNA structure string from the "ncRNA" attribute (e.g. "(19.(6.(2.(4.14)12.)10.)9").
     ncrna_structure: Option<String>,
     has_non_polya_rna_edit: bool,
+    refseq_match_codes: Vec<String>,
+    refseq_edits: Vec<RefseqEdit>,
+    is_gencode_basic: bool,
+    is_gencode_primary: bool,
 }
 
 struct TranscriptRowCore {
@@ -658,6 +670,53 @@ fn is_non_polya_rna_edit(value: &str) -> bool {
     }
 }
 
+fn push_unique(values: &mut Vec<String>, value: &str) {
+    if !values.iter().any(|existing| existing == value) {
+        values.push(value.to_string());
+    }
+}
+
+fn parse_refseq_edit(value: &str, description: Option<&str>) -> Option<RefseqEdit> {
+    let parts = value.split_whitespace().collect::<Vec<_>>();
+    if !(parts.len() == 2 || parts.len() == 3) {
+        return None;
+    }
+    let start = parts[0].parse::<i64>().ok()?;
+    let end = parts[1].parse::<i64>().ok()?;
+    let replacement_len = if parts.len() == 3 {
+        Some(i64::try_from(parts[2].len()).ok()?)
+    } else {
+        None
+    };
+    let length_preserving = replacement_len.is_some_and(|len| end - start + 1 == len);
+    let op_x = description.is_some_and(|d| d.contains("op=X"));
+    Some(RefseqEdit {
+        start,
+        end,
+        replacement_len,
+        skip_refseq_offset: length_preserving || op_x,
+    })
+}
+
+fn sort_refseq_edits(edits: &mut [RefseqEdit]) {
+    edits.sort_by_key(|edit| {
+        (
+            edit.start,
+            edit.end,
+            edit.replacement_len.unwrap_or(i64::MIN),
+        )
+    });
+}
+
+#[allow(dead_code)]
+fn build_refseq_match(attrs: &TranscriptAttributes) -> Option<String> {
+    if attrs.refseq_match_codes.is_empty() {
+        None
+    } else {
+        Some(attrs.refseq_match_codes.join("&"))
+    }
+}
+
 fn parse_transcript_attributes_json(
     object: &serde_json::Map<String, Value>,
     tx_start: i64,
@@ -678,6 +737,11 @@ fn parse_transcript_attributes_json(
         };
         let code = attr_obj.get("code").and_then(Value::as_str).unwrap_or("");
         let value = attr_obj.get("value").and_then(Value::as_str).unwrap_or("");
+        let description = attr_obj.get("description").and_then(Value::as_str);
+
+        if code.starts_with("rseq") {
+            push_unique(&mut out.refseq_match_codes, code);
+        }
 
         match code {
             "cds_start_NF" if value == "1" => {
@@ -703,15 +767,25 @@ fn parse_transcript_attributes_json(
                     out.ncrna_structure = Some(structure.to_string());
                 }
             }
-            "_rna_edit" if check_rna_edits && !out.has_non_polya_rna_edit => {
-                if is_non_polya_rna_edit(value) {
+            "gencode_basic" => {
+                out.is_gencode_basic = true;
+            }
+            "gencode_primary" => {
+                out.is_gencode_primary = true;
+            }
+            "_rna_edit" => {
+                if check_rna_edits && !out.has_non_polya_rna_edit && is_non_polya_rna_edit(value) {
                     out.has_non_polya_rna_edit = true;
+                }
+                if let Some(edit) = parse_refseq_edit(value, description) {
+                    out.refseq_edits.push(edit);
                 }
             }
             _ => {}
         }
     }
 
+    sort_refseq_edits(&mut out.refseq_edits);
     out
 }
 
@@ -741,6 +815,11 @@ fn parse_transcript_attributes_storable(
             .get("value")
             .and_then(SValue::as_string)
             .unwrap_or_default();
+        let description = attr_obj.get("description").and_then(SValue::as_string);
+
+        if code.starts_with("rseq") {
+            push_unique(&mut out.refseq_match_codes, &code);
+        }
 
         match code.as_str() {
             "cds_start_NF" if value == "1" => {
@@ -766,15 +845,25 @@ fn parse_transcript_attributes_storable(
                     out.ncrna_structure = Some(structure.to_string());
                 }
             }
-            "_rna_edit" if check_rna_edits && !out.has_non_polya_rna_edit => {
-                if is_non_polya_rna_edit(&value) {
+            "gencode_basic" => {
+                out.is_gencode_basic = true;
+            }
+            "gencode_primary" => {
+                out.is_gencode_primary = true;
+            }
+            "_rna_edit" => {
+                if check_rna_edits && !out.has_non_polya_rna_edit && is_non_polya_rna_edit(&value) {
                     out.has_non_polya_rna_edit = true;
+                }
+                if let Some(edit) = parse_refseq_edit(&value, description.as_deref()) {
+                    out.refseq_edits.push(edit);
                 }
             }
             _ => {}
         }
     }
 
+    sort_refseq_edits(&mut out.refseq_edits);
     out
 }
 
@@ -2498,6 +2587,118 @@ mod tests {
         assert!(parsed.cds_start_nf);
         assert!(!parsed.cds_end_nf);
         assert_eq!(parsed.mature_mirna_regions, vec![(141, 158)]);
+    }
+
+    #[test]
+    fn parse_refseq_and_gencode_attributes_json() {
+        let payload = json!({
+            "attributes": [
+                { "code": "rseq_mrna_match", "value": "ignored" },
+                { "code": "rseq_mrna_match", "value": "duplicate ignored" },
+                { "code": "rseq_cds_match", "value": "ignored" },
+                { "code": "gencode_basic", "value": "1" },
+                { "code": "gencode_primary", "value": "1" },
+                { "code": "_rna_edit", "value": "10 12 AAA" },
+                { "code": "_rna_edit", "value": "1 2 GG", "description": "op=X" },
+                { "code": "_rna_edit", "value": "7 9" }
+            ]
+        });
+        let object = payload.as_object().unwrap();
+
+        let parsed = parse_transcript_attributes_json(object, 100, 200, 1, false, false, true);
+
+        assert_eq!(
+            build_refseq_match(&parsed).as_deref(),
+            Some("rseq_mrna_match&rseq_cds_match")
+        );
+        assert!(parsed.is_gencode_basic);
+        assert!(parsed.is_gencode_primary);
+        assert_eq!(
+            parsed.refseq_edits,
+            vec![
+                RefseqEdit {
+                    start: 1,
+                    end: 2,
+                    replacement_len: Some(2),
+                    skip_refseq_offset: true,
+                },
+                RefseqEdit {
+                    start: 7,
+                    end: 9,
+                    replacement_len: None,
+                    skip_refseq_offset: false,
+                },
+                RefseqEdit {
+                    start: 10,
+                    end: 12,
+                    replacement_len: Some(3),
+                    skip_refseq_offset: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_refseq_and_gencode_attributes_storable() {
+        fn attr(code: &str, value: &str, description: Option<&str>) -> SValue {
+            let mut attr = HashMap::new();
+            attr.insert("code".to_string(), SValue::String(Arc::from(code)));
+            attr.insert("value".to_string(), SValue::String(Arc::from(value)));
+            if let Some(description) = description {
+                attr.insert(
+                    "description".to_string(),
+                    SValue::String(Arc::from(description)),
+                );
+            }
+            SValue::Hash(Arc::new(attr))
+        }
+
+        let mut object = HashMap::new();
+        object.insert(
+            "attributes".to_string(),
+            SValue::Array(Arc::new(vec![
+                attr("rseq_mrna_match", "ignored", None),
+                attr("rseq_mrna_match", "duplicate ignored", None),
+                attr("rseq_cds_match", "ignored", None),
+                attr("gencode_basic", "1", None),
+                attr("gencode_primary", "1", None),
+                attr("_rna_edit", "10 12 AAA", None),
+                attr("_rna_edit", "1 2 GG", Some("op=X")),
+                attr("_rna_edit", "7 9", None),
+            ])),
+        );
+
+        let parsed = parse_transcript_attributes_storable(&object, 100, 200, 1, false, false, true);
+
+        assert_eq!(
+            build_refseq_match(&parsed).as_deref(),
+            Some("rseq_mrna_match&rseq_cds_match")
+        );
+        assert!(parsed.is_gencode_basic);
+        assert!(parsed.is_gencode_primary);
+        assert_eq!(
+            parsed.refseq_edits,
+            vec![
+                RefseqEdit {
+                    start: 1,
+                    end: 2,
+                    replacement_len: Some(2),
+                    skip_refseq_offset: true,
+                },
+                RefseqEdit {
+                    start: 7,
+                    end: 9,
+                    replacement_len: None,
+                    skip_refseq_offset: false,
+                },
+                RefseqEdit {
+                    start: 10,
+                    end: 12,
+                    replacement_len: Some(3),
+                    skip_refseq_offset: true,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -11,8 +11,8 @@ use crate::info::CacheInfo;
 use crate::util::ProvenanceWriter;
 use crate::util::{
     BatchBuilder, ColumnMap, RefseqEditTuple, canonical_json_string, json_bool, json_i32, json_i64,
-    json_str, normalize_genomic_end, normalize_genomic_start, open_binary_reader, parse_i64,
-    stable_hash,
+    json_str, normalize_genomic_end, normalize_genomic_start, open_binary_reader, parse_bool,
+    parse_i64, stable_hash,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -786,6 +786,10 @@ fn build_refseq_match(attrs: &TranscriptAttributes) -> Option<String> {
     }
 }
 
+fn presence_attribute_is_true(value: &str) -> bool {
+    parse_bool(Some(value)).unwrap_or(true)
+}
+
 fn parse_transcript_attributes_json(
     object: &serde_json::Map<String, Value>,
     tx_start: i64,
@@ -813,11 +817,11 @@ fn parse_transcript_attributes_json(
         }
 
         match code {
-            "cds_start_NF" if value == "1" => {
+            "cds_start_NF" if presence_attribute_is_true(value) => {
                 out.cds_start_nf = true;
                 out.cds_nf_order.push("cds_start_NF");
             }
-            "cds_end_NF" if value == "1" => {
+            "cds_end_NF" if presence_attribute_is_true(value) => {
                 out.cds_end_nf = true;
                 out.cds_nf_order.push("cds_end_NF");
             }
@@ -891,11 +895,11 @@ fn parse_transcript_attributes_storable(
         }
 
         match code.as_str() {
-            "cds_start_NF" if value == "1" => {
+            "cds_start_NF" if presence_attribute_is_true(&value) => {
                 out.cds_start_nf = true;
                 out.cds_nf_order.push("cds_start_NF");
             }
-            "cds_end_NF" if value == "1" => {
+            "cds_end_NF" if presence_attribute_is_true(&value) => {
                 out.cds_end_nf = true;
                 out.cds_nf_order.push("cds_end_NF");
             }
@@ -2965,6 +2969,23 @@ mod tests {
     }
 
     #[test]
+    fn json_transcript_attributes_treat_presence_only_cds_nf_as_true() {
+        let payload = json!({
+            "attributes": [
+                { "code": "cds_start_NF", "name": "CDS start not found", "value": "" },
+                { "code": "cds_end_NF", "name": "CDS end not found", "value": "0" }
+            ]
+        });
+        let object = payload.as_object().unwrap();
+
+        let parsed = parse_transcript_attributes_json(object, 100, 200, 1, false, false, false);
+
+        assert!(parsed.cds_start_nf);
+        assert!(!parsed.cds_end_nf);
+        assert_eq!(build_flags_str(&parsed).as_deref(), Some("cds_start_NF"));
+    }
+
+    #[test]
     fn json_transcript_attributes_parse_wrapped_minus_strand_regions() {
         let payload = json!({
             "attributes": [
@@ -3014,6 +3035,25 @@ mod tests {
         assert!(parsed.cds_start_nf);
         assert!(!parsed.cds_end_nf);
         assert_eq!(parsed.mature_mirna_regions, vec![(141, 158)]);
+    }
+
+    #[test]
+    fn storable_transcript_attributes_treat_presence_only_cds_nf_as_true() {
+        let mut object = HashMap::new();
+        object.insert(
+            "attributes".to_string(),
+            SValue::Array(Arc::new(vec![
+                storable_attribute("cds_start_NF", "false", None),
+                storable_attribute("cds_end_NF", "", None),
+            ])),
+        );
+
+        let parsed =
+            parse_transcript_attributes_storable(&object, 100, 200, 1, false, false, false);
+
+        assert!(!parsed.cds_start_nf);
+        assert!(parsed.cds_end_nf);
+        assert_eq!(build_flags_str(&parsed).as_deref(), Some("cds_end_NF"));
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -570,6 +570,22 @@ fn json_source_cache(object: &serde_json::Map<String, Value>) -> Option<String> 
     }
 }
 
+fn storable_display_xref_id(object: &std::collections::HashMap<String, SValue>) -> Option<String> {
+    object
+        .get("display_xref")
+        .and_then(SValue::as_hash)
+        .and_then(|display_xref| sv_str(display_xref.get("display_id")))
+        .or_else(|| sv_str(object.get("display_xref_id")))
+        .filter(|value| value != "-")
+}
+
+fn storable_source_cache(object: &std::collections::HashMap<String, SValue>) -> Option<String> {
+    object
+        .get("_source_cache")
+        .and_then(SValue::as_string)
+        .filter(|value| !value.is_empty() && value != "-")
+}
+
 fn refseq_edit_tuples(attrs: &TranscriptAttributes) -> Vec<RefseqEditTuple> {
     attrs
         .refseq_edits
@@ -1870,10 +1886,12 @@ fn append_transcript_storable_row_into(
         batch.set_opt_utf8_owned(idx, value.as_ref());
     }
     if let Some(idx) = col_idx.display_xref_id {
-        batch.set_null(idx);
+        let value = storable_display_xref_id(object);
+        batch.set_opt_utf8_owned(idx, value.as_ref());
     }
     if let Some(idx) = col_idx.source_cache {
-        batch.set_null(idx);
+        let value = storable_source_cache(object);
+        batch.set_opt_utf8_owned(idx, value.as_ref());
     }
     // coding_region_start/end: read from object first; if undef (common in
     // storable binary), derive from cdna_coding_start/end + exon array.
@@ -2159,16 +2177,18 @@ fn append_transcript_storable_row_into(
             batch.set_opt_utf8_owned(idx, value.as_ref());
         }
         if let Some(idx) = col_idx.refseq_match {
-            batch.set_null(idx);
+            let value = build_refseq_match(&attributes);
+            batch.set_opt_utf8_owned(idx, value.as_ref());
         }
         if let Some(idx) = col_idx.refseq_edits {
-            batch.set_refseq_edit_list(idx, None);
+            let edits = refseq_edit_tuples(&attributes);
+            batch.set_refseq_edit_list(idx, (!edits.is_empty()).then_some(edits.as_slice()));
         }
         if let Some(idx) = col_idx.is_gencode_basic {
-            batch.set_opt_bool(idx, Some(false));
+            batch.set_opt_bool(idx, Some(attributes.is_gencode_basic));
         }
         if let Some(idx) = col_idx.is_gencode_primary {
-            batch.set_opt_bool(idx, Some(false));
+            batch.set_opt_bool(idx, Some(attributes.is_gencode_primary));
         }
     }
 
@@ -2393,6 +2413,19 @@ mod tests {
         )
     }
 
+    fn storable_attribute(code: &str, value: &str, description: Option<&str>) -> SValue {
+        let mut attr = HashMap::new();
+        attr.insert("code".to_string(), SValue::String(Arc::from(code)));
+        attr.insert("value".to_string(), SValue::String(Arc::from(value)));
+        if let Some(description) = description {
+            attr.insert(
+                "description".to_string(),
+                SValue::String(Arc::from(description)),
+            );
+        }
+        SValue::Hash(Arc::new(attr))
+    }
+
     fn storable_bioseq(seq: &str) -> SValue {
         let mut primary = HashMap::new();
         primary.insert(
@@ -2589,6 +2622,87 @@ mod tests {
         );
         assert_eq!(batch_bool_value(&batch, "is_gencode_basic"), Some(true));
         assert_eq!(batch_bool_value(&batch, "is_gencode_primary"), Some(false));
+    }
+
+    #[test]
+    fn append_transcript_storable_row_promotes_issue_190_fields() {
+        let (mut batch, col_idx, provenance, _) = transcript_test_components("storable");
+        let mut display_xref = HashMap::new();
+        display_xref.insert(
+            "display_id".to_string(),
+            SValue::String(Arc::from("NM_000002.3")),
+        );
+
+        let mut object = HashMap::new();
+        object.insert(
+            "biotype".to_string(),
+            SValue::String(Arc::from("protein_coding")),
+        );
+        object.insert(
+            "_source_cache".to_string(),
+            SValue::String(Arc::from("LRG_RefSeq")),
+        );
+        object.insert(
+            "display_xref".to_string(),
+            SValue::Blessed {
+                class: Arc::from("Bio::EnsEMBL::DBEntry"),
+                value: Arc::new(SValue::Hash(Arc::new(display_xref))),
+            },
+        );
+        object.insert(
+            "attributes".to_string(),
+            SValue::Array(Arc::new(vec![
+                storable_attribute("rseq_mrna_match", "1", None),
+                storable_attribute("rseq_mrna_match", "duplicate ignored", None),
+                storable_attribute("rseq_cds_match", "1", None),
+                storable_attribute("gencode_primary", "1", None),
+                storable_attribute("_rna_edit", "30 30 T", None),
+                storable_attribute("_rna_edit", "20 25", Some("op=X")),
+            ])),
+        );
+
+        let payload = SValue::Hash(Arc::new(object.clone()));
+        let core = TranscriptRowCore {
+            chrom: "1".to_string(),
+            start: 100,
+            end: 200,
+            source_start: 100,
+            source_end: 200,
+            strand: 1,
+            stable_id: "ENST000190".to_string(),
+        };
+
+        append_transcript_storable_row_into(
+            &payload,
+            &object,
+            core,
+            false,
+            "/tmp/transcript.storable.gz",
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "display_xref_id").as_deref(),
+            Some("NM_000002.3")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "source_cache").as_deref(),
+            Some("LRG_RefSeq")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "refseq_match").as_deref(),
+            Some("rseq_mrna_match&rseq_cds_match")
+        );
+        assert_eq!(
+            batch_refseq_edit_values(&batch),
+            Some(vec![(20, 25, None, true), (30, 30, Some(1), true)])
+        );
+        assert_eq!(batch_bool_value(&batch, "is_gencode_basic"), Some(false));
+        assert_eq!(batch_bool_value(&batch, "is_gencode_primary"), Some(true));
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -948,7 +948,9 @@ fn parse_transcript_attributes_storable(
 type MapperSegment = (i64, i64, i64, i64, i8);
 
 /// Extract cDNA mapper segments from JSON transcript object.
-/// Path: `_variation_effect_feature_cache.mapper.pair_genomic.{region_key}[].{from,to,ori}`
+/// Primary VEP path:
+/// `_variation_effect_feature_cache.mapper.exon_coord_mapper._pair_cdna.CDNA[]`.
+/// Falls back to the simplified legacy `mapper.pair_genomic.{region_key}[]` shape.
 fn extract_cdna_mapper_segments_json(
     object: &serde_json::Map<String, Value>,
 ) -> Option<Vec<MapperSegment>> {
@@ -956,6 +958,37 @@ fn extract_cdna_mapper_segments_json(
         .get("_variation_effect_feature_cache")
         .and_then(unwrap_blessed_object_optional)?;
     let mapper = vef.get("mapper").and_then(unwrap_blessed_object_optional)?;
+
+    extract_pair_cdna_segments_json(mapper).or_else(|| extract_pair_genomic_segments_json(mapper))
+}
+
+fn extract_pair_cdna_segments_json(
+    mapper: &serde_json::Map<String, Value>,
+) -> Option<Vec<MapperSegment>> {
+    let pairs = mapper
+        .get("exon_coord_mapper")
+        .and_then(unwrap_blessed_object_optional)?
+        .get("_pair_cdna")
+        .and_then(unwrap_blessed_object_optional)?
+        .get("CDNA")
+        .and_then(Value::as_array)?;
+
+    let mut segments = Vec::new();
+    for pair_val in pairs {
+        let pair = unwrap_blessed_object_optional(pair_val).or_else(|| pair_val.as_object());
+        let Some(pair) = pair else {
+            continue;
+        };
+        if let Some(seg) = extract_cdna_to_genomic_mapper_pair_json(pair) {
+            segments.push(seg);
+        }
+    }
+    cdna_mapper_segments_or_none(segments)
+}
+
+fn extract_pair_genomic_segments_json(
+    mapper: &serde_json::Map<String, Value>,
+) -> Option<Vec<MapperSegment>> {
     let pair_genomic = mapper
         .get("pair_genomic")
         .and_then(unwrap_blessed_object_optional)?;
@@ -976,12 +1009,29 @@ fn extract_cdna_mapper_segments_json(
             }
         }
     }
+    cdna_mapper_segments_or_none(segments)
+}
+
+fn cdna_mapper_segments_or_none(mut segments: Vec<MapperSegment>) -> Option<Vec<MapperSegment>> {
     if segments.is_empty() {
         None
     } else {
         sort_cdna_mapper_segments(&mut segments);
         Some(segments)
     }
+}
+
+fn extract_cdna_to_genomic_mapper_pair_json(
+    pair: &serde_json::Map<String, Value>,
+) -> Option<MapperSegment> {
+    let from = pair.get("from").and_then(unwrap_blessed_object_optional)?;
+    let to = pair.get("to").and_then(unwrap_blessed_object_optional)?;
+    let ori = json_i64(pair.get("ori")).and_then(|v| i8::try_from(v).ok())?;
+    let c_start = json_i64(from.get("start"))?;
+    let c_end = json_i64(from.get("end"))?;
+    let g_start = json_i64(to.get("start"))?;
+    let g_end = json_i64(to.get("end"))?;
+    Some((g_start, g_end, c_start, c_end, ori))
 }
 
 fn extract_mapper_pair_json(pair: &serde_json::Map<String, Value>) -> Option<MapperSegment> {
@@ -1003,6 +1053,37 @@ fn extract_cdna_mapper_segments_storable(
         .get("_variation_effect_feature_cache")
         .and_then(SValue::as_hash)?;
     let mapper = vef.get("mapper").and_then(SValue::as_hash)?;
+
+    extract_pair_cdna_segments_storable(mapper)
+        .or_else(|| extract_pair_genomic_segments_storable(mapper))
+}
+
+fn extract_pair_cdna_segments_storable(
+    mapper: &std::collections::HashMap<String, SValue>,
+) -> Option<Vec<MapperSegment>> {
+    let pairs = mapper
+        .get("exon_coord_mapper")
+        .and_then(SValue::as_hash)?
+        .get("_pair_cdna")
+        .and_then(SValue::as_hash)?
+        .get("CDNA")
+        .and_then(SValue::as_array)?;
+
+    let mut segments = Vec::new();
+    for pair_val in pairs.iter() {
+        let Some(pair) = pair_val.as_hash() else {
+            continue;
+        };
+        if let Some(seg) = extract_cdna_to_genomic_mapper_pair_storable(pair) {
+            segments.push(seg);
+        }
+    }
+    cdna_mapper_segments_or_none(segments)
+}
+
+fn extract_pair_genomic_segments_storable(
+    mapper: &std::collections::HashMap<String, SValue>,
+) -> Option<Vec<MapperSegment>> {
     let pair_genomic = mapper.get("pair_genomic").and_then(SValue::as_hash)?;
 
     let mut segments = Vec::new();
@@ -1023,12 +1104,7 @@ fn extract_cdna_mapper_segments_storable(
             }
         }
     }
-    if segments.is_empty() {
-        None
-    } else {
-        sort_cdna_mapper_segments(&mut segments);
-        Some(segments)
-    }
+    cdna_mapper_segments_or_none(segments)
 }
 
 fn sort_cdna_mapper_segments(segments: &mut [MapperSegment]) {
@@ -1045,6 +1121,19 @@ fn extract_mapper_pair_storable(
     let g_end = sv_i64(from.get("end"))?;
     let c_start = sv_i64(to.get("start"))?;
     let c_end = sv_i64(to.get("end"))?;
+    Some((g_start, g_end, c_start, c_end, ori))
+}
+
+fn extract_cdna_to_genomic_mapper_pair_storable(
+    pair: &std::collections::HashMap<String, SValue>,
+) -> Option<MapperSegment> {
+    let from = pair.get("from").and_then(SValue::as_hash)?;
+    let to = pair.get("to").and_then(SValue::as_hash)?;
+    let ori = sv_i64(pair.get("ori")).and_then(|v| i8::try_from(v).ok())?;
+    let c_start = sv_i64(from.get("start"))?;
+    let c_end = sv_i64(from.get("end"))?;
+    let g_start = sv_i64(to.get("start"))?;
+    let g_end = sv_i64(to.get("end"))?;
     Some((g_start, g_end, c_start, c_end, ori))
 }
 
@@ -2458,6 +2547,28 @@ mod tests {
         SValue::Hash(Arc::new(pair))
     }
 
+    fn storable_cdna_mapper_pair(
+        cdna_start: i64,
+        cdna_end: i64,
+        genomic_start: i64,
+        genomic_end: i64,
+        ori: i64,
+    ) -> SValue {
+        let mut from = HashMap::new();
+        from.insert("start".to_string(), SValue::Int(cdna_start));
+        from.insert("end".to_string(), SValue::Int(cdna_end));
+
+        let mut to = HashMap::new();
+        to.insert("start".to_string(), SValue::Int(genomic_start));
+        to.insert("end".to_string(), SValue::Int(genomic_end));
+
+        let mut pair = HashMap::new();
+        pair.insert("from".to_string(), SValue::Hash(Arc::new(from)));
+        pair.insert("to".to_string(), SValue::Hash(Arc::new(to)));
+        pair.insert("ori".to_string(), SValue::Int(ori));
+        SValue::Hash(Arc::new(pair))
+    }
+
     fn storable_bioseq(seq: &str) -> SValue {
         let mut primary = HashMap::new();
         primary.insert(
@@ -2769,6 +2880,57 @@ mod tests {
         mapper.insert(
             "pair_genomic".to_string(),
             SValue::Hash(Arc::new(pair_genomic)),
+        );
+        let mut vef_cache = HashMap::new();
+        vef_cache.insert("mapper".to_string(), SValue::Hash(Arc::new(mapper)));
+        let mut object = HashMap::new();
+        object.insert(
+            "_variation_effect_feature_cache".to_string(),
+            SValue::Hash(Arc::new(vef_cache)),
+        );
+
+        assert_eq!(
+            extract_cdna_mapper_segments_storable(&object).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn cdna_mapper_segments_extract_nested_pair_cdna() {
+        let expected = vec![(10, 12, 1, 3, 1), (50, 55, 6, 11, -1)];
+        let payload = json!({
+            "_variation_effect_feature_cache": {
+                "mapper": {
+                    "exon_coord_mapper": {
+                        "_pair_cdna": {
+                            "CDNA": [
+                                { "from": { "start": 6, "end": 11 }, "to": { "start": 50, "end": 55 }, "ori": -1 },
+                                { "from": { "start": 1, "end": 3 }, "to": { "start": 10, "end": 12 }, "ori": 1 }
+                            ]
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(
+            extract_cdna_mapper_segments_json(payload.as_object().unwrap()).unwrap(),
+            expected
+        );
+
+        let mut pair_cdna = HashMap::new();
+        pair_cdna.insert(
+            "CDNA".to_string(),
+            SValue::Array(Arc::new(vec![
+                storable_cdna_mapper_pair(6, 11, 50, 55, -1),
+                storable_cdna_mapper_pair(1, 3, 10, 12, 1),
+            ])),
+        );
+        let mut exon_coord_mapper = HashMap::new();
+        exon_coord_mapper.insert("_pair_cdna".to_string(), SValue::Hash(Arc::new(pair_cdna)));
+        let mut mapper = HashMap::new();
+        mapper.insert(
+            "exon_coord_mapper".to_string(),
+            SValue::Hash(Arc::new(exon_coord_mapper)),
         );
         let mut vef_cache = HashMap::new();
         vef_cache.insert("mapper".to_string(), SValue::Hash(Arc::new(mapper)));

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -1412,8 +1412,8 @@ pub(crate) fn parse_transcript_line_into(
     if col_idx.gene_hgnc_id.is_some() || col_idx.gene_hgnc_id_native.is_some() {
         let native_value = json_str(
             object
-                .get("gene_hgnc_id")
-                .or_else(|| object.get("_gene_hgnc_id")),
+                .get("_gene_hgnc_id")
+                .or_else(|| object.get("gene_hgnc_id")),
         );
         if let Some(idx) = col_idx.gene_hgnc_id {
             batch.set_opt_utf8_owned(idx, native_value.as_ref());
@@ -1969,8 +1969,8 @@ fn append_transcript_storable_row_into(
     if col_idx.gene_hgnc_id.is_some() || col_idx.gene_hgnc_id_native.is_some() {
         let native_value = sv_str(
             object
-                .get("gene_hgnc_id")
-                .or_else(|| object.get("_gene_hgnc_id")),
+                .get("_gene_hgnc_id")
+                .or_else(|| object.get("gene_hgnc_id")),
         );
         if let Some(idx) = col_idx.gene_hgnc_id {
             batch.set_opt_utf8_owned(idx, native_value.as_ref());
@@ -2768,6 +2768,46 @@ mod tests {
     }
 
     #[test]
+    fn parse_transcript_line_prefers_underscored_gene_hgnc_id() {
+        let (mut batch, col_idx, provenance, cache_info) = transcript_test_components("storable");
+        let payload = json!({
+            "stable_id": "ENST000191",
+            "strand": 1,
+            "biotype": "protein_coding",
+            "_gene_hgnc_id": "HGNC:native",
+            "gene_hgnc_id": "HGNC:fallback"
+        });
+        let line = format!(
+            "1\t100\t200\tJSON:{}",
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let written = parse_transcript_line_into(
+            &line,
+            "/tmp/transcript.txt",
+            &cache_info,
+            &SimplePredicate::default(),
+            false,
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        assert!(written);
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "gene_hgnc_id").as_deref(),
+            Some("HGNC:native")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "gene_hgnc_id_native").as_deref(),
+            Some("HGNC:native")
+        );
+    }
+
+    #[test]
     fn append_transcript_storable_row_promotes_issue_190_fields() {
         let (mut batch, col_idx, provenance, _) = transcript_test_components("storable");
         let mut display_xref = HashMap::new();
@@ -2846,6 +2886,57 @@ mod tests {
         );
         assert_eq!(batch_bool_value(&batch, "is_gencode_basic"), Some(false));
         assert_eq!(batch_bool_value(&batch, "is_gencode_primary"), Some(true));
+    }
+
+    #[test]
+    fn append_transcript_storable_row_prefers_underscored_gene_hgnc_id() {
+        let (mut batch, col_idx, provenance, _) = transcript_test_components("storable");
+        let mut object = HashMap::new();
+        object.insert(
+            "biotype".to_string(),
+            SValue::String(Arc::from("protein_coding")),
+        );
+        object.insert(
+            "_gene_hgnc_id".to_string(),
+            SValue::String(Arc::from("HGNC:native")),
+        );
+        object.insert(
+            "gene_hgnc_id".to_string(),
+            SValue::String(Arc::from("HGNC:fallback")),
+        );
+
+        let payload = SValue::Hash(Arc::new(object.clone()));
+        let core = TranscriptRowCore {
+            chrom: "1".to_string(),
+            start: 100,
+            end: 200,
+            source_start: 100,
+            source_end: 200,
+            strand: 1,
+            stable_id: "ENST000191".to_string(),
+        };
+
+        append_transcript_storable_row_into(
+            &payload,
+            &object,
+            core,
+            false,
+            "/tmp/transcript.storable.gz",
+            &mut batch,
+            &col_idx,
+            &provenance,
+        )
+        .unwrap();
+
+        let batch = batch.finish().unwrap();
+        assert_eq!(
+            batch_utf8_value(&batch, "gene_hgnc_id").as_deref(),
+            Some("HGNC:native")
+        );
+        assert_eq!(
+            batch_utf8_value(&batch, "gene_hgnc_id_native").as_deref(),
+            Some("HGNC:native")
+        );
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/transcript.rs
+++ b/datafusion/bio-format-ensembl-cache/src/transcript.rs
@@ -975,6 +975,7 @@ fn extract_cdna_mapper_segments_json(
     if segments.is_empty() {
         None
     } else {
+        sort_cdna_mapper_segments(&mut segments);
         Some(segments)
     }
 }
@@ -1021,8 +1022,13 @@ fn extract_cdna_mapper_segments_storable(
     if segments.is_empty() {
         None
     } else {
+        sort_cdna_mapper_segments(&mut segments);
         Some(segments)
     }
+}
+
+fn sort_cdna_mapper_segments(segments: &mut [MapperSegment]) {
+    segments.sort_by_key(|(g_start, g_end, c_start, _c_end, _ori)| (*g_start, *g_end, *c_start));
 }
 
 fn extract_mapper_pair_storable(
@@ -2426,6 +2432,28 @@ mod tests {
         SValue::Hash(Arc::new(attr))
     }
 
+    fn storable_mapper_pair(
+        genomic_start: i64,
+        genomic_end: i64,
+        cdna_start: i64,
+        cdna_end: i64,
+        ori: i64,
+    ) -> SValue {
+        let mut from = HashMap::new();
+        from.insert("start".to_string(), SValue::Int(genomic_start));
+        from.insert("end".to_string(), SValue::Int(genomic_end));
+
+        let mut to = HashMap::new();
+        to.insert("start".to_string(), SValue::Int(cdna_start));
+        to.insert("end".to_string(), SValue::Int(cdna_end));
+
+        let mut pair = HashMap::new();
+        pair.insert("from".to_string(), SValue::Hash(Arc::new(from)));
+        pair.insert("to".to_string(), SValue::Hash(Arc::new(to)));
+        pair.insert("ori".to_string(), SValue::Int(ori));
+        SValue::Hash(Arc::new(pair))
+    }
+
     fn storable_bioseq(seq: &str) -> SValue {
         let mut primary = HashMap::new();
         primary.insert(
@@ -2703,6 +2731,53 @@ mod tests {
         );
         assert_eq!(batch_bool_value(&batch, "is_gencode_basic"), Some(false));
         assert_eq!(batch_bool_value(&batch, "is_gencode_primary"), Some(true));
+    }
+
+    #[test]
+    fn cdna_mapper_segments_are_sorted_by_genomic_then_cdna_start() {
+        let expected = vec![(10, 12, 1, 3, 1), (50, 55, 6, 11, 1)];
+        let payload = json!({
+            "_variation_effect_feature_cache": {
+                "mapper": {
+                    "pair_genomic": {
+                        "1": [
+                            { "from": { "start": 50, "end": 55 }, "to": { "start": 6, "end": 11 }, "ori": 1 },
+                            { "from": { "start": 10, "end": 12 }, "to": { "start": 1, "end": 3 }, "ori": 1 }
+                        ]
+                    }
+                }
+            }
+        });
+        assert_eq!(
+            extract_cdna_mapper_segments_json(payload.as_object().unwrap()).unwrap(),
+            expected
+        );
+
+        let mut pair_genomic = HashMap::new();
+        pair_genomic.insert(
+            "1".to_string(),
+            SValue::Array(Arc::new(vec![
+                storable_mapper_pair(50, 55, 6, 11, 1),
+                storable_mapper_pair(10, 12, 1, 3, 1),
+            ])),
+        );
+        let mut mapper = HashMap::new();
+        mapper.insert(
+            "pair_genomic".to_string(),
+            SValue::Hash(Arc::new(pair_genomic)),
+        );
+        let mut vef_cache = HashMap::new();
+        vef_cache.insert("mapper".to_string(), SValue::Hash(Arc::new(mapper)));
+        let mut object = HashMap::new();
+        object.insert(
+            "_variation_effect_feature_cache".to_string(),
+            SValue::Hash(Arc::new(vef_cache)),
+        );
+
+        assert_eq!(
+            extract_cdna_mapper_segments_storable(&object).unwrap(),
+            expected
+        );
     }
 
     #[test]

--- a/datafusion/bio-format-ensembl-cache/src/util.rs
+++ b/datafusion/bio-format-ensembl-cache/src/util.rs
@@ -1,7 +1,7 @@
 use crate::errors::{Result, exec_err};
 use crate::schema::{
     cdna_mapper_segment_list_data_type, exon_list_data_type, mirna_region_list_data_type,
-    prediction_list_data_type, protein_feature_list_data_type,
+    prediction_list_data_type, protein_feature_list_data_type, refseq_edit_list_data_type,
 };
 use datafusion::arrow::array::{
     ArrayBuilder, ArrayRef, BooleanBuilder, Float32Builder, Float64Builder, Int8Builder,
@@ -18,6 +18,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 const IO_BUFFER_SIZE: usize = 64 * 1024;
+
+#[allow(dead_code)]
+pub(crate) type RefseqEditTuple = (i64, i64, Option<i64>, bool);
 
 pub(crate) fn open_text_reader(path: &Path) -> Result<Box<dyn BufRead + Send>> {
     let file = File::open(path)
@@ -655,6 +658,61 @@ impl BatchBuilder {
         self.mark_written(col);
     }
 
+    /// Append a list of RefSeq RNA edit metadata to a `List<Struct>` column.
+    #[allow(dead_code)]
+    pub fn set_refseq_edit_list(&mut self, col: usize, edits: Option<&[RefseqEditTuple]>) {
+        let mut overflow: Option<(usize, usize)> = None;
+        if let AnyBuilder::RefseqEditList(list_builder) = &mut self.builders[col] {
+            match edits {
+                Some(edit_slice) => {
+                    let current_child_len = list_builder.values().len();
+                    let next_child_len = current_child_len.saturating_add(edit_slice.len());
+                    if next_child_len > i32::MAX as usize {
+                        overflow = Some((current_child_len, edit_slice.len()));
+                        list_builder.append(false);
+                        self.mark_written(col);
+                    } else {
+                        let struct_builder = list_builder.values();
+                        for &(start, end, replacement_len, skip_refseq_offset) in edit_slice {
+                            struct_builder
+                                .field_builder::<Int64Builder>(0)
+                                .unwrap()
+                                .append_value(start);
+                            struct_builder
+                                .field_builder::<Int64Builder>(1)
+                                .unwrap()
+                                .append_value(end);
+                            let replacement_builder =
+                                struct_builder.field_builder::<Int64Builder>(2).unwrap();
+                            match replacement_len {
+                                Some(v) => replacement_builder.append_value(v),
+                                None => replacement_builder.append_null(),
+                            }
+                            struct_builder
+                                .field_builder::<BooleanBuilder>(3)
+                                .unwrap()
+                                .append_value(skip_refseq_offset);
+                            struct_builder.append(true);
+                        }
+                        list_builder.append(true);
+                    }
+                }
+                None => {
+                    list_builder.append(false);
+                }
+            }
+        }
+        if let Some((current_child_len, added)) = overflow {
+            let col_name = self.schema.field(col).name().clone();
+            self.set_pending_error_once(format!(
+                "Arrow List offset overflow in column '{col_name}' ({current_child_len} + {added} values exceeds i32::MAX). \
+                 Reduce batch_size_hint."
+            ));
+            return;
+        }
+        self.mark_written(col);
+    }
+
     /// Append a list of protein features to a `List<Struct>` column.
     /// Each feature is `(analysis, hseqname, start, end)`.
     #[allow(clippy::type_complexity)]
@@ -856,6 +914,7 @@ enum AnyBuilder {
     ExonList(ListBuilder<StructBuilder>),
     MirnaRegionList(ListBuilder<StructBuilder>),
     CdnaMapperList(ListBuilder<StructBuilder>),
+    RefseqEditList(ListBuilder<StructBuilder>),
     ProteinFeatureList(ListBuilder<StructBuilder>),
     PredictionList(ListBuilder<StructBuilder>),
 }
@@ -873,6 +932,7 @@ impl AnyBuilder {
             Self::ExonList(b) => b.append(false),
             Self::MirnaRegionList(b) => b.append(false),
             Self::CdnaMapperList(b) => b.append(false),
+            Self::RefseqEditList(b) => b.append(false),
             Self::ProteinFeatureList(b) => b.append(false),
             Self::PredictionList(b) => b.append(false),
         }
@@ -924,6 +984,24 @@ impl AnyBuilder {
                     ],
                 );
                 Ok(Self::CdnaMapperList(ListBuilder::new(struct_builder)))
+            }
+            dt if *dt == refseq_edit_list_data_type() => {
+                let fields = vec![
+                    Field::new("start", DataType::Int64, false),
+                    Field::new("end", DataType::Int64, false),
+                    Field::new("replacement_len", DataType::Int64, true),
+                    Field::new("skip_refseq_offset", DataType::Boolean, false),
+                ];
+                let struct_builder = StructBuilder::new(
+                    fields,
+                    vec![
+                        Box::new(Int64Builder::with_capacity(capacity * 4)),
+                        Box::new(Int64Builder::with_capacity(capacity * 4)),
+                        Box::new(Int64Builder::with_capacity(capacity * 4)),
+                        Box::new(BooleanBuilder::with_capacity(capacity * 4)),
+                    ],
+                );
+                Ok(Self::RefseqEditList(ListBuilder::new(struct_builder)))
             }
             dt if *dt == mirna_region_list_data_type() => {
                 let fields = vec![
@@ -992,6 +1070,7 @@ impl AnyBuilder {
             Self::ExonList(mut builder) => Arc::new(builder.finish()),
             Self::MirnaRegionList(mut builder) => Arc::new(builder.finish()),
             Self::CdnaMapperList(mut builder) => Arc::new(builder.finish()),
+            Self::RefseqEditList(mut builder) => Arc::new(builder.finish()),
             Self::ProteinFeatureList(mut builder) => Arc::new(builder.finish()),
             Self::PredictionList(mut builder) => Arc::new(builder.finish()),
         }

--- a/datafusion/bio-format-ensembl-cache/src/util.rs
+++ b/datafusion/bio-format-ensembl-cache/src/util.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 const IO_BUFFER_SIZE: usize = 64 * 1024;
 
-#[allow(dead_code)]
 pub(crate) type RefseqEditTuple = (i64, i64, Option<i64>, bool);
 
 pub(crate) fn open_text_reader(path: &Path) -> Result<Box<dyn BufRead + Send>> {
@@ -659,7 +658,6 @@ impl BatchBuilder {
     }
 
     /// Append a list of RefSeq RNA edit metadata to a `List<Struct>` column.
-    #[allow(dead_code)]
     pub fn set_refseq_edit_list(&mut self, col: usize, edits: Option<&[RefseqEditTuple]>) {
         let mut overflow: Option<(usize, usize)> = None;
         if let AnyBuilder::RefseqEditList(list_builder) = &mut self.builders[col] {

--- a/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
@@ -822,6 +822,69 @@ async fn transcript_promoted_metadata_columns_queryable() -> datafusion::common:
 }
 
 #[tokio::test]
+async fn transcript_issue_190_columns_queryable_for_storable_and_merged()
+-> datafusion::common::Result<()> {
+    for fixture in ["transcript_storable", "transcript_merged_layout"] {
+        let provider = TranscriptTableProvider::new(ensembl_options(fixture_path(fixture)))?;
+
+        let ctx = SessionContext::new();
+        ctx.register_table("tx", Arc::new(provider))?;
+
+        let batches = ctx
+            .sql(
+                "SELECT display_xref_id, source_cache, refseq_match, refseq_edits, \
+                 is_gencode_basic, is_gencode_primary FROM tx",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        assert!(
+            !batches.is_empty(),
+            "expected transcript batches for {fixture}"
+        );
+        assert_eq!(batches[0].num_columns(), 6);
+        assert!(
+            batches[0]
+                .column_by_name("refseq_edits")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .is_some(),
+            "refseq_edits should be a ListArray for {fixture}"
+        );
+
+        let null_counts = ctx
+            .sql(
+                "SELECT COUNT(*) FROM tx \
+                 WHERE is_gencode_basic IS NULL OR is_gencode_primary IS NULL",
+            )
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(
+            first_i64(&null_counts),
+            0,
+            "gencode booleans should be non-null for {fixture}"
+        );
+
+        for col in ["is_gencode_basic", "is_gencode_primary"] {
+            assert!(
+                batches[0]
+                    .column_by_name(col)
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .is_some(),
+                "{col} should be a BooleanArray for {fixture}"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn transcript_mature_mirna_regions_queryable() -> datafusion::common::Result<()> {
     let provider =
         TranscriptTableProvider::new(ensembl_options(fixture_path("transcript_storable")))?;

--- a/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
@@ -635,6 +635,22 @@ async fn transcript_schema_contains_vep_columns() -> datafusion::common::Result<
         .field_with_name("ncrna_structure")
         .expect("ncrna_structure column missing");
     assert_eq!(ncrna_structure.data_type(), &DataType::Utf8);
+    for col in [
+        "display_xref_id",
+        "source_cache",
+        "refseq_match",
+        "refseq_edits",
+        "is_gencode_basic",
+        "is_gencode_primary",
+    ] {
+        assert!(schema.field_with_name(col).is_ok(), "missing column: {col}");
+    }
+    let refseq_edits = schema.field_with_name("refseq_edits").unwrap();
+    assert!(
+        matches!(refseq_edits.data_type(), DataType::List(_)),
+        "refseq_edits should be List<Struct>, got {:?}",
+        refseq_edits.data_type()
+    );
 
     Ok(())
 }

--- a/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/integration_tests.rs
@@ -885,6 +885,34 @@ async fn transcript_issue_190_columns_queryable_for_storable_and_merged()
 }
 
 #[tokio::test]
+async fn transcript_raw_free_existing_columns_remain_queryable() -> datafusion::common::Result<()> {
+    let provider =
+        TranscriptTableProvider::new(ensembl_options(fixture_path("transcript_storable")))?;
+    let ctx = SessionContext::new();
+    ctx.register_table("tx", Arc::new(provider))?;
+
+    let batches = ctx
+        .sql(
+            "SELECT gene_stable_id, gene_hgnc_id_native, cdna_mapper_segments, spliced_seq, \
+             five_prime_utr_seq, three_prime_utr_seq, translateable_seq, flags_str, \
+             cds_start_nf, cds_end_nf, bam_edit_status, has_non_polya_rna_edit, \
+             mature_mirna_regions, ncrna_structure FROM tx LIMIT 5",
+        )
+        .await?
+        .collect()
+        .await?;
+
+    assert!(!batches.is_empty());
+    assert_eq!(batches[0].num_columns(), 14);
+    assert!(
+        batches[0].column_by_name("raw_object_json").is_none(),
+        "raw_object_json must not be projected by the raw-free contract query"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn transcript_mature_mirna_regions_queryable() -> datafusion::common::Result<()> {
     let provider =
         TranscriptTableProvider::new(ensembl_options(fixture_path("transcript_storable")))?;

--- a/datafusion/bio-format-ensembl-cache/tests/parquet_roundtrip_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/parquet_roundtrip_tests.rs
@@ -1,6 +1,8 @@
 //! Parquet round-trip tests: write VEP cache → Parquet → read back, verify.
 
-use datafusion::arrow::array::{Array, Int64Array, ListArray, StringArray, StructArray};
+use datafusion::arrow::array::{
+    Array, BooleanArray, Int64Array, ListArray, StringArray, StructArray,
+};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::TableProvider;
 use datafusion::parquet::arrow::ArrowWriter;
@@ -357,6 +359,54 @@ async fn transcript_parquet_roundtrip_ncrna_structure() -> datafusion::common::R
         "ncrna_structure should be string type, got {:?}",
         field.data_type()
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn transcript_parquet_roundtrip_issue_190_fields() -> datafusion::common::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let provider =
+        TranscriptTableProvider::new(ensembl_options(fixture_path("transcript_storable")))?;
+
+    let parquet_path =
+        write_provider_to_parquet(Arc::new(provider), "tx_issue_190", &temp_dir).await;
+
+    let ctx = SessionContext::new();
+    ctx.register_parquet("tx", &parquet_path, ParquetReadOptions::default())
+        .await?;
+
+    let batches = ctx
+        .sql(
+            "SELECT display_xref_id, source_cache, refseq_match, refseq_edits, \
+             is_gencode_basic, is_gencode_primary FROM tx LIMIT 5",
+        )
+        .await?
+        .collect()
+        .await?;
+    assert!(!batches.is_empty());
+    assert!(batches[0].num_rows() > 0);
+    assert_eq!(batches[0].num_columns(), 6);
+
+    assert!(
+        batches[0]
+            .column_by_name("refseq_edits")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .is_some(),
+        "refseq_edits should remain a ListArray after parquet round-trip"
+    );
+
+    for col in ["is_gencode_basic", "is_gencode_primary"] {
+        let values = batches[0]
+            .column_by_name(col)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap_or_else(|| panic!("{col} should remain BooleanArray after round-trip"));
+        assert_eq!(values.null_count(), 0, "{col} should remain non-null");
+    }
 
     Ok(())
 }

--- a/datafusion/bio-format-ensembl-cache/tests/parquet_roundtrip_tests.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/parquet_roundtrip_tests.rs
@@ -791,6 +791,16 @@ async fn parquet_roundtrip_preserves_all_schema_fields() -> datafusion::common::
         );
     }
 
+    let batches = ctx
+        .sql(
+            "SELECT display_xref_id, source_cache, refseq_match, refseq_edits, \
+             is_gencode_basic, is_gencode_primary FROM tx LIMIT 1",
+        )
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(batches[0].num_columns(), 6);
+
     Ok(())
 }
 

--- a/openspec/changes/add-vep-annotation/proposal.md
+++ b/openspec/changes/add-vep-annotation/proposal.md
@@ -58,6 +58,9 @@ does not support a legacy `merged=true` compatibility option.
 - `datafusion/bio-format-ensembl-cache/src/util.rs` — Add `List<Struct>` builder support
 - `datafusion/bio-format-ensembl-cache/tests/integration_tests.rs` — Cover promoted transcript and motif columns
 - `datafusion/bio-format-ensembl-cache/README.md` — Document the expanded schema contract
+- Complete issue #190 raw-free transcript schema contract by promoting
+  `display_xref_id`, `source_cache`, `refseq_match`, `refseq_edits`,
+  `is_gencode_basic`, and `is_gencode_primary` from transcript objects.
 
 **Separate repo (`datafusion-bio-functions`):**
 - New crate `datafusion/bio-function-vep/` with consequence engine, index layer, execution layer, source-mode handling, and UDFs

--- a/openspec/changes/add-vep-annotation/specs/vep-annotation/spec.md
+++ b/openspec/changes/add-vep-annotation/specs/vep-annotation/spec.md
@@ -236,6 +236,19 @@ The system SHALL expose transcript and motif attributes that are currently embed
 - **WHEN** a query does not select `mature_mirna_regions`
 - **THEN** the parser skips the transcript-attribute walk needed to derive those intervals
 
+#### Scenario: Query raw-free RefSeq and GENCODE transcript metadata
+- **WHEN** a user executes `SELECT stable_id, display_xref_id, source_cache, refseq_match, is_gencode_basic, is_gencode_primary FROM vep_transcript`
+- **THEN** those values are returned from typed transcript columns
+- **AND** the query does not require selecting `raw_object_json`
+- **AND** `source_cache` preserves the raw `_source_cache` string without source normalization
+
+#### Scenario: Query parsed RefSeq edit metadata
+- **WHEN** transcript attributes contain `_rna_edit` entries with two or three whitespace-separated fields
+- **THEN** `refseq_edits` contains `List<Struct<start:Int64, end:Int64, replacement_len:Int64?, skip_refseq_offset:Boolean>>`
+- **AND** `replacement_len` is the length of the third field when present
+- **AND** `skip_refseq_offset` is true when the edit is length-preserving or the attribute description contains `op=X`
+- **AND** entries are sorted by `start`, then `end`, then `replacement_len`
+
 #### Scenario: Query motif transcription factors
 - **WHEN** a user executes `SELECT motif_id, transcription_factors FROM vep_motif_feature`
 - **THEN** the motif transcription factor annotation is returned from a dedicated top-level column

--- a/openspec/changes/add-vep-annotation/tasks.md
+++ b/openspec/changes/add-vep-annotation/tasks.md
@@ -115,6 +115,16 @@
 - [x] 2.9.8 Add unit tests for explicit source-mode validation, schema metadata, rejected path inference, and `db_id` parsing
 - [x] 2.9.9 Add gated integration smoke tests against a real RefSeq cache path for chr22, MT, and an alternate contig
 
+### 2.10 Complete Raw-Free Transcript Schema Contract (issue #190)
+- [ ] 2.10.1 Add transcript schema columns `display_xref_id`, `source_cache`, `refseq_match`, `refseq_edits`, `is_gencode_basic`, and `is_gencode_primary`
+- [ ] 2.10.2 Add Arrow builder support for `List<Struct<start:Int64, end:Int64, replacement_len:Int64?, skip_refseq_offset:Boolean>>`
+- [ ] 2.10.3 Parse RefSeq match codes, RefSeq edit metadata, and GENCODE booleans from transcript attributes in both JSON and Storable paths
+- [ ] 2.10.4 Populate `display_xref_id` from `display_xref.display_id` and `source_cache` from raw `_source_cache` in both parser paths
+- [ ] 2.10.5 Add integration tests showing standard and merged transcript cache layouts can query the promoted columns without projecting `raw_object_json`
+- [ ] 2.10.6 Add Parquet round-trip coverage for the new raw-free transcript columns
+- [ ] 2.10.7 Guard existing promoted transcript-object columns required by raw-free downstream VEP annotation
+- [ ] 2.10.8 Document the complete raw-free transcript schema contract in the `bio-format-ensembl-cache` README
+
 ## 3. Phase 3: Consequence Engine (bio-functions)
 
 ### 3.1 Implement Genetic Code Tables (`codon.rs`)


### PR DESCRIPTION
## Summary
- Promote issue #190 transcript fields into typed schema columns: display_xref_id, source_cache, refseq_match, refseq_edits, is_gencode_basic, and is_gencode_primary.
- Populate the fields from JSON and Storable transcript paths without relying on raw_object_json, including RefSeq edit parsing and GENCODE boolean defaults.
- Add query-boundary, Parquet, OpenSpec, and README coverage for the raw-free transcript contract.

## Test Plan
- cargo test -p datafusion-bio-format-ensembl-cache
- cargo check --workspace
- openspec validate add-vep-annotation --strict

Closes #190