### PR TITLE
fix(bbi): BigWig pushdown no longer clips interval coordinates

### DIFF
--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -158,8 +158,14 @@ impl TableProvider for BigBedTableProvider {
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = project_schema(&self.schema, projection);
-        let regions =
-            plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
+        // `widen_to_chromosome = false`: BigBedRead returns full overlapping BED
+        // entries (coordinates are never clipped), so positional pruning is safe.
+        let regions = plan_bbi_scan_regions(
+            filters,
+            &self.chroms,
+            self.coordinate_system_zero_based,
+            false,
+        );
         Ok(Arc::new(BigBedExec {
             file_path: self.file_path.clone(),
             schema: schema.clone(),

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -208,6 +208,9 @@ impl ExecutionPlan for BigWigExec {
 struct CurrentRegion {
     chrom: String,
     iter: BigWigIntervalIter<ReopenableFile, BigWigRead<ReopenableFile>>,
+    /// Exclusive upper bound on `start`; once an interval reaches it the
+    /// (start-sorted) region is done and we stop reading further blocks.
+    stop_at: Option<u32>,
 }
 
 /// Lazily yields fixed-size [`RecordBatch`]es across all scan regions, opening a
@@ -241,6 +244,7 @@ impl BigWigRegionStream {
             Ok(iter) => Some(Ok(CurrentRegion {
                 chrom: region.chrom,
                 iter,
+                stop_at: region.stop_at,
             })),
             Err(error) => Some(Err(to_external_error(error))),
         }
@@ -283,12 +287,25 @@ impl Iterator for BigWigRegionStream {
             }
 
             let current = self.current.as_mut().expect("current region is set");
+            // Copied out before the loop so the loop only borrows `current.iter`,
+            // leaving `self.current` free to clear on early termination.
+            let stop_at = current.stop_at;
+            let chrom = current.chrom.clone();
             let mut rows: Vec<(u32, u32, f32)> = Vec::with_capacity(BBI_BATCH_ROWS);
+            let mut region_done = false;
             for value in current.iter.by_ref() {
                 let value = match value {
                     Ok(value) => value,
                     Err(error) => return Some(Err(to_external_error(error))),
                 };
+                // Intervals stream in ascending `start`, so once one reaches the
+                // upper bound nothing further in this region can match: stop.
+                if let Some(stop_at) = stop_at
+                    && value.start >= stop_at
+                {
+                    region_done = true;
+                    break;
+                }
                 let start = if self.coordinate_system_zero_based {
                     value.start
                 } else {
@@ -300,13 +317,17 @@ impl Iterator for BigWigRegionStream {
                 }
             }
 
+            if region_done {
+                // No more matching rows in this region — don't reopen it.
+                self.current = None;
+            }
+
             if rows.is_empty() {
-                // Region fully drained; advance to the next one.
+                // Region drained (or stopped with nothing buffered); advance.
                 self.current = None;
                 continue;
             }
 
-            let chrom = current.chrom.clone();
             return Some(self.build_batch(&chrom, &rows));
         }
     }

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -103,8 +103,15 @@ impl TableProvider for BigWigTableProvider {
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = project_schema(&self.schema, projection);
-        let regions =
-            plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
+        // `widen_to_chromosome = true`: BigWigRead clips interval values to the
+        // query window, so we scan whole chromosomes and let DataFusion's Inexact
+        // re-filter drop surplus rows, rather than emitting clipped coordinates.
+        let regions = plan_bbi_scan_regions(
+            filters,
+            &self.chroms,
+            self.coordinate_system_zero_based,
+            true,
+        );
         Ok(Arc::new(BigWigExec {
             file_path: self.file_path.clone(),
             schema: schema.clone(),

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -4,7 +4,7 @@
 //! genomic-region planning, path validation) and are reused by both
 //! [`crate::bigwig`] and [`crate::bigbed`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
@@ -76,10 +76,25 @@ pub(crate) fn projection_display(schema: &SchemaRef) -> String {
     }
 }
 
+/// Plan the native interval-query regions for a BBI scan.
+///
+/// `widen_to_chromosome` controls how a positional coordinate filter is turned
+/// into a query window:
+///
+/// * `false` (BigBed) — honor the filter's start/end bounds. `BigBedRead`
+///   returns full BED entries that *overlap* the window, so narrowing the window
+///   prunes work without altering the emitted coordinates.
+/// * `true` (BigWig) — ignore the positional bounds and scan each matched
+///   chromosome in full. `BigWigRead` *clips* interval values to the query
+///   window, so a sub-range would emit truncated start/end coordinates. Because
+///   coordinate filters are pushed down as `Inexact` (DataFusion re-applies
+///   them), scanning the whole chromosome is still correct — it only trades
+///   within-chromosome seek pruning for unclipped intervals.
 pub(crate) fn plan_bbi_scan_regions(
     filters: &[Expr],
     chroms: &[(String, u32)],
     coordinate_system_zero_based: bool,
+    widen_to_chromosome: bool,
 ) -> Vec<BbiScanRegion> {
     let analysis = extract_genomic_regions(filters, coordinate_system_zero_based);
     if analysis.unsatisfiable {
@@ -106,6 +121,24 @@ pub(crate) fn plan_bbi_scan_regions(
         .iter()
         .map(|(chrom, len)| (chrom.as_str(), *len))
         .collect();
+
+    if widen_to_chromosome {
+        // De-duplicate by chromosome so overlapping or OR'd ranges never scan the
+        // same chromosome twice (which would duplicate rows).
+        let mut seen = HashSet::new();
+        return source_regions
+            .into_iter()
+            .filter(|region| seen.insert(region.chrom.clone()))
+            .filter_map(|region| {
+                let length = *chrom_lengths.get(region.chrom.as_str())?;
+                (length > 0).then_some(BbiScanRegion {
+                    chrom: region.chrom,
+                    start: 0,
+                    end: length,
+                })
+            })
+            .collect();
+    }
 
     source_regions
         .into_iter()

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -26,6 +26,14 @@ pub(crate) struct BbiScanRegion {
     pub(crate) chrom: String,
     pub(crate) start: u32,
     pub(crate) end: u32,
+    /// Exclusive upper bound on interval `start` for early termination, in the
+    /// same 0-based coordinate space as the native interval `start`. `None`
+    /// means "no upper bound — drain the whole region".
+    ///
+    /// Used only by the BigWig provider: it scans whole chromosomes to avoid
+    /// coordinate clipping, but the streamed intervals are start-sorted, so it
+    /// can stop as soon as `start >= stop_at` rather than reading to the end.
+    pub(crate) stop_at: Option<u32>,
 }
 
 pub(crate) fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
@@ -131,10 +139,17 @@ pub(crate) fn plan_bbi_scan_regions(
             .filter(|region| seen.insert(region.chrom.clone()))
             .filter_map(|region| {
                 let length = *chrom_lengths.get(region.chrom.as_str())?;
+                // Scan the whole chromosome (so intervals are never clipped) but
+                // remember the filter's upper bound: `region.end` is 1-based
+                // inclusive, which equals the 0-based exclusive bound on `start`,
+                // letting the start-sorted stream stop early. `None` (no upper
+                // bound) means drain the whole chromosome.
+                let stop_at = region.end.map(|end| end.min(length as u64) as u32);
                 (length > 0).then_some(BbiScanRegion {
                     chrom: region.chrom,
                     start: 0,
                     end: length,
+                    stop_at,
                 })
             })
             .collect();
@@ -160,10 +175,13 @@ fn convert_genomic_region_to_bbi(
         .map(|end| end.min(length as u64) as u32)
         .unwrap_or(length);
 
+    // The narrow (BigBed) path bounds the scan with the query window itself, so
+    // it needs no separate early-termination cursor.
     (start < end).then_some(BbiScanRegion {
         chrom: region.chrom,
         start,
         end,
+        stop_at: None,
     })
 }
 

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -432,6 +432,101 @@ async fn streams_large_region_in_fixed_size_batches() -> TestResult<()> {
 }
 
 #[tokio::test]
+async fn bigwig_early_terminates_at_upper_bound() -> TestResult<()> {
+    // 20k intervals at starts 0, 2, 4, ...; a `start < 100` upper bound must stop
+    // the scan after the 50 matching rows instead of streaming the whole
+    // chromosome. The exec applies only the early-stop cursor (DataFusion
+    // re-applies the predicate above it), so observing 50 rows here — not
+    // 20_000 — proves the scan terminated early rather than read-then-filtered.
+    let intervals = 20_000u32;
+    let fixture = write_large_bigwig_fixture(intervals)?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    let state = ctx.state();
+    // A chrom predicate is required for the region's upper bound to be extracted.
+    let filter = col("chrom")
+        .eq(lit("chr1"))
+        .and(col("start").lt(lit(100u32)));
+    let plan = table.scan(&state, None, &[filter], None).await?;
+    let stream = plan.execute(0, ctx.task_ctx())?;
+    let batches = collect(stream).await?;
+
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total, 50,
+        "early termination should emit only the matching prefix, not the whole chromosome"
+    );
+    assert_eq!(
+        batches.len(),
+        1,
+        "50 rows fit in a single batch; a full scan would emit many"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn bigwig_early_termination_spans_multiple_batches() -> TestResult<()> {
+    // `start < 20_000` matches the first 10_000 intervals (starts 0..19_998),
+    // which is more than one 8_192-row batch — verifying the stop cursor fires
+    // mid-stream across batch boundaries, not only within the first batch.
+    let intervals = 20_000u32;
+    let fixture = write_large_bigwig_fixture(intervals)?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    let state = ctx.state();
+    let filter = col("chrom")
+        .eq(lit("chr1"))
+        .and(col("start").lt(lit(20_000u32)));
+    let plan = table.scan(&state, None, &[filter], None).await?;
+    let stream = plan.execute(0, ctx.task_ctx())?;
+    let batches = collect(stream).await?;
+
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total, 10_000,
+        "should stop after the 10_000 matching intervals, not read all 20_000"
+    );
+    assert!(
+        batches.len() >= 2,
+        "10_000 rows must span multiple fixed-size batches, got {}",
+        batches.len()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn bigwig_lower_bound_only_scans_whole_chromosome() -> TestResult<()> {
+    // A lower bound alone (`start > 100`) has no upper bound to stop at, and a
+    // safe left seek isn't possible (it would clip the straddling interval), so
+    // the scan must read the whole chromosome and let DataFusion filter. Guards
+    // against accidentally deriving a stop cursor from the lower bound.
+    let intervals = 20_000u32;
+    let fixture = write_large_bigwig_fixture(intervals)?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    let state = ctx.state();
+    let filter = col("chrom")
+        .eq(lit("chr1"))
+        .and(col("start").gt(lit(100u32)));
+    let plan = table.scan(&state, None, &[filter], None).await?;
+    let stream = plan.execute(0, ctx.task_ctx())?;
+    let batches = collect(stream).await?;
+
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total, intervals as usize,
+        "lower-bound-only filters must not early-terminate"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn accepts_file_localhost_uri_paths() -> TestResult<()> {
     let fixture = write_bigwig_fixture()?;
     let uri = format!("file://localhost{}", fixture.path().to_string_lossy());

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -173,9 +173,57 @@ async fn pushes_bigwig_genomic_filter_into_scan_regions() -> TestResult<()> {
         plan_text.contains("BigWigExec"),
         "expected BigWigExec in plan:\n{plan_text}"
     );
+    // BigWig prunes by chromosome but scans it in full: BigWigRead clips interval
+    // values to the query window, so a positional sub-range (e.g. chr2:0-10)
+    // would emit truncated coordinates. The Inexact pushdown lets DataFusion
+    // re-apply `start < 10` after the unclipped scan.
     assert!(
-        plan_text.contains("regions=[chr2:0-10]"),
-        "expected chr2 interval pruning in plan:\n{plan_text}"
+        plan_text.contains("regions=[chr2:0-100]"),
+        "expected chr2 to be scanned in full:\n{plan_text}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn bigwig_genomic_filter_returns_unclipped_intervals() -> TestResult<()> {
+    // Regression: a `start < N` filter must not clip the emitted interval `end`.
+    // The chr2 interval is [5, 12); filtering `start < 10` must still return
+    // end = 12, not 10 (the filter bound / clipped window edge).
+    let fixture = write_bigwig_fixture()?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let df = ctx
+        .sql("SELECT chrom, start, \"end\", value FROM bw WHERE chrom = 'chr2' AND start < 10")
+        .await?;
+    let batches = df.collect().await?;
+
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    let batch = &batches[0];
+    let chrom = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let start = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    let end = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    assert_eq!(chrom.value(0), "chr2");
+    assert_eq!(start.value(0), 5);
+    assert_eq!(
+        end.value(0),
+        12,
+        "interval end must be the true 12, not clipped to the filter bound"
     );
 
     Ok(())


### PR DESCRIPTION
## Problem

The BigWig table provider corrupts interval coordinates when a genomic-coordinate predicate is pushed down. `BigWigRead::get_interval` **clips** interval values to the query window, but the provider derives that window from the predicate — so a `start < N` filter truncates the emitted `end`:

| filter | emitted `end` | true `end` |
|---|---|---|
| `start < 10` | **10** ❌ | 12 |
| `start < 7` | **7** ❌ | 12 |
| `start < 100` | 12 ✓ | 12 |

For a stored interval `chr2:[5,12)`, `WHERE chrom='chr2' AND start < 10` returns `[5,10)` instead of `[5,12)`.

Because these filters are declared `TableProviderFilterPushDown::Inexact`, DataFusion re-applies them — so the provider is required to return a faithful **superset**. Clipping returns *altered* rows, violating that contract. The result is that predicate-pushdown and client-side filtering disagree (caught downstream by polars-bio's `test_bbi_predicate_pushdown_matches_client_side_filtering`).

**BigBed is not affected**: `BigBedRead::get_interval` returns full overlapping BED entries without clipping.

## Fix

Add a `widen_to_chromosome` flag to `plan_bbi_scan_regions`:

- **BigWig (`true`)** — ignore the positional bounds and scan each *matched* chromosome in full (de-duplicated so OR'd/overlapping ranges never double-scan). Intervals come back unclipped; DataFusion's `Inexact` re-filter drops the surplus rows. This trades within-chromosome seek pruning for correctness.
- **BigBed (`false`)** — unchanged; keeps positional pruning since its reader returns full entries.

Chromosome-level pruning is preserved for BigWig (only matched chromosomes are scanned).

## Tests

- New `bigwig_genomic_filter_returns_unclipped_intervals`: asserts `end == 12` for `chrom='chr2' AND start < 10` (fails before this change, passes after).
- Updated `pushes_bigwig_genomic_filter_into_scan_regions`: now expects `regions=[chr2:0-100]` (full-chromosome scan) with a comment explaining why.
- All 13 bbi provider tests pass; `cargo fmt --check` and `cargo clippy` clean.

## Follow-up

Once released (e.g. v1.8.3), bump the `tag` in polars-bio PR #393 (`datafusion-bio-format-*`) to pick up the fix.