### PR TITLE
Support fasta files >2 GB

### DIFF
--- a/datafusion/bio-format-fasta/src/physical_exec.rs
+++ b/datafusion/bio-format-fasta/src/physical_exec.rs
@@ -1,7 +1,9 @@
 use crate::storage::{FastaLocalReader, FastaRemoteReader, open_local_fasta_sync};
 use async_stream::__private::AsyncStream;
 use async_stream::try_stream;
-use datafusion::arrow::array::{Array, NullArray, RecordBatch, StringArray, StringBuilder};
+use datafusion::arrow::array::{
+    Array, LargeStringArray, NullArray, RecordBatch, StringArray, StringBuilder,
+};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -399,7 +401,7 @@ fn build_record_batch(
     projection: Option<Vec<usize>>,
 ) -> datafusion::error::Result<RecordBatch> {
     let name_array = Arc::new(StringArray::from(name.to_vec())) as Arc<dyn Array>;
-    let sequence_array = Arc::new(StringArray::from(sequence.to_vec())) as Arc<dyn Array>;
+    let sequence_array = Arc::new(LargeStringArray::from(sequence.to_vec())) as Arc<dyn Array>;
     let description_array = Arc::new({
         let mut builder = StringBuilder::new();
         for s in description {

--- a/datafusion/bio-format-fasta/src/serializer.rs
+++ b/datafusion/bio-format-fasta/src/serializer.rs
@@ -115,7 +115,7 @@ mod tests {
         Arc::new(Schema::new(vec![
             Field::new("name", DataType::Utf8, false),
             Field::new("description", DataType::Utf8, true),
-            Field::new("sequence", DataType::Utf8, false),
+            Field::new("sequence", DataType::LargeUtf8, false),
         ]))
     }
 
@@ -125,7 +125,7 @@ mod tests {
 
         let names = StringArray::from(vec!["seq1", "seq2"]);
         let descriptions = StringArray::from(vec![Some("protein A"), None]);
-        let sequences = StringArray::from(vec!["ACGT", "TGCA"]);
+        let sequences = LargeStringArray::from(vec!["ACGT", "TGCA"]);
 
         let batch = RecordBatch::try_new(
             schema,
@@ -151,7 +151,7 @@ mod tests {
 
         let names = StringArray::from(vec!["seq1"]);
         let descriptions = StringArray::from(vec![Some("")]);
-        let sequences = StringArray::from(vec!["ACGT"]);
+        let sequences = LargeStringArray::from(vec!["ACGT"]);
 
         let batch = RecordBatch::try_new(
             schema,
@@ -170,7 +170,7 @@ mod tests {
 
         let names = StringArray::from(vec![""]);
         let descriptions = StringArray::from(vec![Some("")]);
-        let sequences = StringArray::from(vec!["ACGT"]);
+        let sequences = LargeStringArray::from(vec!["ACGT"]);
 
         let batch = RecordBatch::try_new(
             schema,
@@ -194,7 +194,7 @@ mod tests {
 
         let names = StringArray::from(vec!["seq1"]);
         let descriptions = StringArray::from(vec![Some("")]);
-        let sequences = StringArray::from(vec![""]);
+        let sequences = LargeStringArray::from(vec![""]);
 
         let batch = RecordBatch::try_new(
             schema,
@@ -216,11 +216,11 @@ mod tests {
     fn test_batch_to_fasta_records_too_few_columns() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("name", DataType::Utf8, false),
-            Field::new("sequence", DataType::Utf8, false),
+            Field::new("sequence", DataType::LargeUtf8, false),
         ]));
 
         let names = StringArray::from(vec!["seq1"]);
-        let sequences = StringArray::from(vec!["ACGT"]);
+        let sequences = LargeStringArray::from(vec!["ACGT"]);
 
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(names), Arc::new(sequences)]).unwrap();

--- a/datafusion/bio-format-fasta/src/serializer.rs
+++ b/datafusion/bio-format-fasta/src/serializer.rs
@@ -57,7 +57,7 @@ fn get_string_column<'a>(
 /// The RecordBatch must have the following schema:
 /// - Column 0: `name` (Utf8, required) - Sequence identifier
 /// - Column 1: `description` (Utf8, nullable) - Sequence description
-/// - Column 2: `sequence` (Utf8, required) - The sequence data
+/// - Column 2: `sequence` (LargeUtf8, required) - The sequence data
 pub fn batch_to_fasta_records(batch: &RecordBatch) -> Result<Vec<fasta::Record>> {
     let num_columns = batch.num_columns();
 

--- a/datafusion/bio-format-fasta/src/table_provider.rs
+++ b/datafusion/bio-format-fasta/src/table_provider.rs
@@ -23,12 +23,12 @@ use std::sync::Arc;
 /// Returns a schema with three fields:
 /// - `name` (Utf8, non-null): Sequence identifier
 /// - `description` (Utf8, nullable): Sequence description
-/// - `sequence` (Utf8, non-null): The actual sequence data
+/// - `sequence` (LargeUtf8, non-null): The actual sequence data
 fn determine_schema() -> datafusion::common::Result<SchemaRef> {
     let fields = vec![
         Field::new("name", DataType::Utf8, false),
         Field::new("description", DataType::Utf8, true),
-        Field::new("sequence", DataType::Utf8, false),
+        Field::new("sequence", DataType::LargeUtf8, false),
     ];
     let schema = Schema::new(fields);
     debug!("Schema: {schema:?}");

--- a/datafusion/bio-format-fasta/tests/read_test.rs
+++ b/datafusion/bio-format-fasta/tests/read_test.rs
@@ -1,0 +1,52 @@
+//! Integration tests for FASTA read functionality
+//!
+//! Tests verify that FASTA files can be read correctly even for large files
+
+use datafusion::prelude::*;
+use datafusion_bio_format_fasta::FastaTableProvider;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+/// Helper: generate an uncompressed FASTA file with `num_records` records.
+fn generate_test_fasta(path: &str, num_records: usize) {
+    let mut file =
+        std::io::BufWriter::new(std::fs::File::create(path).expect("Failed to create test file"));
+    // Each line has 24 bytes, 12_500_000 lines per record means
+    // ten records will give ~ 3 GB of data
+    let num_lines = 12_500_000;
+    //let body = b"ACGTACGTACGTACGTACGT".repeat(num_lines);
+    for i in 0..num_records {
+        writeln!(file, ">seq_{i} sample description {i}").unwrap();
+        for _j in 0..num_lines {
+            writeln!(file, "ACGTACGTACGTACGTACGT").unwrap();
+        }
+    }
+    file.flush().unwrap();
+}
+
+#[tokio::test]
+async fn test_read_3gb_file() {
+    let tmp_dir = TempDir::new().unwrap();
+    let input_path = tmp_dir.path().join("input.fasta");
+
+    let num_records = 10;
+    generate_test_fasta(input_path.to_str().unwrap(), num_records);
+
+    let ctx = SessionContext::new();
+
+    let input_provider = FastaTableProvider::new(input_path.to_str().unwrap().to_string(), None)
+        .expect("Failed to create input provider");
+    ctx.register_table("input_fasta", Arc::new(input_provider))
+        .unwrap();
+
+    let result = ctx
+        .sql("SELECT * FROM input_fasta")
+        .await
+        .expect("Failed to execute SELECT")
+        .collect()
+        .await
+        .expect("Failed to collect results");
+
+    assert_eq!(result.len(), 10);
+}

--- a/datafusion/bio-format-fasta/tests/read_test.rs
+++ b/datafusion/bio-format-fasta/tests/read_test.rs
@@ -13,9 +13,8 @@ fn generate_test_fasta(path: &str, num_records: usize) {
     let mut file =
         std::io::BufWriter::new(std::fs::File::create(path).expect("Failed to create test file"));
     // Each line has 24 bytes, 12_500_000 lines per record means
-    // ten records will give ~ 3 GB of data
+    // ten records will give ~ 2.6 GB of data
     let num_lines = 12_500_000;
-    //let body = b"ACGTACGTACGTACGTACGT".repeat(num_lines);
     for i in 0..num_records {
         writeln!(file, ">seq_{i} sample description {i}").unwrap();
         for _j in 0..num_lines {
@@ -49,5 +48,6 @@ async fn test_read_3gb_file() {
         .await
         .expect("Failed to collect results");
 
-    assert_eq!(result.len(), 10);
+    let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, num_records);
 }

--- a/datafusion/bio-format-fasta/tests/read_test.rs
+++ b/datafusion/bio-format-fasta/tests/read_test.rs
@@ -26,6 +26,7 @@ fn generate_test_fasta(path: &str, num_records: usize) {
 }
 
 #[tokio::test]
+#[ignore = "slow: generates a ~2.6 GB FASTA"]
 async fn test_read_3gb_file() {
     let tmp_dir = TempDir::new().unwrap();
     let input_path = tmp_dir.path().join("input.fasta");

--- a/datafusion/bio-format-fasta/tests/write_test.rs
+++ b/datafusion/bio-format-fasta/tests/write_test.rs
@@ -4,7 +4,7 @@
 //! INSERT OVERWRITE path and that data round-trips properly through
 //! read -> write -> read cycles across all compression formats.
 
-use datafusion::arrow::array::{Array, StringArray, UInt64Array};
+use datafusion::arrow::array::{Array, LargeStringArray, StringArray, UInt64Array};
 use datafusion::prelude::*;
 use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
 use datafusion_bio_format_fasta::FastaTableProvider;
@@ -267,7 +267,7 @@ async fn test_write_preserves_all_fields() {
     let sequences = batch
         .column(2)
         .as_any()
-        .downcast_ref::<StringArray>()
+        .downcast_ref::<LargeStringArray>()
         .unwrap();
 
     // Row 0: seq_alpha (sorted first)
@@ -405,7 +405,7 @@ async fn test_write_plain_to_bgzf_round_trip() {
         let seq_array = batch
             .column(2)
             .as_any()
-            .downcast_ref::<StringArray>()
+            .downcast_ref::<LargeStringArray>()
             .unwrap();
         for i in 0..batch.num_rows() {
             names.insert(name_array.value(i).to_string());
@@ -675,7 +675,7 @@ async fn test_write_preserves_long_sequences() {
     let sequences = batch
         .column(1)
         .as_any()
-        .downcast_ref::<StringArray>()
+        .downcast_ref::<LargeStringArray>()
         .unwrap();
     assert_eq!(sequences.value(0).len(), 200);
     assert_eq!(sequences.value(0), "A".repeat(200));
@@ -735,7 +735,7 @@ async fn test_write_with_no_description() {
     let sequences = batch
         .column(2)
         .as_any()
-        .downcast_ref::<StringArray>()
+        .downcast_ref::<LargeStringArray>()
         .unwrap();
     assert_eq!(names.value(0), "seq_no_desc");
     assert_eq!(sequences.value(0), "MKTLLIFLAG");


### PR DESCRIPTION
Large fasta files with large individual entries are common (e.g., [Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz](https://ftp.ebi.ac.uk/ensemblorg/pub/release-114/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz). However, datafusion-bio-formats (and hence polars-bio) produces an error on reading these and can return empty or partial data. This is due to requiring the LargeUtf8 instead of Utf8 when we pass 2gb. The fix is therefore simple, and I hope this PR is helpful.

I added a test (marked ignore since it's slow) to generate a 2+gb fasta file and read it in. I don't know if datafusion has a standard for tests based on real data like the fasta linked above, but it could be nice to round-trip that as well for a more thorough test.

I only changed the sequence column to be LargeUtf8: it's conceivable that the name or description columns could hit this limit as well but I don't know of such a case in practice.