### PR TITLE
test(bbi): add COUNT(*) coverage for BigWig and BigBed

### DIFF
--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -605,3 +605,53 @@ async fn pushes_bigbed_genomic_filter_into_scan_regions() -> TestResult<()> {
 
     Ok(())
 }
+
+// COUNT(*) / empty-projection smoke tests — verify the BBI providers handle
+// the zero-column projection consistently (audit follow-up to #208).
+
+fn count_star_value(batch: &datafusion::arrow::record_batch::RecordBatch) -> i64 {
+    batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+        .unwrap()
+        .value(0)
+}
+
+#[tokio::test]
+async fn count_star_bigwig() -> TestResult<()> {
+    let fixture = write_bigwig_fixture()?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+    let ctx = SessionContext::new();
+    ctx.register_table("bw", Arc::new(table))?;
+
+    let batches = ctx
+        .sql("SELECT count(*) AS c FROM bw")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(batches.len(), 1);
+    assert_eq!(count_star_value(&batches[0]), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn count_star_bigbed() -> TestResult<()> {
+    let fixture = write_bigbed_fixture()?;
+    let table = BigBedTableProvider::new(
+        fixture.path().to_string_lossy().to_string(),
+        true,
+        BigBedSchemaMode::Auto,
+    )?;
+    let ctx = SessionContext::new();
+    ctx.register_table("bb", Arc::new(table))?;
+
+    let batches = ctx
+        .sql("SELECT count(*) AS c FROM bb")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(batches.len(), 1);
+    assert_eq!(count_star_value(&batches[0]), 3);
+    Ok(())
+}

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use bigtools::bed::bedparser::BedFileStream;
 use bigtools::beddata::BedParserStreamingIterator;
 use bigtools::{BigBedWrite, BigWigWrite};
-use datafusion::arrow::array::{Float32Array, StringArray, UInt32Array, UInt64Array};
+use datafusion::arrow::array::{Float32Array, Int64Array, StringArray, UInt32Array, UInt64Array};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::TableProvider;
 use datafusion::physical_plan::common::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
@@ -609,11 +610,11 @@ async fn pushes_bigbed_genomic_filter_into_scan_regions() -> TestResult<()> {
 // COUNT(*) / empty-projection smoke tests — verify the BBI providers handle
 // the zero-column projection consistently (audit follow-up to #208).
 
-fn count_star_value(batch: &datafusion::arrow::record_batch::RecordBatch) -> i64 {
+fn count_star_value(batch: &RecordBatch) -> i64 {
     batch
         .column(0)
         .as_any()
-        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+        .downcast_ref::<Int64Array>()
         .unwrap()
         .value(0)
 }


### PR DESCRIPTION
## Summary

Follow-up to #208. During that audit, BBI (BigWig/BigBed) was the only format provider with **no `COUNT(*)` / empty-projection test coverage**. The static analysis concluded BBI was already correct — it produces a zero-field projected schema in `scan()` matched by a zero-column batch with an explicit row count (`common.rs` `build_batch` / `with_row_count`). These tests confirm that empirically.

## Tests

- `count_star_bigwig` — `SELECT count(*)` over the in-memory BigWig fixture (3 rows).
- `count_star_bigbed` — `SELECT count(*)` over the in-memory BigBed fixture (3 rows).

Both pass; full `cargo test -p datafusion-bio-format-bbi` is green with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)