### PR TITLE
fix(ensembl-cache): use directory-derived chrom for split-layout variation (#192)

### DIFF
--- a/datafusion/bio-format-ensembl-cache/src/discovery.rs
+++ b/datafusion/bio-format-ensembl-cache/src/discovery.rs
@@ -42,7 +42,13 @@ pub(crate) fn discover_variation_files(cache_root: &Path) -> Result<Vec<PathBuf>
                             || lower.contains("var.gz")
                             || (looks_like_region_file_name(&lower)
                                 && !lower.ends_with("_reg.gz")
-                                && !lower.contains("transcript")))
+                                && !lower.contains("transcript")
+                                // In a split-layout cache the bare `<region>.gz`
+                                // is the (binary) transcript file and the real
+                                // variation file is the sibling `<region>_var.gz`.
+                                // Only treat the bare region file as variation in
+                                // the merged layout, where no `_var` sibling exists.
+                                && !has_variation_sibling(path)))
                 })
         })
         .cloned()
@@ -298,6 +304,29 @@ pub(crate) fn extract_distinct_chroms(
     Some(chroms.into_iter().collect())
 }
 
+/// Returns `true` if a bare region file (e.g. `25000001-26000000.gz`) has a
+/// sibling variation file (e.g. `25000001-26000000_var.gz`) in the same
+/// directory.
+///
+/// This distinguishes the classic *split-layout* cache (separate transcript /
+/// `_var` / `_reg` files per region) from the *merged* layout (a single bare
+/// region file holds variation data). In the split layout the bare region file
+/// is the binary transcript Storable and must NOT be classified as variation.
+fn has_variation_sibling(path: &Path) -> bool {
+    let Some(stem) = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.strip_suffix(".gz"))
+    else {
+        return false;
+    };
+    let var_sibling = format!("{stem}_var.gz");
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    parent.join(&var_sibling).is_file()
+}
+
 fn looks_like_region_file_name(name: &str) -> bool {
     let Some(stem) = name.strip_suffix(".gz") else {
         return false;
@@ -418,6 +447,53 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let files = discover_variation_files(dir.path()).unwrap();
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn variation_split_layout_excludes_bare_transcript_region_file() {
+        // Classic split-layout cache (e.g. Ensembl release 84): each region dir
+        // has a bare transcript file, a `_var` variation file, and a `_reg`
+        // regulatory file. Only the `_var` file is the real variation file.
+        let dir = tempfile::tempdir().unwrap();
+        let region = dir.path().join("1");
+        create_file(&region.join("25000001-26000000.gz")); // transcript (binary Storable)
+        create_file(&region.join("25000001-26000000_var.gz")); // variation (the real one)
+        create_file(&region.join("25000001-26000000_reg.gz")); // regulatory (binary)
+
+        let files = discover_variation_files(dir.path()).unwrap();
+        let names: Vec<&str> = files.iter().map(|p| p.to_str().unwrap()).collect();
+
+        assert!(
+            names
+                .iter()
+                .any(|n| n.ends_with("25000001-26000000_var.gz")),
+            "expected the _var.gz variation file, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.ends_with("25000001-26000000.gz")),
+            "bare transcript region file must NOT be classified as variation, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.ends_with("_reg.gz")),
+            "regulatory file must NOT be classified as variation, got {names:?}"
+        );
+        assert_eq!(
+            files.len(),
+            1,
+            "expected exactly one variation file, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn variation_merged_layout_picks_up_bare_region_file() {
+        // Merged layout: a bare region file with NO `_var.gz` sibling should
+        // still be treated as variation.
+        let dir = tempfile::tempdir().unwrap();
+        create_file(&dir.path().join("1/25000001-26000000.gz"));
+
+        let files = discover_variation_files(dir.path()).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_str().unwrap().ends_with("25000001-26000000.gz"));
     }
 
     // -----------------------------------------------------------------------

--- a/datafusion/bio-format-ensembl-cache/src/physical_exec.rs
+++ b/datafusion/bio-format-ensembl-cache/src/physical_exec.rs
@@ -598,6 +598,9 @@ fn process_partition(
         && kind == EnsemblEntityKind::Variation
     {
         let source_file_str = bgzf_path.to_str().unwrap_or_default();
+        // Split-layout `_var.gz` files have no chrom column; derive the chrom
+        // from the region directory so the per-line parser can fall back to it.
+        let dir_chrom = extract_chrom_from_path(bgzf_path, EnsemblEntityKind::Variation);
         let mut bgzf_reader =
             crate::tabix_reader::BgzfPartitionLineReader::open(bgzf_path, bgzf_part)?;
 
@@ -613,6 +616,7 @@ fn process_partition(
                 variation_ctx.as_ref().unwrap(),
                 &provenance,
                 source_id_writer.as_mut().unwrap(),
+                dir_chrom.as_deref(),
             )? {
                 VariationParseResult::Added => {
                     match dispatch_row(
@@ -662,6 +666,15 @@ fn process_partition(
             &source_file.to_string_lossy()
         } else {
             source_file_str
+        };
+
+        // Directory-derived chrom for split-layout variation `_var.gz` files,
+        // which carry no chrom column. Computed once per file; ignored by the
+        // parser when the line already carries a chrom (merged/tabix layout).
+        let variation_dir_chrom = if kind == EnsemblEntityKind::Variation {
+            extract_chrom_from_path(source_file, EnsemblEntityKind::Variation)
+        } else {
+            None
         };
 
         // Merge the pst0 header check with the alias-count scan to avoid
@@ -899,6 +912,7 @@ fn process_partition(
                         variation_ctx.as_ref().unwrap(),
                         &provenance,
                         source_id_writer.as_mut().unwrap(),
+                        variation_dir_chrom.as_deref(),
                     )? {
                         VariationParseResult::Added => true,
                         VariationParseResult::Skipped => false,

--- a/datafusion/bio-format-ensembl-cache/src/variation.rs
+++ b/datafusion/bio-format-ensembl-cache/src/variation.rs
@@ -477,6 +477,7 @@ pub(crate) fn parse_variation_line_into(
     ctx: &VariationContext,
     provenance: &ProvenanceWriter,
     source_id_writer: &mut SourceIdWriter,
+    dir_chrom: Option<&str>,
 ) -> Result<VariationParseResult> {
     let trimmed = line.trim();
     if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -501,8 +502,19 @@ pub(crate) fn parse_variation_line_into(
     // Extract required fields — return Malformed instead of Err so a single
     // bad line does not abort the entire partition and silently drop all
     // subsequent records.
-    let Some(chrom_ref) = field_at(ctx.chrom_tab).and_then(normalize_nullable_ref) else {
-        return Ok(VariationParseResult::Malformed);
+    //
+    // Split-layout `_var.gz` files (e.g. Ensembl release 84) carry NO chrom
+    // column: `variation_cols` has no chr/seq_region field, so `ctx.chrom_tab`
+    // is `None` and the chromosome is implicit from the region directory name.
+    // In that case fall back to the directory-derived chrom resolved at file
+    // discovery time. The merged/tabix layout DOES carry a chrom column, so
+    // `ctx.chrom_tab` is `Some` and the per-line value takes precedence.
+    let chrom_ref = match field_at(ctx.chrom_tab).and_then(normalize_nullable_ref) {
+        Some(chrom) => chrom,
+        None => match dir_chrom {
+            Some(chrom) => chrom,
+            None => return Ok(VariationParseResult::Malformed),
+        },
     };
 
     let Some(source_start) = parse_i64_ref(field_at(ctx.start_tab)) else {
@@ -928,7 +940,19 @@ mod tests {
         ProvenanceWriter,
         SourceIdWriter,
     ) {
-        let info = make_cache_info(standard_cols(), standard_sources());
+        setup_variation_parser_with_cols(standard_cols())
+    }
+
+    fn setup_variation_parser_with_cols(
+        cols: Vec<String>,
+    ) -> (
+        BatchBuilder,
+        VariationColumnIndices,
+        VariationContext,
+        ProvenanceWriter,
+        SourceIdWriter,
+    ) {
+        let info = make_cache_info(cols, standard_sources());
         let schema =
             variation_schema(&info, false, crate::source_type::CacheSourceType::Ensembl).unwrap();
         let col_map = ColumnMap::from_schema(&schema);
@@ -940,6 +964,100 @@ mod tests {
         (builder, col_idx, ctx, provenance, source_id_writer)
     }
 
+    /// Release-84 split-layout `variation_cols`: starts with `variation_name`
+    /// and has NO chrom/seq_region column — chrom is implicit from the region
+    /// directory name.
+    fn split_layout_cols() -> Vec<String> {
+        vec![
+            "variation_name",
+            "failed",
+            "somatic",
+            "start",
+            "end",
+            "allele_string",
+            "strand",
+            "minor_allele",
+            "minor_allele_freq",
+            "clin_sig",
+            "phenotype_or_disease",
+            "pubmed",
+            "var_synonyms",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
+    }
+
+    #[test]
+    fn parse_split_layout_uses_directory_chrom() {
+        // Split-layout `_var.gz` line: no chrom column. Columns are
+        // variation_name, failed, somatic, start, end, allele_string, ...
+        let (mut batch, col_idx, ctx, prov, mut sid) =
+            setup_variation_parser_with_cols(split_layout_cols());
+        assert_eq!(ctx.chrom_tab, None, "split layout must have no chrom field");
+        let predicate = SimplePredicate {
+            chrom: Some("21".to_string()),
+            ..Default::default()
+        };
+        let line = "rs574523538\t0\t0\t25000001\t25000001\tC/T\t1";
+        let result = parse_variation_line_into(
+            line,
+            "test_var.gz",
+            &predicate,
+            1_000_000,
+            false,
+            &mut batch,
+            &col_idx,
+            &ctx,
+            &prov,
+            &mut sid,
+            Some("21"),
+        )
+        .unwrap();
+        assert_eq!(result, VariationParseResult::Added);
+        assert_eq!(batch.len(), 1);
+        let rb = batch.finish().unwrap();
+        let chroms = rb
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(chroms.value(0), "21");
+    }
+
+    #[test]
+    fn parse_merged_layout_line_chrom_takes_precedence_over_dir_chrom() {
+        // Merged/tabix layout DOES carry a chrom column. Even when a directory
+        // chrom is supplied, the per-line chrom must win — the dir fallback only
+        // applies when `variation_cols` has no chrom field.
+        let (mut batch, col_idx, ctx, prov, mut sid) = setup_variation_parser();
+        assert_eq!(ctx.chrom_tab, Some(0));
+        let predicate = SimplePredicate::default();
+        let line = "7\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
+        let result = parse_variation_line_into(
+            line,
+            "test.gz",
+            &predicate,
+            1_000_000,
+            false,
+            &mut batch,
+            &col_idx,
+            &ctx,
+            &prov,
+            &mut sid,
+            Some("21"),
+        )
+        .unwrap();
+        assert_eq!(result, VariationParseResult::Added);
+        let rb = batch.finish().unwrap();
+        let chroms = rb
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(chroms.value(0), "7");
+    }
+
     #[test]
     fn parse_valid_line() {
         let (mut batch, col_idx, ctx, prov, mut sid) = setup_variation_parser();
@@ -947,7 +1065,7 @@ mod tests {
         let line = "1\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Added);
@@ -960,7 +1078,7 @@ mod tests {
         let predicate = SimplePredicate::default();
         let result = parse_variation_line_into(
             "", "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Skipped);
@@ -982,6 +1100,7 @@ mod tests {
             &ctx,
             &prov,
             &mut sid,
+            None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Skipped);
@@ -994,7 +1113,7 @@ mod tests {
         let line = ".\t100\t100\trs12345\tA/G";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Malformed);
@@ -1007,7 +1126,7 @@ mod tests {
         let line = "1\t.\t100\trs12345\tA/G";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Malformed);
@@ -1023,7 +1142,7 @@ mod tests {
         let line = "1\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Skipped);
@@ -1036,7 +1155,7 @@ mod tests {
         let line = "1\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
         parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, true, // zero-based
-            &mut batch, &col_idx, &ctx, &prov, &mut sid,
+            &mut batch, &col_idx, &ctx, &prov, &mut sid, None,
         )
         .unwrap();
         // Start should be 99 (100 - 1) in zero-based


### PR DESCRIPTION
## Summary
Fixes the second bug in split-layout (e.g. Ensembl release 84) variation conversion: the per-line variation parser ignored the **directory-derived chromosome**, so every line in a `_var.gz` file under a region directory (e.g. `21/`) was classified `Malformed` → **0 variation rows**.

Split-layout `_var.gz` files have **no chrom column** — `info.txt`'s `variation_cols` begins `variation_name,failed,somatic,start,end,...` with no `chr`/`seq_region` field. `VariationContext::chrom_tab` is therefore `None`, the parser found no chrom field, and dropped every row. The chromosome is implicit from the region directory name, which is already resolved at discovery/pruning time via `discovery::extract_chrom_from_path`.

`Fixes #192`.

## Fix
- Add a `dir_chrom: Option<&str>` parameter to `parse_variation_line_into`, used as a fallback **only when `ctx.chrom_tab` is `None`**.
- Thread the directory-derived chrom at both variation call sites in `physical_exec.rs` (text-line path and BGZF-partition path), computed once per file via `extract_chrom_from_path`.
- Merged/tabix layout, which DOES carry a chrom column, is unchanged: the per-line chrom always takes precedence.

Minimal and localized: +142 / -9 lines across `variation.rs` and `physical_exec.rs`.

## Tests (TDD)
- `parse_split_layout_uses_directory_chrom` — split-layout line (no chrom column) under `21/` now parses with chrom `21` and is `Added` (>0 rows). **Verified fail-before / pass-after**: with the fix reverted it returns `Malformed`.
- `parse_merged_layout_line_chrom_takes_precedence_over_dir_chrom` — guards the merged path: when a chrom column exists, the per-line chrom wins over `dir_chrom`.

`cargo test -p datafusion-bio-format-ensembl-cache` → all green (428 + 8 + 89 + 15 + 31 passing). `cargo fmt --all -- --check` clean.

## Stacking on #189
This branch is based on `fix/ensembl-cache-split-layout-variation-discovery` (PR #189). The variation parser is only *reached* once discovery correctly classifies the `_var.gz`, so this fix needs #189 to be testable end-to-end. **Review/merge after #189.** This PR's diff therefore also contains #189's single commit (`415c11a`); the new work is the top commit `a57f5dd`. If #189 merges first, rebasing onto `master` will reduce this PR to just the chrom commit.

## Known limitation — separate bug (#193), out of scope
End-to-end conversion of the release-84 fixture still yields **0 rows** because of a *third, independent* problem filed as **#193**: release-84 `_var.gz` files are **whitespace-delimited legacy positional format** (0 tabs across 116k lines; variable field count, not the 31 `variation_cols`), but the parser splits strictly on TAB and maps by `variation_cols`. Fixing that requires confirming the legacy column layout against VEP cache-dump source and is intentionally **not** attempted here to avoid a fragile change. This chrom fix is a correct and necessary prerequisite regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
