### PR TITLE
test(port-cache-dir): Tier 2 v2 port (13 unit-port + 2 Axis-B + 3 integration)

### DIFF
--- a/datafusion/bio-format-ensembl-cache/src/discovery.rs
+++ b/datafusion/bio-format-ensembl-cache/src/discovery.rs
@@ -42,7 +42,13 @@ pub(crate) fn discover_variation_files(cache_root: &Path) -> Result<Vec<PathBuf>
                             || lower.contains("var.gz")
                             || (looks_like_region_file_name(&lower)
                                 && !lower.ends_with("_reg.gz")
-                                && !lower.contains("transcript")))
+                                && !lower.contains("transcript")
+                                // In a split-layout cache the bare `<region>.gz`
+                                // is the (binary) transcript file and the real
+                                // variation file is the sibling `<region>_var.gz`.
+                                // Only treat the bare region file as variation in
+                                // the merged layout, where no `_var` sibling exists.
+                                && !has_variation_sibling(path)))
                 })
         })
         .cloned()
@@ -298,6 +304,29 @@ pub(crate) fn extract_distinct_chroms(
     Some(chroms.into_iter().collect())
 }
 
+/// Returns `true` if a bare region file (e.g. `25000001-26000000.gz`) has a
+/// sibling variation file (e.g. `25000001-26000000_var.gz`) in the same
+/// directory.
+///
+/// This distinguishes the classic *split-layout* cache (separate transcript /
+/// `_var` / `_reg` files per region) from the *merged* layout (a single bare
+/// region file holds variation data). In the split layout the bare region file
+/// is the binary transcript Storable and must NOT be classified as variation.
+fn has_variation_sibling(path: &Path) -> bool {
+    let Some(stem) = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.strip_suffix(".gz"))
+    else {
+        return false;
+    };
+    let var_sibling = format!("{stem}_var.gz");
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    parent.join(&var_sibling).is_file()
+}
+
 fn looks_like_region_file_name(name: &str) -> bool {
     let Some(stem) = name.strip_suffix(".gz") else {
         return false;
@@ -418,6 +447,53 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let files = discover_variation_files(dir.path()).unwrap();
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn variation_split_layout_excludes_bare_transcript_region_file() {
+        // Classic split-layout cache (e.g. Ensembl release 84): each region dir
+        // has a bare transcript file, a `_var` variation file, and a `_reg`
+        // regulatory file. Only the `_var` file is the real variation file.
+        let dir = tempfile::tempdir().unwrap();
+        let region = dir.path().join("1");
+        create_file(&region.join("25000001-26000000.gz")); // transcript (binary Storable)
+        create_file(&region.join("25000001-26000000_var.gz")); // variation (the real one)
+        create_file(&region.join("25000001-26000000_reg.gz")); // regulatory (binary)
+
+        let files = discover_variation_files(dir.path()).unwrap();
+        let names: Vec<&str> = files.iter().map(|p| p.to_str().unwrap()).collect();
+
+        assert!(
+            names
+                .iter()
+                .any(|n| n.ends_with("25000001-26000000_var.gz")),
+            "expected the _var.gz variation file, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.ends_with("25000001-26000000.gz")),
+            "bare transcript region file must NOT be classified as variation, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.ends_with("_reg.gz")),
+            "regulatory file must NOT be classified as variation, got {names:?}"
+        );
+        assert_eq!(
+            files.len(),
+            1,
+            "expected exactly one variation file, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn variation_merged_layout_picks_up_bare_region_file() {
+        // Merged layout: a bare region file with NO `_var.gz` sibling should
+        // still be treated as variation.
+        let dir = tempfile::tempdir().unwrap();
+        create_file(&dir.path().join("1/25000001-26000000.gz"));
+
+        let files = discover_variation_files(dir.path()).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_str().unwrap().ends_with("25000001-26000000.gz"));
     }
 
     // -----------------------------------------------------------------------

--- a/datafusion/bio-format-ensembl-cache/src/info.rs
+++ b/datafusion/bio-format-ensembl-cache/src/info.rs
@@ -163,6 +163,52 @@ fn parse_variation_cols(raw: &str) -> Vec<String> {
         .collect()
 }
 
+/// Validates that the parsed cache info's assembly matches the expected value.
+///
+/// Equivalent to Perl `Bio::EnsEMBL::VEP::CacheDir->new` raising
+/// "Cache assembly version <X> do not match" (CacheDir.t subtest #17) or
+/// "Mismatch in assembly versions" (subtest #20). Vepyr uses a single
+/// idiomatic error string for both control-flow paths since the underlying
+/// invariant is identical: `info.assembly == expected`.
+///
+/// Test-driven helper: no production caller today. Surfaced as `pub(crate)`
+/// for a future config-vs-cache validation pass (would live in
+/// `AnnotateVcfConfig::validate_against(&CacheInfo)` once that lands).
+#[allow(dead_code)]
+pub(crate) fn validate_assembly(info: &CacheInfo, expected: &str) -> Result<()> {
+    if info.assembly != expected {
+        return Err(exec_err(format!(
+            "Cache assembly mismatch: info.txt declares {} but expected {}",
+            info.assembly, expected
+        )));
+    }
+    Ok(())
+}
+
+/// Validates that the cache exposes a `gnomADe` source descriptor.
+///
+/// Equivalent to Perl `--af_gnomad` rejection when the cache lacks gnomADe
+/// (CacheDir.t subtest #33; regex `/gnomad.+not available/`). Wording is
+/// vepyr-idiomatic; the contract is "case-insensitive 'gnomad' and 'not
+/// available' substrings are present in the error message".
+///
+/// Test-driven helper: no production caller today. Same future fold-in as
+/// `validate_assembly`.
+#[allow(dead_code)]
+pub(crate) fn validate_af_gnomad(info: &CacheInfo) -> Result<()> {
+    if !info
+        .source_descriptors
+        .iter()
+        .any(|s| s.source_key == "gnomade")
+    {
+        return Err(exec_err(
+            "gnomAD allele-frequency data not available in this cache \
+             (no source_gnomADe entry in info.txt)",
+        ));
+    }
+    Ok(())
+}
+
 fn normalize_source_name(raw: &str) -> String {
     let mut normalized = String::with_capacity(raw.len() + 4);
     let mut previous_is_underscore = false;
@@ -478,5 +524,482 @@ mod tests {
         assert!(keys.contains(&"dbsnp"));
         assert!(keys.contains(&"cosmic"));
         assert!(keys.contains(&"clinvar"));
+    }
+
+    // =======================================================================
+    // Port: CacheDir.t  (Perl `Bio::EnsEMBL::VEP::CacheDir`)
+    //
+    // Tracks `porting-tests/detailed_plans/CacheDir.md` (v2 paradigm; sztywno
+    // 1:1; standalone tests). Each row in this submodule corresponds to a
+    // numbered Perl subtest. See the audit for full justifications.
+    //
+    // Architectural-no-analogue rows (no Rust code; documented here):
+    //   #3   Config->new ok                  vepyr has no separate
+    //                                        construct-and-validate step on
+    //                                        clap-derived AnnotateVcfConfig.
+    //   #5   ref($cd) == 'CacheDir'          Rust uses concrete types; class
+    //                                        identity is statically guaranteed.
+    //   #21  $cd->root_dir == <root>         vepyr stores only the resolved
+    //                                        full path (cache_root); no
+    //                                        separate root_dir concept.
+    //   #26  ref($as->[0]) == 'Cache::Transcript'
+    //   #27  is_deeply($as->[0]->info, $cd->version_data)
+    //   #31  ref($as->[1]) == 'Cache::Variation'
+    //                                        Class identity + per-source info
+    //                                        passthrough are Perl-internal;
+    //                                        vepyr providers share one
+    //                                        CacheInfo via ProviderInner.
+    //   #34  3-source ordering [Transcript, RegFeat, Variation]
+    //                                        vepyr has no ordered list of
+    //                                        providers; per-source CSQ
+    //                                        coverage owned by the per-source
+    //                                        ports.
+    //   #35  var_type='tabix' -> Cache::VariationTabix
+    //                                        post-A1 spec collapse (2026-05-25,
+    //                                        commit 99c4881): vepyr converts
+    //                                        all variation caches to parquet
+    //                                        at build time; var_type is
+    //                                        parsed but no longer dispatches
+    //                                        to a separate backend.
+    // =======================================================================
+    mod port_cache_dir {
+        use super::*;
+        use std::collections::HashMap;
+        use std::fs::File;
+
+        /// Writes a v115-shaped `info.txt` into `dir`. Used by the happy-path
+        /// rows (4, 12, 22, 23, 24, B2, rowB1 negative) as a curated fixture.
+        fn make_v115_info_txt(dir: &std::path::Path) {
+            let content = "species\thomo_sapiens\n\
+                           assembly\tGRCh38\n\
+                           cache_version\t115\n\
+                           serialiser_type\tstorable\n\
+                           var_type\ttabix\n\
+                           cache_region_size\t1000000\n\
+                           variation_cols\tchr,variation_name,start,end,allele_string\n\
+                           source_dbSNP\t156\n\
+                           source_gnomADe\tv4.1\n";
+            write_info_file(dir, content);
+        }
+
+        // -------------------------------------------------------------------
+        // Row 4 / Row 12 / Row 22 — happy-path construction + cache_root getter
+        // -------------------------------------------------------------------
+
+        // SUBTEST #4 (Group A — constructor happy path):
+        //   Perl: CacheDir->new({config, root_dir}) returns defined object.
+        //   Rust: CacheInfo::from_root(path) returns Ok for a v115 info.txt.
+        #[test]
+        fn row04_constructor_happy_path() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).expect("happy-path construction");
+            assert_eq!(info.species, "homo_sapiens");
+            assert_eq!(info.assembly, "GRCh38");
+            assert_eq!(info.cache_version, "115");
+        }
+
+        // SUBTEST #12 (Group A — new({dir => full_path}) bypasses path
+        // resolution): the full-path entry point is vepyr's primary mode.
+        // Overlaps semantically with row 4; documented as a deliberate
+        // duplicate to honour sztywno-1:1.
+        #[test]
+        fn row12_full_path_entry_point() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).expect("full-path entry point");
+            // Same shape as row04; the test exists to honour sztywno-1:1.
+            assert_eq!(info.species, "homo_sapiens");
+        }
+
+        // SUBTEST #22 (Group C — $cd->dir getter returns resolved full path):
+        //   Perl: $cd->dir == <cache_dir>
+        //   Rust: info.cache_root equals the tempdir path passed in.
+        #[test]
+        fn row22_cache_root_getter() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            assert_eq!(info.cache_root, dir.path().to_path_buf());
+        }
+
+        // -------------------------------------------------------------------
+        // Row 10 — no_fasta suppression (vacuous-true in vepyr)
+        // -------------------------------------------------------------------
+
+        // SUBTEST #10 (Group A — no_fasta => 1 suppresses FASTA auto-detection):
+        //   Perl: with `no_fasta => 1`, `param('fasta')` returns falsy.
+        //   Rust: vepyr's CacheInfo has no `fasta` field; there is no
+        //   auto-detection to suppress. The equivalent in vepyr is: explicit
+        //   FASTA path required, absence => no FASTA reference checks at all.
+        //   This test asserts that even with a sibling .fa file present,
+        //   CacheInfo::from_root never populates a fasta-like field
+        //   (because the struct has no such field).
+        #[test]
+        fn row10_no_fasta_suppression_vacuous_in_vepyr() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            // Write a .fa next to info.txt — Perl would auto-detect this.
+            File::create(dir.path().join("test.fa")).unwrap();
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            // Enumerate CacheInfo fields explicitly; none of them is fasta-like.
+            let _: &std::path::PathBuf = &info.cache_root;
+            let _: &String = &info.source_cache_path;
+            let _: &String = &info.species;
+            let _: &String = &info.assembly;
+            let _: &String = &info.cache_version;
+            let _: &Option<String> = &info.serializer_type;
+            let _: &Option<String> = &info.var_type;
+            let _: &Option<i64> = &info.cache_region_size;
+            let _: &Vec<String> = &info.variation_cols;
+            let _: &Vec<SourceDescriptor> = &info.source_descriptors;
+            // No fasta field exists; the .fa next to info.txt is invisible
+            // to vepyr's parser. Suppression is vacuously true.
+        }
+
+        // -------------------------------------------------------------------
+        // Row 17 / Row 20 — assembly-mismatch validator
+        // -------------------------------------------------------------------
+
+        // SUBTEST #17 (Group B5 — assembly mismatch error):
+        //   Perl: throws /Cache assembly version .+bar.+ do not match/ when
+        //         config passes assembly => 'bar' against a GRCh38 cache.
+        //   Rust: validate_assembly returns Err with both names embedded.
+        //   Wording deviation: vepyr uses "Cache assembly mismatch: ..."
+        //   idiom rather than Perl regex literal; Rule 1 permits per-row
+        //   wording deviation when contract semantics are preserved.
+        #[test]
+        fn row17_assembly_mismatch_config_vs_cache() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            let err = validate_assembly(&info, "bar")
+                .expect_err("validator must reject mismatched assembly")
+                .to_string();
+            assert!(err.contains("GRCh38"), "err missing GRCh38: {err}");
+            assert!(err.contains("bar"), "err missing 'bar': {err}");
+            assert!(
+                err.to_lowercase().contains("assembly"),
+                "err missing 'assembly': {err}"
+            );
+        }
+
+        // SUBTEST #20 (Group B8 — info.txt vs config silent divergence):
+        //   Perl: cache dir physically exists but info.txt assembly mismatches
+        //         /Mismatch in assembly versions/. Distinct control-flow path
+        //         from #17 (which tests config-vs-cache mismatch).
+        //   Rust: same validator, inverse scenario (info.txt declares GRCh37
+        //   but caller expected GRCh38).
+        #[test]
+        fn row20_assembly_mismatch_info_vs_config() {
+            let dir = tempfile::tempdir().unwrap();
+            write_info_file(
+                dir.path(),
+                "species\thomo_sapiens\nassembly\tGRCh37\ncache_version\t115\n",
+            );
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            assert_eq!(info.assembly, "GRCh37");
+            let err = validate_assembly(&info, "GRCh38")
+                .expect_err("validator must reject info-vs-config mismatch")
+                .to_string();
+            assert!(err.contains("GRCh37"), "err missing GRCh37: {err}");
+            assert!(err.contains("GRCh38"), "err missing GRCh38: {err}");
+        }
+
+        // -------------------------------------------------------------------
+        // Row 23 — full info-hash snapshot (v115 shape)
+        // -------------------------------------------------------------------
+
+        // SUBTEST #23 (Group C — is_deeply $cd->info, {...} 60-line snapshot):
+        //   Perl: full info hash snapshot, including v84-only fields.
+        //   Rust: explicit field-by-field assertion against the v115-shaped
+        //   tempdir info.txt. Perl-only fields (polyphen, sift, cell_types,
+        //   regulatory, build, valid_chromosomes) are INTENTIONALLY OMITTED:
+        //   they are not on vepyr's CacheInfo struct, by design. See
+        //   CacheDir.md "Known v115-vs-Perl-fixture differences".
+        //   cell_types specifically is a blocked-future-work entry (row #29).
+        #[test]
+        fn row23_info_snapshot_v115_shape() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            assert_eq!(info.species, "homo_sapiens");
+            assert_eq!(info.assembly, "GRCh38");
+            assert_eq!(info.cache_version, "115");
+            assert_eq!(info.serializer_type.as_deref(), Some("storable"));
+            assert_eq!(info.var_type.as_deref(), Some("tabix"));
+            assert_eq!(info.cache_region_size, Some(1_000_000));
+            assert_eq!(
+                info.variation_cols,
+                vec!["chr", "variation_name", "start", "end", "allele_string"]
+            );
+            assert_eq!(
+                info.source_descriptors.len(),
+                2,
+                "fixture declares source_dbSNP + source_gnomADe"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Row 24 — version_data sub-hash via source_descriptors
+        // -------------------------------------------------------------------
+
+        // SUBTEST #24 (Group C — is_deeply $cd->version_data, {...}):
+        //   Perl: source-version sub-hash on the cache.
+        //   Rust: source_descriptors carries the same role as Perl's
+        //   version_data. Field mapping: Perl's version_data includes
+        //   `assembly`, which in vepyr lives on CacheInfo::assembly (NOT on
+        //   source_descriptors).
+        #[test]
+        fn row24_version_data_via_source_descriptors() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            let by_key: HashMap<&str, &str> = info
+                .source_descriptors
+                .iter()
+                .map(|s| (s.source_key.as_str(), s.value.as_str()))
+                .collect();
+            assert_eq!(by_key.get("dbsnp"), Some(&"156"));
+            assert_eq!(by_key.get("gnomade"), Some(&"v4.1"));
+            // `assembly` lives on CacheInfo, not on source_descriptors:
+            assert_eq!(info.assembly, "GRCh38");
+        }
+
+        // -------------------------------------------------------------------
+        // Row 32 / Row 33 — gnomADe presence + absence validator
+        // -------------------------------------------------------------------
+
+        // SUBTEST #32 (Group D — check_existing=1 + af_gnomad=1 against v84
+        // cache succeeds because v84 has source_gnomADe):
+        //   Perl: passes silently when the cache declares source_gnomADe.
+        //   Rust: validate_af_gnomad returns Ok when source_descriptors
+        //   contains "gnomade".
+        #[test]
+        fn row32_af_gnomad_passes_when_source_present() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path()); // includes source_gnomADe v4.1
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            validate_af_gnomad(&info).expect("validator must accept gnomADe-bearing cache");
+        }
+
+        // SUBTEST #33 (Group D — check_existing=1 + af_gnomad=1 against
+        // ExAC-only cache throws):
+        //   Perl: throws /gnomad.+not available/.
+        //   Rust: validate_af_gnomad returns Err. Wording: case-insensitive
+        //   match to Perl regex (both "gnomad" and "not available" substrings
+        //   must be present in the error message).
+        #[test]
+        fn row33_af_gnomad_rejects_when_source_absent() {
+            let dir = tempfile::tempdir().unwrap();
+            // Curated ExAC-shaped info.txt (no source_gnomADe).
+            write_info_file(
+                dir.path(),
+                "species\thomo_sapiens\nassembly\tGRCh38\nsource_ExAC\t0.3\n",
+            );
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            let err = validate_af_gnomad(&info)
+                .expect_err("validator must reject gnomADe-less cache")
+                .to_string()
+                .to_lowercase();
+            assert!(
+                err.contains("gnomad") && err.contains("not available"),
+                "err missing required substrings: {err}"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Axis-B Row B1 — post-A1 collapse: parquet serializer accepted by parser
+        // -------------------------------------------------------------------
+
+        // AXIS-B ROW B1 (vepyr-side invariant; verified via verify-sweeps PR #21):
+        //   CacheInfo::from_root accepts serializer_type=parquet without
+        //   rejection. The validate_serializer guard
+        //   (table_provider.rs::validate_serializer) is only invoked from
+        //   ProviderInner::new for transcript/regulatory/motif/exon/translation
+        //   entities — NOT from CacheInfo::from_root itself. The partitioned
+        //   parquet production path used by annotate_to_vcf bypasses
+        //   CacheInfo::from_root and EnsemblCacheTableProvider::for_entity
+        //   entirely (it reads Arrow metadata via
+        //   CacheSourceType::from_partitioned_cache_source instead).
+        #[allow(non_snake_case)]
+        #[test]
+        fn rowB1_from_root_accepts_parquet_serializer() {
+            let dir = tempfile::tempdir().unwrap();
+            write_info_file(
+                dir.path(),
+                "species\thomo_sapiens\nassembly\tGRCh38\nserializer_type\tparquet\n",
+            );
+            let info = CacheInfo::from_root(dir.path())
+                .expect("CacheInfo::from_root must accept serializer_type=parquet");
+            assert_eq!(info.serializer_type.as_deref(), Some("parquet"));
+        }
+
+        // -------------------------------------------------------------------
+        // Axis-B Row B2 — post-A1 collapse: var_type=tabix parsed-but-no-op
+        // -------------------------------------------------------------------
+
+        // AXIS-B ROW B2 (vepyr-side invariant):
+        //   var_type=tabix is parsed into Some("tabix") on CacheInfo, but
+        //   does NOT trigger any separate tabix-backend dispatch at provider
+        //   construction. Pins the post-A1 invariant that the field is
+        //   parsed-but-no-op, preventing accidental re-introduction of a
+        //   tabix backend path.
+        #[allow(non_snake_case)]
+        #[test]
+        fn rowB2_var_type_tabix_parsed_but_no_dispatch() {
+            let dir = tempfile::tempdir().unwrap();
+            make_v115_info_txt(dir.path());
+            let info = CacheInfo::from_root(dir.path()).unwrap();
+            assert_eq!(info.var_type.as_deref(), Some("tabix"));
+            // No backend-dispatch effect to assert positively. The contract
+            // is "the parsed value never reaches a backend selector"; this
+            // is structurally enforced by ProviderInner::new (table_provider.rs:120)
+            // not branching on info.var_type at all.
+        }
+
+        // ===================================================================
+        // Blocked-future-work rows (commented-out tests).
+        //
+        // Each row below is gated on a missing vepyr API. The example test
+        // body documents what the test would assert once the API lands; the
+        // commented-out form keeps cargo green while the gap exists. Cross-
+        // reference: `porting-tests/future-work-vepyr.md`.
+        // ===================================================================
+
+        // SUBTEST #6 (Group A — auto-detected synonyms path):
+        //   Perl: param('synonyms') resolves to <cache_dir>/chr_synonyms.txt
+        //         when present in the cache directory.
+        //   Rust: BLOCKED — no auto_detect_chr_synonyms helper in vepyr.
+        //   Future-work entry: future-work-vepyr.md
+        //     §"auto_detect_chr_synonyms / auto_detect_fasta on cache_root".
+        //
+        // #[test]
+        // fn row06_auto_detect_chr_synonyms() {
+        //     let dir = tempfile::tempdir().unwrap();
+        //     make_v115_info_txt(dir.path());
+        //     File::create(dir.path().join("chr_synonyms.txt")).unwrap();
+        //     // let detected = auto_detect_chr_synonyms(dir.path()); // missing API
+        //     // assert_eq!(detected, Some(dir.path().join("chr_synonyms.txt")));
+        // }
+
+        // SUBTEST #7 (Group A — auto-detected FASTA path):
+        //   Perl: param('fasta') resolves to the cache dir's *.fa file.
+        //   Rust: BLOCKED — no auto_detect_fasta helper in vepyr.
+        //   Future-work entry: same as #6.
+        //
+        // #[test]
+        // fn row07_auto_detect_fasta() {
+        //     let dir = tempfile::tempdir().unwrap();
+        //     make_v115_info_txt(dir.path());
+        //     File::create(dir.path().join("test.fa")).unwrap();
+        //     // let detected = auto_detect_fasta(dir.path()); // missing API
+        //     // assert_eq!(detected, Some(dir.path().join("test.fa")));
+        // }
+
+        // SUBTEST #8 (Group A — config-set synonyms wins over auto-detect):
+        //   Perl: param('synonyms') == 'bar' when config provides 'bar' even
+        //         though chr_synonyms.txt is present.
+        //   Rust: BLOCKED — gated on row 6 + a config priority rule.
+        //
+        // #[test]
+        // fn row08_synonyms_config_wins_over_autodetect() {
+        //     // ... gated on row 6 helper landing ...
+        // }
+
+        // SUBTEST #9 (Group A — config-set FASTA wins over auto-detect):
+        //   Perl: param('fasta') == 'foo' even though cache_dir/*.fa exists.
+        //   Rust: BLOCKED — gated on row 7 + a config priority rule.
+        //
+        // #[test]
+        // fn row09_fasta_config_wins_over_autodetect() {
+        //     // ... gated on row 7 helper landing ...
+        // }
+
+        // SUBTEST #11 (Group A — new({cache_version}) resolves species + assembly):
+        //   Perl: with only cache_version on the config, CacheDir scans the
+        //         root_dir for the unique species/assembly under that version.
+        //   Rust: BLOCKED — vepyr has no resolve_cache_dir helper.
+        //   Future-work entry: future-work-vepyr.md §"resolve_cache_dir —
+        //     path resolver from (species, version, assembly)".
+        //
+        // #[test]
+        // fn row11_new_resolves_species_assembly_from_cache_version() {
+        //     // let path = resolve_cache_dir(root, None, Some(115), None)?;
+        //     // assert_eq!(path, root.join("homo_sapiens/115_GRCh38"));
+        // }
+
+        // SUBTEST #13 (Group B1 — no root_dir and no dir):
+        //   Perl: throws /No root_dir or dir specified/.
+        //   Rust: BLOCKED — gated on resolve_cache_dir (same entry).
+        //
+        // #[test]
+        // fn row13_no_root_dir_or_dir_throws() {
+        //     // resolve_cache_dir(None, ...) → Err containing "No root_dir or dir specified"
+        // }
+
+        // SUBTEST #14 (Group B2 — species='bar', no such dir):
+        //   Perl: throws /Cache directory .+ not found/.
+        //   Rust: BLOCKED — gated on resolve_cache_dir.
+        //
+        // #[test]
+        // fn row14_unknown_species_throws() {
+        //     // resolve_cache_dir(root, Some("bar"), Some(115), None) → Err "not found"
+        // }
+
+        // SUBTEST #15 (Group B3 — species='homo_sapiens_refseq' deprecated suffix):
+        //   Perl: throws a helpful /Should not use .+ as --species/ message.
+        //   Rust: BLOCKED — gated on resolve_cache_dir (vepyr's equivalent
+        //   error exists but for a different reason: cache_source_type must
+        //   be explicit; see table_provider.rs:121).
+        //
+        // #[test]
+        // fn row15_refseq_species_suffix_throws_helpful_message() {
+        //     // resolve_cache_dir(root, Some("homo_sapiens_refseq"), ...) → Err
+        // }
+
+        // SUBTEST #16 (Group B4 — cache_version=20, no such cache):
+        //   Perl: throws /No cache found for .+ 20/.
+        //   Rust: BLOCKED — gated on resolve_cache_dir.
+        //
+        // #[test]
+        // fn row16_unknown_cache_version_throws() {
+        //     // resolve_cache_dir(root, None, Some(20), None) → Err "No cache found"
+        // }
+
+        // SUBTEST #18 (Group B6 — no assembly, multiple available under species):
+        //   Perl: throws /Multiple assemblies found/.
+        //   Rust: BLOCKED — ambiguity-handling is part of resolve_cache_dir.
+        //
+        // #[test]
+        // fn row18_multiple_assemblies_throws() {
+        //     // resolve_cache_dir(root, Some("foo"), Some(115), None) → Err "Multiple"
+        // }
+
+        // SUBTEST #19 (Group B7 — species='foo', assembly='tar', no match):
+        //   Perl: throws /No cache found/.
+        //   Rust: BLOCKED — gated on resolve_cache_dir.
+        //
+        // #[test]
+        // fn row19_unknown_species_assembly_combo_throws() {
+        //     // resolve_cache_dir(root, Some("foo"), Some(115), Some("tar")) → Err
+        // }
+
+        // SUBTEST #29 (Group D — RegFeat available_cell_types matches 37-entry list):
+        //   Perl: $as->[1]->{available_cell_types} parsed from info.txt
+        //         cell_types line.
+        //   Rust: BLOCKED — `cell_types` is not on vepyr's CacheInfo.
+        //   Future-work entry: future-work-vepyr.md §"CacheInfo::cell_types".
+        //
+        // #[test]
+        // fn row29_cell_types_parsed_from_info_txt() {
+        //     let dir = tempfile::tempdir().unwrap();
+        //     write_info_file(
+        //         dir.path(),
+        //         "species\thomo_sapiens\nassembly\tGRCh38\ncell_types\tA549,GM12878,K562\n",
+        //     );
+        //     let info = CacheInfo::from_root(dir.path()).unwrap();
+        //     // assert_eq!(info.cell_types, vec!["A549","GM12878","K562"]); // missing field
+        // }
     }
 }

--- a/datafusion/bio-format-ensembl-cache/src/physical_exec.rs
+++ b/datafusion/bio-format-ensembl-cache/src/physical_exec.rs
@@ -598,6 +598,9 @@ fn process_partition(
         && kind == EnsemblEntityKind::Variation
     {
         let source_file_str = bgzf_path.to_str().unwrap_or_default();
+        // Split-layout `_var.gz` files have no chrom column; derive the chrom
+        // from the region directory so the per-line parser can fall back to it.
+        let dir_chrom = extract_chrom_from_path(bgzf_path, EnsemblEntityKind::Variation);
         let mut bgzf_reader =
             crate::tabix_reader::BgzfPartitionLineReader::open(bgzf_path, bgzf_part)?;
 
@@ -613,6 +616,7 @@ fn process_partition(
                 variation_ctx.as_ref().unwrap(),
                 &provenance,
                 source_id_writer.as_mut().unwrap(),
+                dir_chrom.as_deref(),
             )? {
                 VariationParseResult::Added => {
                     match dispatch_row(
@@ -662,6 +666,15 @@ fn process_partition(
             &source_file.to_string_lossy()
         } else {
             source_file_str
+        };
+
+        // Directory-derived chrom for split-layout variation `_var.gz` files,
+        // which carry no chrom column. Computed once per file; ignored by the
+        // parser when the line already carries a chrom (merged/tabix layout).
+        let variation_dir_chrom = if kind == EnsemblEntityKind::Variation {
+            extract_chrom_from_path(source_file, EnsemblEntityKind::Variation)
+        } else {
+            None
         };
 
         // Merge the pst0 header check with the alias-count scan to avoid
@@ -899,6 +912,7 @@ fn process_partition(
                         variation_ctx.as_ref().unwrap(),
                         &provenance,
                         source_id_writer.as_mut().unwrap(),
+                        variation_dir_chrom.as_deref(),
                     )? {
                         VariationParseResult::Added => true,
                         VariationParseResult::Skipped => false,

--- a/datafusion/bio-format-ensembl-cache/src/variation.rs
+++ b/datafusion/bio-format-ensembl-cache/src/variation.rs
@@ -477,6 +477,7 @@ pub(crate) fn parse_variation_line_into(
     ctx: &VariationContext,
     provenance: &ProvenanceWriter,
     source_id_writer: &mut SourceIdWriter,
+    dir_chrom: Option<&str>,
 ) -> Result<VariationParseResult> {
     let trimmed = line.trim();
     if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -501,8 +502,19 @@ pub(crate) fn parse_variation_line_into(
     // Extract required fields — return Malformed instead of Err so a single
     // bad line does not abort the entire partition and silently drop all
     // subsequent records.
-    let Some(chrom_ref) = field_at(ctx.chrom_tab).and_then(normalize_nullable_ref) else {
-        return Ok(VariationParseResult::Malformed);
+    //
+    // Split-layout `_var.gz` files (e.g. Ensembl release 84) carry NO chrom
+    // column: `variation_cols` has no chr/seq_region field, so `ctx.chrom_tab`
+    // is `None` and the chromosome is implicit from the region directory name.
+    // In that case fall back to the directory-derived chrom resolved at file
+    // discovery time. The merged/tabix layout DOES carry a chrom column, so
+    // `ctx.chrom_tab` is `Some` and the per-line value takes precedence.
+    let chrom_ref = match field_at(ctx.chrom_tab).and_then(normalize_nullable_ref) {
+        Some(chrom) => chrom,
+        None => match dir_chrom {
+            Some(chrom) => chrom,
+            None => return Ok(VariationParseResult::Malformed),
+        },
     };
 
     let Some(source_start) = parse_i64_ref(field_at(ctx.start_tab)) else {
@@ -928,7 +940,19 @@ mod tests {
         ProvenanceWriter,
         SourceIdWriter,
     ) {
-        let info = make_cache_info(standard_cols(), standard_sources());
+        setup_variation_parser_with_cols(standard_cols())
+    }
+
+    fn setup_variation_parser_with_cols(
+        cols: Vec<String>,
+    ) -> (
+        BatchBuilder,
+        VariationColumnIndices,
+        VariationContext,
+        ProvenanceWriter,
+        SourceIdWriter,
+    ) {
+        let info = make_cache_info(cols, standard_sources());
         let schema =
             variation_schema(&info, false, crate::source_type::CacheSourceType::Ensembl).unwrap();
         let col_map = ColumnMap::from_schema(&schema);
@@ -940,6 +964,100 @@ mod tests {
         (builder, col_idx, ctx, provenance, source_id_writer)
     }
 
+    /// Release-84 split-layout `variation_cols`: starts with `variation_name`
+    /// and has NO chrom/seq_region column — chrom is implicit from the region
+    /// directory name.
+    fn split_layout_cols() -> Vec<String> {
+        vec![
+            "variation_name",
+            "failed",
+            "somatic",
+            "start",
+            "end",
+            "allele_string",
+            "strand",
+            "minor_allele",
+            "minor_allele_freq",
+            "clin_sig",
+            "phenotype_or_disease",
+            "pubmed",
+            "var_synonyms",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
+    }
+
+    #[test]
+    fn parse_split_layout_uses_directory_chrom() {
+        // Split-layout `_var.gz` line: no chrom column. Columns are
+        // variation_name, failed, somatic, start, end, allele_string, ...
+        let (mut batch, col_idx, ctx, prov, mut sid) =
+            setup_variation_parser_with_cols(split_layout_cols());
+        assert_eq!(ctx.chrom_tab, None, "split layout must have no chrom field");
+        let predicate = SimplePredicate {
+            chrom: Some("21".to_string()),
+            ..Default::default()
+        };
+        let line = "rs574523538\t0\t0\t25000001\t25000001\tC/T\t1";
+        let result = parse_variation_line_into(
+            line,
+            "test_var.gz",
+            &predicate,
+            1_000_000,
+            false,
+            &mut batch,
+            &col_idx,
+            &ctx,
+            &prov,
+            &mut sid,
+            Some("21"),
+        )
+        .unwrap();
+        assert_eq!(result, VariationParseResult::Added);
+        assert_eq!(batch.len(), 1);
+        let rb = batch.finish().unwrap();
+        let chroms = rb
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(chroms.value(0), "21");
+    }
+
+    #[test]
+    fn parse_merged_layout_line_chrom_takes_precedence_over_dir_chrom() {
+        // Merged/tabix layout DOES carry a chrom column. Even when a directory
+        // chrom is supplied, the per-line chrom must win — the dir fallback only
+        // applies when `variation_cols` has no chrom field.
+        let (mut batch, col_idx, ctx, prov, mut sid) = setup_variation_parser();
+        assert_eq!(ctx.chrom_tab, Some(0));
+        let predicate = SimplePredicate::default();
+        let line = "7\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
+        let result = parse_variation_line_into(
+            line,
+            "test.gz",
+            &predicate,
+            1_000_000,
+            false,
+            &mut batch,
+            &col_idx,
+            &ctx,
+            &prov,
+            &mut sid,
+            Some("21"),
+        )
+        .unwrap();
+        assert_eq!(result, VariationParseResult::Added);
+        let rb = batch.finish().unwrap();
+        let chroms = rb
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(chroms.value(0), "7");
+    }
+
     #[test]
     fn parse_valid_line() {
         let (mut batch, col_idx, ctx, prov, mut sid) = setup_variation_parser();
@@ -947,7 +1065,7 @@ mod tests {
         let line = "1\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Added);
@@ -960,7 +1078,7 @@ mod tests {
         let predicate = SimplePredicate::default();
         let result = parse_variation_line_into(
             "", "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Skipped);
@@ -982,6 +1100,7 @@ mod tests {
             &ctx,
             &prov,
             &mut sid,
+            None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Skipped);
@@ -994,7 +1113,7 @@ mod tests {
         let line = ".\t100\t100\trs12345\tA/G";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Malformed);
@@ -1007,7 +1126,7 @@ mod tests {
         let line = "1\t.\t100\trs12345\tA/G";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Malformed);
@@ -1023,7 +1142,7 @@ mod tests {
         let line = "1\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
         let result = parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, false, &mut batch, &col_idx, &ctx, &prov,
-            &mut sid,
+            &mut sid, None,
         )
         .unwrap();
         assert_eq!(result, VariationParseResult::Skipped);
@@ -1036,7 +1155,7 @@ mod tests {
         let line = "1\t100\t100\trs12345\tA/G\t0\t0\t1\tG\t0.45\t.\t0\t.\t.\t.";
         parse_variation_line_into(
             line, "test.gz", &predicate, 1_000_000, true, // zero-based
-            &mut batch, &col_idx, &ctx, &prov, &mut sid,
+            &mut batch, &col_idx, &ctx, &prov, &mut sid, None,
         )
         .unwrap();
         // Start should be 99 (100 - 1) in zero-based

--- a/datafusion/bio-format-ensembl-cache/tests/port_cache_dir.rs
+++ b/datafusion/bio-format-ensembl-cache/tests/port_cache_dir.rs
@@ -1,0 +1,96 @@
+//! Port tests for `CacheDir.t` rows 25, 28, 30 — provider construction
+//! against the real v115-shaped cache fixture
+//! (`tests/fixtures/real_vep_115_chr22/`).
+//!
+//! These are integration tests because `EnsemblCacheTableProvider::for_entity`
+//! exercises end-to-end file-discovery + schema-building + serializer
+//! validation in `ProviderInner::new` (table_provider.rs). The unit-level
+//! parser behaviour for these rows is covered by `info.rs::tests::port_cache_dir`.
+//!
+//! See `porting-tests/detailed_plans/CacheDir.md` for the audit, and
+//! `porting-tests/plans/2026-05-28-port-cache-dir.md` Task 10 for the plan.
+
+use datafusion_bio_format_ensembl_cache::{
+    CacheSourceType, EnsemblCacheOptions, EnsemblCacheTableProvider, EnsemblEntityKind,
+};
+
+fn fixture_path() -> String {
+    format!(
+        "{}/tests/fixtures/real_vep_115_chr22",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn ensembl_options() -> EnsemblCacheOptions {
+    EnsemblCacheOptions::new(fixture_path()).with_cache_source_type(CacheSourceType::Ensembl)
+}
+
+// SUBTEST #25 (Group D — default config activates only transcript):
+//   Perl: get_all_AnnotationSources returns 1-element array of Cache::Transcript.
+//   Rust: EnsemblCacheTableProvider::for_entity(Transcript, opts) returns Ok.
+//   The "ARRAY of one" claim has no analogue (vepyr constructs one provider
+//   per call); the testable surface is "Transcript provider is constructable
+//   from this cache".
+#[test]
+fn row25_transcript_provider_constructable() {
+    let _provider =
+        EnsemblCacheTableProvider::for_entity(EnsemblEntityKind::Transcript, ensembl_options())
+            .expect("Transcript provider must construct from v115 fixture");
+}
+
+// SUBTEST #28 (Group D — regulatory => 1 activates RegFeat in addition to
+// Transcript):
+//   Perl: 2 sources [Transcript, RegFeat]; the "list-contains-two" claim has
+//   no analogue under vepyr's per-entity construction. Testable surface:
+//   RegFeat provider is constructable.
+//
+// NOTE: if the real_vep_115_chr22 fixture lacks regulatory data, this test
+// will error during file discovery in ProviderInner::new. In that case the
+// row downgrades to a commented-out test per plan Task 10 rule. See test
+// output for the diagnostic.
+#[test]
+fn row28_regulatory_feature_provider_constructable() {
+    match EnsemblCacheTableProvider::for_entity(
+        EnsemblEntityKind::RegulatoryFeature,
+        ensembl_options(),
+    ) {
+        Ok(_provider) => {
+            // GREEN — fixture exposes regulatory data.
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            // Plan Task 10 downgrade rule: if the fixture lacks regulatory
+            // files, the row gates on a fixture-extension future-work entry.
+            // Surface a clear panic so the controller catches it as a
+            // downgrade signal rather than a silent skip.
+            panic!(
+                "row28 RegulatoryFeature provider failed to construct from v115 fixture: {msg}. \
+                 If the fixture lacks regulatory data, downgrade this row per \
+                 plan Task 10 rule and add a 'real_vep_115_chr22 fixture extension' \
+                 future-work entry."
+            );
+        }
+    }
+}
+
+// SUBTEST #30 (Group D — check_existing => 1 activates Variation in addition
+// to Transcript):
+//   Perl: 2 sources [Transcript, Variation]; testable surface = Variation
+//   provider is constructable.
+#[test]
+fn row30_variation_provider_constructable() {
+    match EnsemblCacheTableProvider::for_entity(EnsemblEntityKind::Variation, ensembl_options()) {
+        Ok(_provider) => {
+            // GREEN — fixture exposes variation data.
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            panic!(
+                "row30 Variation provider failed to construct from v115 fixture: {msg}. \
+                 If the fixture lacks variation data, downgrade this row per \
+                 plan Task 10 rule and add a 'real_vep_115_chr22 fixture extension' \
+                 future-work entry."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Port CacheDir.t per v2 paradigm. 39% parity (12 blocked-future-work rows fold to existing future-work-vepyr.md entries). 586/0/1 full crate suite. See porting-tests dev-test for plan + status. Branch off fix/ensembl-cache-split-layout-variation-chrom.