### PR TITLE
fix(bed): emit 0-based half-open coordinates for use_zero_based (#413)

### DIFF
--- a/datafusion/bio-format-bed/src/physical_exec.rs
+++ b/datafusion/bio-format-bed/src/physical_exec.rs
@@ -193,11 +193,12 @@ async fn get_remote_bed_stream(
             // For 1-based output: use as-is (noodles already returns 1-based)
             let start_pos = record.feature_start()?.get() as u32;
             poss.push(if coordinate_system_zero_based { start_pos - 1 } else { start_pos });
-            // End position: noodles returns 1-based exclusive end
-            // For 0-based half-open: subtract 1 to get 0-based exclusive end
-            // For 1-based closed: use as-is
+            // End position: noodles returns the 1-based *inclusive* end (the last
+            // covered base). Numerically this equals the 0-based half-open exclusive
+            // end, so the end coordinate is identical in both coordinate systems:
+            // only the start differs by 1. (fixes #413)
             let end_pos = record.feature_end().unwrap()?.get() as u32;
-            pose.push(if coordinate_system_zero_based { end_pos - 1 } else { end_pos });
+            pose.push(end_pos);
             name.push(record.name().map(|n| n.to_string()));
 
             record_num += 1;
@@ -284,11 +285,12 @@ async fn get_local_bed(
             // For 1-based output: use as-is (noodles already returns 1-based)
             let start_pos = record.feature_start()?.get() as u32;
             poss.push(if coordinate_system_zero_based { start_pos - 1 } else { start_pos });
-            // End position: noodles returns 1-based exclusive end
-            // For 0-based half-open: subtract 1 to get 0-based exclusive end
-            // For 1-based closed: use as-is
+            // End position: noodles returns the 1-based *inclusive* end (the last
+            // covered base). Numerically this equals the 0-based half-open exclusive
+            // end, so the end coordinate is identical in both coordinate systems:
+            // only the start differs by 1. (fixes #413)
             let end_pos = record.feature_end().unwrap()?.get() as u32;
-            pose.push(if coordinate_system_zero_based { end_pos - 1 } else { end_pos });
+            pose.push(end_pos);
             name.push(record.name().map(|n| n.to_string()));
 
             record_num += 1;

--- a/datafusion/bio-format-bed/tests/coordinate_system_test.rs
+++ b/datafusion/bio-format-bed/tests/coordinate_system_test.rs
@@ -1,0 +1,104 @@
+// Regression tests for BED coordinate-system conversion (issue #413).
+//
+// A BED file stores intervals as 0-based half-open `[start, end)`. The reader
+// must therefore emit, for an on-disk record `chrom  start  end`:
+//   * zero_based = true  -> (start, end)         unchanged: 0-based half-open
+//   * zero_based = false -> (start + 1, end)      1-based closed
+//
+// Before the fix the zero_based path decremented `end` by one, producing
+// 0-based *closed* intervals (`end - 1`), contradicting the documented
+// 0-based half-open semantics. The end coordinate is identical in both
+// systems because a 1-based inclusive end equals a 0-based exclusive end.
+use datafusion::arrow::array::UInt32Array;
+use datafusion::prelude::*;
+use datafusion_bio_format_bed::table_provider::{BEDFields, BedTableProvider};
+use std::sync::Arc;
+
+/// Read the fixture and return the (start, end) columns in file order.
+async fn read_coords(zero_based: bool) -> (Vec<u32>, Vec<u32>) {
+    let path = format!("{}/tests/coords.bed", env!("CARGO_MANIFEST_DIR"));
+    let provider = BedTableProvider::new(path, BEDFields::BED4, None, zero_based).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_table("bed", Arc::new(provider)).unwrap();
+    let batches = ctx
+        .sql("SELECT start, \"end\" FROM bed")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut starts = Vec::new();
+    let mut ends = Vec::new();
+    for b in &batches {
+        let s = b
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("start is UInt32");
+        let e = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("end is UInt32");
+        for i in 0..b.num_rows() {
+            starts.push(s.value(i));
+            ends.push(e.value(i));
+        }
+    }
+    (starts, ends)
+}
+
+// On-disk fixture (tests/coords.bed):
+//   chr1  1000  2000
+//   chr2  1500  2500
+//   chrX  5000  8000
+const FILE_STARTS: [u32; 3] = [1000, 1500, 5000];
+const FILE_ENDS: [u32; 3] = [2000, 2500, 8000];
+
+#[tokio::test]
+async fn zero_based_outputs_0based_half_open() {
+    let (starts, ends) = read_coords(true).await;
+    // start unchanged, end unchanged -> identical to the on-disk record.
+    assert_eq!(
+        starts, FILE_STARTS,
+        "0-based start must equal the file start"
+    );
+    assert_eq!(
+        ends, FILE_ENDS,
+        "0-based half-open end must equal the file end (not end - 1)"
+    );
+}
+
+#[tokio::test]
+async fn one_based_outputs_1based_closed() {
+    let (starts, ends) = read_coords(false).await;
+    let expected_starts: Vec<u32> = FILE_STARTS.iter().map(|s| s + 1).collect();
+    // start + 1, end unchanged.
+    assert_eq!(
+        starts, expected_starts,
+        "1-based start must be file start + 1"
+    );
+    assert_eq!(
+        ends.as_slice(),
+        FILE_ENDS,
+        "1-based closed end must equal the file end"
+    );
+}
+
+#[tokio::test]
+async fn both_systems_preserve_interval_length() {
+    // The number of covered bases must be identical regardless of coordinate
+    // system: half-open length = end - start; closed length = end - (start) + 1
+    // ... but here the lengths are computed against their own start, so both
+    // must equal the original on-disk span (end - start).
+    let (z_starts, z_ends) = read_coords(true).await;
+    let (o_starts, o_ends) = read_coords(false).await;
+    for i in 0..FILE_STARTS.len() {
+        let half_open_len = z_ends[i] - z_starts[i];
+        let closed_len = o_ends[i] - o_starts[i] + 1;
+        let file_span = FILE_ENDS[i] - FILE_STARTS[i];
+        assert_eq!(half_open_len, file_span, "half-open length mismatch");
+        assert_eq!(closed_len, file_span, "closed length mismatch");
+    }
+}

--- a/datafusion/bio-format-bed/tests/coords.bed
+++ b/datafusion/bio-format-bed/tests/coords.bed
@@ -1,0 +1,3 @@
+chr1	1000	2000	feature1
+chr2	1500	2500	feature2
+chrX	5000	8000	feature3


### PR DESCRIPTION
## Summary

Fixes the BED reader so that `use_zero_based=True` produces **0-based half-open** intervals, as documented, instead of **0-based closed** intervals.

Reported downstream as biodatageeks/polars-bio#413.

## The bug

In `bio-format-bed/src/physical_exec.rs` (both `get_remote_bed_stream` and `get_local_bed`), the end coordinate was decremented by one in zero-based mode:

```rust
pose.push(if coordinate_system_zero_based { end_pos - 1 } else { end_pos });
```

For an on-disk record `chr1  1000  2000` this returned `[1000, 1999]` (0-based **closed**) instead of `[1000, 2000)` (0-based **half-open**).

## Root cause

noodles `feature_end().get()` returns the **1-based inclusive** end (the last covered base), whose numeric value equals the **0-based half-open exclusive** end. The end coordinate is therefore identical in both coordinate systems — only the start differs by 1. The previous comment ("noodles returns 1-based exclusive end") was incorrect.

## Fix

Push `end_pos` unchanged in both reader paths; only `start` is adjusted (`start - 1` for 0-based).

## Validation

Validated against UCSC/ENCODE `ENCFF521CWX.bed` (114,800 records) using [oxbow](https://github.com/abdenlab/oxbow) as an independent reference reader:

| | start | end |
|---|---:|---:|
| on-disk (0-based half-open) | 124229081 | 124229093 |
| oxbow (1-based closed ref) | 124229082 | 124229093 |
| `use_zero_based=True` **after fix** | 124229081 | 124229093 ✅ |

After the fix, zero-based output matches the on-disk BED bytes exactly for all 114,800 rows, and the default 1-based output matches oxbow byte-for-byte.

## Tests

Adds `datafusion/bio-format-bed/tests/coordinate_system_test.rs` (+ `coords.bed` fixture):
- `zero_based_outputs_0based_half_open`
- `one_based_outputs_1based_closed`
- `both_systems_preserve_interval_length`

The first and third fail against the pre-fix code and pass after. Existing BED crate tests (multimember gzip) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)