### PR TITLE
ci: guard Claude Code workflows against fork PR failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Auto-review only runs for PRs from the same repository. Pull requests from
+    # forks do not receive repository secrets or an OIDC token, so the action
+    # cannot authenticate (CLAUDE_CODE_OAUTH_TOKEN is empty and `id-token` cannot
+    # be elevated). Fork PRs are instead reviewed on demand via `claude.yml`
+    # by commenting `@claude review this PR`.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:
@@ -27,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1.0.158
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
@@ -41,4 +42,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,9 @@
 name: Claude Code
 
+# On-demand Claude invocation. Triggered by mentioning `@claude` in a comment.
+# These events (issue_comment / pull_request_review* / issues) always run from
+# the default branch with repository secrets and an OIDC token available, even
+# when the pull request comes from a fork — so this is how fork PRs get reviewed.
 on:
   issue_comment:
     types: [created]
@@ -12,11 +16,27 @@ on:
 
 jobs:
   claude:
+    # Only run when `@claude` is mentioned AND the author is a maintainer.
+    # The author_association gate prevents arbitrary external users from
+    # spending the OAuth token or using the comment body as an injection vector.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      ) &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'COLLABORATOR' ||
+        github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,13 +46,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1.0.158
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -47,4 +68,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Problem

Fork PRs trigger `claude-code-review.yml` (on `pull_request`), but GitHub does not expose repository secrets or an elevated OIDC token to workflows running from a fork. So `CLAUDE_CODE_OAUTH_TOKEN` is empty and the action can't authenticate — the auto-review job **fails on every fork PR**.

## Changes

Ports the guardrails from [biodatageeks/polars-bio@38c9a1d](https://github.com/biodatageeks/polars-bio/commit/38c9a1de4d8f14c3494313ba4d184b1d8a8a5386), adapted to this repo.

**`claude-code-review.yml`** — auto-review now only runs for same-repo PRs:
```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```
Fork PRs no longer trigger a doomed auto-review.

**`claude.yml`** — the on-demand `@claude` path runs from the default branch (`master`) *with* secrets, even for fork PRs. It is now gated to maintainers via `author_association` (`OWNER`/`MEMBER`/`COLLABORATOR`), so:
- fork PRs get reviewed on demand when a maintainer comments `@claude`, and
- arbitrary external users can't spend the OAuth token or inject via comment bodies.

Also added `persist-credentials: false` to the on-demand checkout.

**Both files** — action refs pinned to commit SHAs (supply-chain hardening):
- `actions/checkout@93cb6efe…` (v5.0.1)
- `anthropics/claude-code-action@52113681…` (v1.0.158)

### Adapted to this repo (vs. polars-bio)
- Preserved the `issues` trigger, with its own `author_association` gate added.
- Preserved the `actions: read` permission (Claude reading CI results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)