### PR TITLE
fix: single OS thread per partition across reader crates (#212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,10 +112,11 @@ Reader scans decode each partition **inline on the tokio worker that consumes it
 - Decompression parallelism is bounded by the caller's tokio runtime worker-thread
   count; if `target_partitions` exceeds the worker count, concurrent decode is capped there.
 
-Status: FASTQ implements this contract. The remaining reader crates (VCF, BAM, CRAM,
-GFF, GTF, pairs, FASTA) are being migrated to the same `sync_batch_stream` helper;
-BED already executes fully async and satisfies the contract. See
-`openspec/changes/refactor-single-thread-partition-reads/`.
+Status: implemented across all reader crates — FASTQ and FASTA use the
+`sync_batch_stream` helper (linear readers); VCF, BAM, CRAM, GFF, GTF, and pairs use
+`async_stream::try_stream!` generators (region-iterating readers). Both decode inline
+on the consuming worker. BED already executes fully async and satisfies the contract.
+See `openspec/changes/refactor-single-thread-partition-reads/`.
 
 ### Key Dependencies
 - DataFusion 52.1.0 - SQL query engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,25 @@ INSERT OVERWRITE cram_output SELECT * FROM bam_input WHERE chrom = 'chr1'
 ### Object Storage Support
 The `bio-format-core` crate provides cloud storage integration via OpenDAL with support for:
 - Google Cloud Storage (GCS)
-- Amazon S3 
+- Amazon S3
 - Azure Blob Storage
 - Compression detection (GZIP, BGZF, AUTO)
+
+### Thread Usage / `target_partitions` Contract (issue #212)
+
+Reader scans decode each partition **inline on the tokio worker that consumes it**
+(via `bio-format-core`'s `sync_stream::sync_batch_stream`) — no dedicated
+`std::thread` reader per partition and no `mpsc` handoff. Consequences:
+
+- A scan uses **one OS thread per partition**, i.e. `target_partitions` threads (not `~2×`).
+- To use N cores for a scan, set `target_partitions = N`.
+- Decompression parallelism is bounded by the caller's tokio runtime worker-thread
+  count; if `target_partitions` exceeds the worker count, concurrent decode is capped there.
+
+Status: FASTQ implements this contract. The remaining reader crates (VCF, BAM, CRAM,
+GFF, GTF, pairs, FASTA) are being migrated to the same `sync_batch_stream` helper;
+BED already executes fully async and satisfies the contract. See
+`openspec/changes/refactor-single-thread-partition-reads/`.
 
 ### Key Dependencies
 - DataFusion 52.1.0 - SQL query engine
@@ -116,7 +132,7 @@ The `bio-format-core` crate provides cloud storage integration via OpenDAL with 
 
 ### FASTQ Schema
 - `name`: String (required) - Sequence identifier
-- `description`: String (optional) - Sequence description  
+- `description`: String (optional) - Sequence description
 - `sequence`: String (required) - DNA/RNA sequence
 - `quality_scores`: String (required) - Quality scores
 

--- a/README.md
+++ b/README.md
@@ -473,24 +473,24 @@ When an index is available, the query engine uses a three-stage execution model:
 - Result: `min(target_partitions, num_regions)` partitions with roughly equal work
 
 **3. Streaming I/O** — Each partition processes its assigned regions using constant-memory streaming:
-- Dedicated OS thread per partition (not tokio's blocking pool)
-- `mpsc::channel(2)` provides backpressure between producer and consumer
-- At most ~3 RecordBatches in flight per partition (~3-8 MB)
-- Total memory: ~3 batches x `target_partitions` (constant regardless of file size)
+- Decode (decompress + parse + build Arrow batches) runs **inline on the tokio worker that consumes the partition** — no dedicated reader thread and no channel (issue #212)
+- A scan therefore uses **one OS thread per partition** (`target_partitions`), not `~2×`; to use N cores, set `target_partitions = N`
+- Decode parallelism is bounded by the caller's tokio runtime worker-thread count; if `target_partitions` exceeds the worker count, concurrent decode is capped there
+- Only one RecordBatch is built at a time per partition (constant memory regardless of file size)
 
 ```
-                     target_partitions = 4
+                     target_partitions = 4        (one OS thread per partition)
                      ┌──────────────────┐
-Partition 0 (thread) │ chr1:1-125M      │ ─── sequential within partition
-                     │ chr1:125M-249M   │     streaming via channel(2)
+Partition 0 (worker) │ chr1:1-125M      │ ─── sequential within partition
+                     │ chr1:125M-249M   │     decode inline on the worker
                      ├──────────────────┤
-Partition 1 (thread) │ chr2             │ ─── concurrent across partitions
-                     │ chr3             │     max 4 threads active
+Partition 1 (worker) │ chr2             │ ─── concurrent across partitions
+                     │ chr3             │     ~4 threads active (== target_partitions)
                      ├──────────────────┤
-Partition 2 (thread) │ chr4             │
+Partition 2 (worker) │ chr4             │
                      │ chr5, chr6       │
                      ├──────────────────┤
-Partition 3 (thread) │ chrX             │
+Partition 3 (worker) │ chrX             │
                      │ chrY, chrM       │
                      └──────────────────┘
 ```

--- a/datafusion/bio-format-bam/src/physical_exec.rs
+++ b/datafusion/bio-format-bam/src/physical_exec.rs
@@ -1024,17 +1024,26 @@ async fn get_indexed_stream(
                 };
             }
 
+            // Lazily read the BAI at most once per partition — only if an
+            // unmapped-tail region is actually encountered — and reuse it across
+            // all such regions (avoids re-reading the full index per region while
+            // not penalizing the common no-unmapped-tail case).
+            let mut bai_index: Option<bam::bai::Index> = None;
+
             for region in &regions {
                 // Handle unmapped tail regions via direct BGZF seek —
                 // stream records one-by-one instead of collecting into Vec.
                 if region.unmapped_tail {
                     // Dedicated partition for global no-coor records (n_no_coor).
                     if region.chrom == UNPLACED_UNMAPPED_SENTINEL_CHROM {
-                        let no_coor_index = bam::bai::fs::read(&index_path).map_err(|e| {
-                            DataFusionError::Execution(format!(
-                                "Failed to read BAI for unplaced/unmapped tail: {e}"
-                            ))
-                        })?;
+                        if bai_index.is_none() {
+                            bai_index = Some(bam::bai::fs::read(&index_path).map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "Failed to read BAI for unplaced/unmapped tail: {e}"
+                                ))
+                            })?);
+                        }
+                        let no_coor_index = bai_index.as_ref().unwrap();
                         let no_coor_hint =
                             no_coor_index.unplaced_unmapped_record_count().unwrap_or(0);
                         if no_coor_hint == 0 {
@@ -1121,11 +1130,14 @@ async fn get_indexed_stream(
 
                     // Per-reference unmapped tail (reference_sequence_id set,
                     // alignment_start absent).
-                    let unmapped_index = bam::bai::fs::read(&index_path).map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Failed to read BAI for unmapped tail: {e}"
-                        ))
-                    })?;
+                    if bai_index.is_none() {
+                        bai_index = Some(bam::bai::fs::read(&index_path).map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to read BAI for unmapped tail: {e}"
+                            ))
+                        })?);
+                    }
+                    let unmapped_index = bai_index.as_ref().unwrap();
 
                     let ref_idx =
                         names

--- a/datafusion/bio-format-bam/src/physical_exec.rs
+++ b/datafusion/bio-format-bam/src/physical_exec.rs
@@ -26,7 +26,6 @@ use datafusion_bio_format_core::record_filter::evaluate_record_filters;
 use datafusion_bio_format_core::sam_tag_io::{TagBuilders, build_tag_to_index, load_record_tags};
 use datafusion_bio_format_core::table_utils::OptionalField;
 
-use futures::SinkExt;
 use futures_util::{StreamExt, TryStreamExt};
 use log::{debug, info};
 use noodles_bam as bam;
@@ -363,11 +362,11 @@ async fn get_remote_bam_stream(
     Ok(stream)
 }
 
-/// Reads a local BAM file using a synchronous thread with buffer reuse.
+/// Reads a local BAM file with buffer reuse, decoding inline on the consuming task.
 ///
 /// Uses `read_record(&mut record)` to reuse a single record buffer across reads,
-/// avoiding per-record clone allocations. Sends batches via a bounded channel for
-/// backpressure.
+/// avoiding per-record clone allocations. Batches are produced by an
+/// `async_stream::try_stream!` generator that runs on the consuming tokio worker.
 #[allow(clippy::too_many_arguments)]
 async fn get_local_bam_sync(
     file_path: String,
@@ -378,10 +377,8 @@ async fn get_local_bam_sync(
     tag_fields: Option<Vec<String>>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<RecordBatch, ArrowError>>(2);
 
-    std::thread::spawn(move || {
-        let read_and_send = || -> Result<(), DataFusionError> {
+    let stream = async_stream::try_stream! {
             let (mut reader, header) = open_local_bam_sync(&file_path)
                 .map_err(|e| DataFusionError::Execution(format!("Failed to open BAM: {e}")))?;
 
@@ -562,16 +559,15 @@ async fn get_local_bam_sync(
                                 batch_row_count,
                             )?;
 
-                            match futures::executor::block_on(tx.send(Ok(batch))) {
-                                Ok(()) => {}
-                                Err(_) => return Ok(()),
-                            }
+                            yield batch;
 
                             batch_row_count = 0;
                         }
                     }
                     Err(e) => {
-                        return Err(DataFusionError::Execution(format!("BAM read error: {e}")));
+                        Err::<(), DataFusionError>(DataFusionError::Execution(format!(
+                            "BAM read error: {e}"
+                        )))?;
                     }
                 }
             }
@@ -593,18 +589,11 @@ async fn get_local_bam_sync(
                     &projection,
                     batch_row_count,
                 )?;
-                let _ = futures::executor::block_on(tx.send(Ok(batch)));
+                yield batch;
             }
 
             debug!("Local BAM sync scan: {total_records} records");
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(ArrowError::ExternalError(Box::new(e))));
-        }
-    });
-
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }
 
@@ -867,8 +856,9 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
 /// Get a streaming RecordBatch stream from an indexed BAM file for one or more regions.
 ///
-/// Uses `thread::spawn` + `mpsc::channel(2)` for streaming I/O with backpressure.
-/// Each partition processes its assigned regions sequentially, keeping only ~3 batches
+/// Decodes inline on the consuming tokio worker via an `async_stream::try_stream!`
+/// generator (no per-partition reader thread).
+/// Each partition processes its assigned regions sequentially, keeping only ~1 batch
 /// in memory at a time (constant memory regardless of data volume).
 #[allow(clippy::too_many_arguments)]
 async fn get_indexed_stream(
@@ -883,10 +873,8 @@ async fn get_indexed_stream(
     residual_filters: Vec<datafusion::logical_expr::Expr>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<RecordBatch, ArrowError>>(2);
 
-    std::thread::spawn(move || {
-        let read_and_send = || -> Result<(), DataFusionError> {
+    let stream = async_stream::try_stream! {
             let mut indexed_reader =
                 IndexedBamReader::new(&file_path, &index_path).map_err(|e| {
                     DataFusionError::Execution(format!("Failed to open indexed BAM: {e}"))
@@ -917,35 +905,40 @@ async fn get_indexed_stream(
             let mut total_records = 0usize;
             let mut batch_row_count = 0usize;
 
-            /// Helper macro to flush the current batch via the channel.
-            macro_rules! flush_batch {
-                ($batch_row_count:expr, $disconnect_action:expr) => {{
-                    let tag_arrays = if num_tag_fields > 0 {
-                        Some(
-                            builders_to_arrays(tag_builders.builders_mut())
-                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
-                        )
-                    } else {
-                        None
-                    };
-                    let batch = build_record_batch_from_builders(
-                        Arc::clone(&schema),
-                        builders.finish(),
-                        tag_arrays.as_ref(),
-                        &projection,
-                        $batch_row_count,
-                    )?;
+            // NOTE: These helper macros wrap their fallible bodies in
+            // immediately-invoked closures so any `?` stays inside a `Result`-returning
+            // scope. `async_stream::try_stream!` only rewrites `?` it can see directly in
+            // the generator body, not `?` hidden inside macro expansions, so callers apply
+            // `?` to the macro result at the (visible) call site instead.
 
-                    match futures::executor::block_on(tx.send(Ok(batch))) {
-                        Ok(()) => {}
-                        Err(_) => $disconnect_action,
-                    }
-                }};
+            /// Helper macro to build the current batch from the accumulated builders.
+            macro_rules! build_batch {
+                ($batch_row_count:expr) => {
+                    (|| -> Result<RecordBatch, DataFusionError> {
+                        let tag_arrays = if num_tag_fields > 0 {
+                            Some(
+                                builders_to_arrays(tag_builders.builders_mut())
+                                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+                            )
+                        } else {
+                            None
+                        };
+                        let batch = build_record_batch_from_builders(
+                            Arc::clone(&schema),
+                            builders.finish(),
+                            tag_arrays.as_ref(),
+                            &projection,
+                            $batch_row_count,
+                        )?;
+                        Ok(batch)
+                    })()
+                };
             }
 
             /// Helper macro to accumulate fields from a record into builders.
             macro_rules! accumulate_record_fields {
-                ($record:expr, $chrom_name:expr, $start_val:expr, $end_val:expr, $mq:expr) => {{
+                ($record:expr, $chrom_name:expr, $start_val:expr, $end_val:expr, $mq:expr) => {
+                    (|| -> Result<(), DataFusionError> {
                     if flags.name {
                         match $record.name() {
                             Some(read_name) => builders.append_name(Some(&read_name.to_string())),
@@ -1026,7 +1019,9 @@ async fn get_indexed_stream(
                         )
                         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
                     }
-                }};
+                    Ok(())
+                    })()
+                };
             }
 
             for region in &regions {
@@ -1046,15 +1041,12 @@ async fn get_indexed_stream(
                             continue;
                         }
 
-                        let mut no_coor_reader = bam::io::indexed_reader::Builder::default()
-                            .set_index(no_coor_index)
-                            .build_from_path(&file_path)
+                        // Open a plain (Send) reader; the concrete BAI index above is only
+                        // needed for the no-coor hint, not for the record scan.
+                        let (mut no_coor_reader, _no_coor_header) = open_local_bam_sync(&file_path)
                             .map_err(|e| {
                                 DataFusionError::Execution(format!("Failed to open BAM file: {e}"))
                             })?;
-                        let _no_coor_header = no_coor_reader.read_header().map_err(|e| {
-                            DataFusionError::Execution(format!("Failed to read BAM header: {e}"))
-                        })?;
 
                         // Do not seek for no-coor partition. Some all-no-coor BAI files
                         // do not provide a safe seek hint for starting record reads.
@@ -1101,21 +1093,22 @@ async fn get_indexed_stream(
                                         start_val,
                                         end_val,
                                         mq
-                                    );
+                                    )?;
 
                                     total_records += 1;
                                     batch_row_count += 1;
                                     no_coor_count += 1;
 
                                     if batch_row_count == batch_size {
-                                        flush_batch!(batch_row_count, return Ok(()));
+                                        let batch = build_batch!(batch_row_count)?;
+                                        yield batch;
                                         batch_row_count = 0;
                                     }
                                 }
                                 Err(e) => {
-                                    return Err(DataFusionError::Execution(format!(
-                                        "Error reading unplaced/unmapped BAM records: {e}"
-                                    )));
+                                    Err::<(), DataFusionError>(DataFusionError::Execution(
+                                        format!("Error reading unplaced/unmapped BAM records: {e}"),
+                                    ))?;
                                 }
                             }
                         }
@@ -1165,15 +1158,12 @@ async fn get_indexed_stream(
                     .or_else(|| unmapped_index.last_first_record_start_position())
                     .unwrap_or_default();
 
-                    let mut unmapped_reader = bam::io::indexed_reader::Builder::default()
-                        .set_index(unmapped_index)
-                        .build_from_path(&file_path)
+                    // Open a plain (Send) reader; the concrete BAI index above is only
+                    // needed to compute the seek position, not for the record scan.
+                    let (mut unmapped_reader, _unmapped_header) = open_local_bam_sync(&file_path)
                         .map_err(|e| {
                             DataFusionError::Execution(format!("Failed to open BAM file: {e}"))
                         })?;
-                    let _unmapped_header = unmapped_reader.read_header().map_err(|e| {
-                        DataFusionError::Execution(format!("Failed to read BAM header: {e}"))
-                    })?;
                     unmapped_reader.get_mut().seek(seek_pos).map_err(|e| {
                         DataFusionError::Execution(format!("BGZF seek failed: {e}"))
                     })?;
@@ -1228,21 +1218,22 @@ async fn get_indexed_stream(
                                     start_val,
                                     end_val,
                                     mq
-                                );
+                                )?;
 
                                 total_records += 1;
                                 batch_row_count += 1;
                                 unmapped_count += 1;
 
                                 if batch_row_count == batch_size {
-                                    flush_batch!(batch_row_count, return Ok(()));
+                                    let batch = build_batch!(batch_row_count)?;
+                                    yield batch;
                                     batch_row_count = 0;
                                 }
                             }
                             Err(e) => {
-                                return Err(DataFusionError::Execution(format!(
+                                Err::<(), DataFusionError>(DataFusionError::Execution(format!(
                                     "Error reading unmapped BAM records: {e}"
-                                )));
+                                )))?;
                             }
                         }
                     }
@@ -1340,13 +1331,14 @@ async fn get_indexed_stream(
                         }
                     }
 
-                    accumulate_record_fields!(record, chrom_name, start_val, end_val, mq);
+                    accumulate_record_fields!(record, chrom_name, start_val, end_val, mq)?;
 
                     total_records += 1;
                     batch_row_count += 1;
 
                     if batch_row_count == batch_size {
-                        flush_batch!(batch_row_count, return Ok(()));
+                        let batch = build_batch!(batch_row_count)?;
+                        yield batch;
                         batch_row_count = 0;
                     }
                 }
@@ -1354,7 +1346,8 @@ async fn get_indexed_stream(
 
             // Remaining records
             if batch_row_count > 0 {
-                flush_batch!(batch_row_count, {});
+                let batch = build_batch!(batch_row_count)?;
+                yield batch;
             }
 
             debug!(
@@ -1362,14 +1355,6 @@ async fn get_indexed_stream(
                 total_records,
                 regions.len()
             );
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(ArrowError::ExternalError(Box::new(e))));
-        }
-    });
-
-    // Stream batches from the channel
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }

--- a/datafusion/bio-format-bam/src/storage.rs
+++ b/datafusion/bio-format-bam/src/storage.rs
@@ -262,10 +262,17 @@ impl SamReader {
 
 /// A local indexed BAM reader for region-based queries.
 ///
-/// Uses noodles' `IndexedReader::Builder` to support random-access queries using BAI indexes.
-/// This is used when an index file is available and genomic region filters are present.
+/// Holds a plain BGZF-backed BAM reader plus a concrete BAI index to support
+/// random-access queries. This is used when an index file is available and genomic
+/// region filters are present.
+///
+/// Unlike noodles' `IndexedReader` (which stores the index as a non-`Send`
+/// `Box<dyn BinningIndex>`), this keeps the concrete `noodles_bam::bai::Index` so the
+/// reader is `Send`. That lets the indexed scan decode inline on the consuming tokio
+/// worker via `async_stream::try_stream!` instead of a dedicated reader thread.
 pub struct IndexedBamReader {
-    reader: bam::io::IndexedReader<noodles_bgzf::io::Reader<File>>,
+    reader: bam::io::Reader<noodles_bgzf::io::Reader<File>>,
+    index: bam::bai::Index,
     header: sam::Header,
 }
 
@@ -276,12 +283,15 @@ impl IndexedBamReader {
     /// * `file_path` - Path to the BAM file
     /// * `index_path` - Path to the BAI index file
     pub fn new(file_path: &str, index_path: &str) -> Result<Self, Error> {
-        let mut reader = bam::io::indexed_reader::Builder::default()
-            .set_index(bam::bai::fs::read(index_path)?)
-            .build_from_path(file_path)
-            .map_err(Error::other)?;
+        let index = bam::bai::fs::read(index_path)?;
+        let inner = BgzfReader::new(File::open(file_path)?);
+        let mut reader = bam::io::Reader::from(inner);
         let header = reader.read_header()?;
-        Ok(Self { reader, header })
+        Ok(Self {
+            reader,
+            index,
+            header,
+        })
     }
 
     /// Returns a reference to the SAM header.
@@ -306,7 +316,7 @@ impl IndexedBamReader {
         &mut self,
         region: &noodles_core::Region,
     ) -> Result<impl Iterator<Item = Result<Record, Error>> + '_, Error> {
-        self.reader.query(&self.header, region)
+        self.reader.query(&self.header, &self.index, region)
     }
 }
 

--- a/datafusion/bio-format-core/src/lib.rs
+++ b/datafusion/bio-format-core/src/lib.rs
@@ -76,6 +76,8 @@ pub mod record_filter;
 pub mod sam_record_serializer;
 /// Shared SAM/BAM/CRAM optional tag IO helpers
 pub mod sam_tag_io;
+/// Single-thread-per-partition batch stream helper (issue #212)
+pub mod sync_stream;
 /// Table utilities for building DataFusion table providers
 pub mod table_utils;
 /// Tag registry for BAM/CRAM alignment tags

--- a/datafusion/bio-format-core/src/sync_stream.rs
+++ b/datafusion/bio-format-core/src/sync_stream.rs
@@ -1,0 +1,75 @@
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+/// Build a [`SendableRecordBatchStream`] that pulls batches **synchronously** on
+/// the consuming task's thread — no dedicated reader thread, no channel.
+///
+/// Each `poll_next` invokes `next_batch` exactly once. Because the closure does
+/// its (blocking) decompression/parse work inline, that work runs on the same
+/// tokio worker that consumes the partition. A scan therefore uses exactly
+/// `target_partitions` OS threads instead of ~2× (issue #212).
+///
+/// `next_batch` returns `Some(Ok(batch))` for each batch, `Some(Err(_))` to
+/// surface an error (after which it should return `None`), and `None` when the
+/// partition is exhausted.
+pub fn sync_batch_stream<F>(schema: SchemaRef, next_batch: F) -> SendableRecordBatchStream
+where
+    F: FnMut() -> Option<Result<RecordBatch, DataFusionError>> + Send + 'static,
+{
+    let stream = futures::stream::unfold(next_batch, |mut next_batch| async move {
+        let item = next_batch()?;
+        Some((item, next_batch))
+    });
+    Box::pin(RecordBatchStreamAdapter::new(schema, stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use futures::StreamExt;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn yields_batches_then_stops() {
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]));
+        let s = schema.clone();
+        let mut remaining = vec![3, 2, 1];
+        let stream = sync_batch_stream(schema, move || {
+            remaining.pop().map(|v| {
+                Ok(
+                    RecordBatch::try_new(s.clone(), vec![Arc::new(Int32Array::from(vec![v]))])
+                        .unwrap(),
+                )
+            })
+        });
+        let batches: Vec<_> = stream.collect().await;
+        assert_eq!(batches.len(), 3);
+        let total: i32 = batches
+            .iter()
+            .map(|b| b.as_ref().unwrap().num_rows() as i32)
+            .sum();
+        assert_eq!(total, 3);
+    }
+
+    #[tokio::test]
+    async fn propagates_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]));
+        let mut sent = false;
+        let stream = sync_batch_stream(schema, move || {
+            if sent {
+                None
+            } else {
+                sent = true;
+                Some(Err(DataFusionError::Execution("boom".into())))
+            }
+        });
+        let batches: Vec<_> = stream.collect().await;
+        assert_eq!(batches.len(), 1);
+        assert!(batches[0].is_err());
+    }
+}

--- a/datafusion/bio-format-core/src/sync_stream.rs
+++ b/datafusion/bio-format-core/src/sync_stream.rs
@@ -15,6 +15,22 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 /// `next_batch` returns `Some(Ok(batch))` for each batch, `Some(Err(_))` to
 /// surface an error (after which it should return `None`), and `None` when the
 /// partition is exhausted.
+///
+/// # Runtime expectations
+///
+/// Decode is **intentionally blocking on the consuming worker** — that is what
+/// bounds a scan to one OS thread per partition (`target_partitions`) instead of
+/// escaping the runtime with a dedicated reader thread. This suits the
+/// scan-oriented runtimes these providers target (DataFusion executes CPU-bound
+/// operators on its tokio workers anyway). If a caller shares one runtime between
+/// these scans and latency-sensitive async work, it should use a multi-threaded
+/// runtime sized for the scan parallelism it wants; wrapping the decode in
+/// `spawn_blocking`/`block_in_place` is deliberately avoided here because it would
+/// reintroduce the unbounded off-runtime threads this design removes.
+///
+/// For region-iterating readers, an `async_stream` generator (`try_stream!`) that
+/// yields batches from the same synchronous loop is an equivalent alternative to
+/// this helper — it decodes inline on the consuming worker in the same way.
 pub fn sync_batch_stream<F>(schema: SchemaRef, next_batch: F) -> SendableRecordBatchStream
 where
     F: FnMut() -> Option<Result<RecordBatch, DataFusionError>> + Send + 'static,

--- a/datafusion/bio-format-cram/src/physical_exec.rs
+++ b/datafusion/bio-format-cram/src/physical_exec.rs
@@ -845,8 +845,9 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
 /// Get a streaming RecordBatch stream from an indexed CRAM file for one or more regions.
 ///
-/// Uses `thread::spawn` + `mpsc::channel(2)` for streaming I/O with backpressure.
-/// Each partition processes its assigned regions sequentially, keeping only ~3 batches
+/// Decodes inline on the consuming tokio worker via an `async_stream::try_stream!`
+/// generator (no per-partition reader thread).
+/// Each partition processes its assigned regions sequentially, keeping only ~1 batch
 /// in memory at a time (constant memory regardless of data volume).
 #[allow(clippy::too_many_arguments)]
 async fn get_indexed_stream(
@@ -862,10 +863,8 @@ async fn get_indexed_stream(
     residual_filters: Vec<datafusion::logical_expr::Expr>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<RecordBatch, ArrowError>>(2);
 
-    std::thread::spawn(move || {
-        let read_and_send = || -> Result<(), DataFusionError> {
+    let stream = async_stream::try_stream! {
             let mut indexed_reader =
                 IndexedCramReader::new(&file_path, &index_path, reference_path.as_deref())
                     .map_err(|e| {
@@ -1107,14 +1106,7 @@ async fn get_indexed_stream(
                             name.len(),
                         )?;
 
-                        // Send batch with backpressure
-                        loop {
-                            match tx.try_send(Ok(batch.clone())) {
-                                Ok(()) => break,
-                                Err(e) if e.is_disconnected() => return Ok(()),
-                                Err(_) => std::thread::yield_now(),
-                            }
-                        }
+                        yield batch;
 
                         name.clear();
                         chrom.clear();
@@ -1165,13 +1157,7 @@ async fn get_indexed_stream(
                     &projection,
                     name.len(),
                 )?;
-                loop {
-                    match tx.try_send(Ok(batch.clone())) {
-                        Ok(()) => break,
-                        Err(e) if e.is_disconnected() => break,
-                        Err(_) => std::thread::yield_now(),
-                    }
-                }
+                yield batch;
             }
 
             debug!(
@@ -1179,14 +1165,6 @@ async fn get_indexed_stream(
                 total_records,
                 regions.len()
             );
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(ArrowError::ExternalError(Box::new(e))));
-        }
-    });
-
-    // Stream batches from the channel
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }

--- a/datafusion/bio-format-fasta/src/physical_exec.rs
+++ b/datafusion/bio-format-fasta/src/physical_exec.rs
@@ -272,11 +272,12 @@ async fn get_local_fasta(
     Ok(stream)
 }
 
-/// Reads a local FASTA file using a synchronous thread with buffer reuse.
+/// Reads a local FASTA file with buffer reuse, decoding inline on the consuming task.
 ///
-/// Uses `read_record(&mut record)` to reuse a single record buffer across reads,
-/// avoiding per-record clone allocations. Sends batches via a bounded channel for
-/// backpressure. Falls back to the async `get_local_fasta` for GZIP compression.
+/// Uses `read_definition`/`read_sequence` with reused buffers across reads,
+/// avoiding per-record clone allocations. Batches are produced by an
+/// `async_stream::try_stream!` generator that runs on the consuming tokio worker.
+/// Falls back to the async `get_local_fasta` for GZIP compression.
 async fn get_local_fasta_sync(
     file_path: String,
     schema_ref: SchemaRef,
@@ -285,111 +286,88 @@ async fn get_local_fasta_sync(
     compression_type: CompressionType,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<
-        Result<RecordBatch, datafusion::arrow::error::ArrowError>,
-    >(2);
-    std::thread::spawn(move || {
-        let read_and_send = || -> Result<(), DataFusionError> {
-            let mut reader = open_local_fasta_sync(&file_path, compression_type)
-                .map_err(|e| DataFusionError::Execution(format!("Failed to open FASTA: {e}")))?;
+    let stream = try_stream! {
+        let mut reader = open_local_fasta_sync(&file_path, compression_type)
+            .map_err(|e| DataFusionError::Execution(format!("Failed to open FASTA: {e}")))?;
 
-            let mut name: Vec<String> = Vec::with_capacity(batch_size);
-            let mut description: Vec<Option<String>> = Vec::with_capacity(batch_size);
-            let mut sequence: Vec<String> = Vec::with_capacity(batch_size);
+        let mut name: Vec<String> = Vec::with_capacity(batch_size);
+        let mut description: Vec<Option<String>> = Vec::with_capacity(batch_size);
+        let mut sequence: Vec<String> = Vec::with_capacity(batch_size);
 
-            let mut def_buf = String::new();
-            let mut seq_buf = Vec::new();
-            let mut record_num = 0usize;
+        let mut def_buf = String::new();
+        let mut seq_buf = Vec::new();
+        let mut record_num = 0usize;
 
-            loop {
-                def_buf.clear();
-                match reader.read_definition(&mut def_buf) {
-                    Ok(0) => break, // EOF
-                    Ok(_) => {
-                        seq_buf.clear();
-                        reader.read_sequence(&mut seq_buf).map_err(|e| {
-                            DataFusionError::Execution(format!("FASTA sequence read error: {e}"))
+        loop {
+            def_buf.clear();
+            match reader.read_definition(&mut def_buf) {
+                Ok(0) => break, // EOF
+                Ok(_) => {
+                    seq_buf.clear();
+                    reader.read_sequence(&mut seq_buf).map_err(|e| {
+                        DataFusionError::Execution(format!("FASTA sequence read error: {e}"))
+                    })?;
+
+                    let definition: noodles_fasta::record::Definition =
+                        def_buf.parse().map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "FASTA definition parse error: {e}"
+                            ))
                         })?;
 
-                        let definition: noodles_fasta::record::Definition =
-                            def_buf.parse().map_err(|e| {
-                                DataFusionError::Execution(format!(
-                                    "FASTA definition parse error: {e}"
-                                ))
-                            })?;
+                    name.push(
+                        std::str::from_utf8(definition.name())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                    description.push(
+                        definition
+                            .description()
+                            .map(|s| std::str::from_utf8(s).unwrap_or("").to_string()),
+                    );
+                    sequence.push(std::str::from_utf8(&seq_buf).unwrap_or("").to_string());
 
-                        name.push(
-                            std::str::from_utf8(definition.name())
-                                .unwrap_or("")
-                                .to_string(),
-                        );
-                        description.push(
-                            definition
-                                .description()
-                                .map(|s| std::str::from_utf8(s).unwrap_or("").to_string()),
-                        );
-                        sequence.push(std::str::from_utf8(&seq_buf).unwrap_or("").to_string());
+                    record_num += 1;
 
-                        record_num += 1;
+                    if record_num.is_multiple_of(batch_size) {
+                        debug!("Record number: {record_num}");
+                        let batch = build_record_batch(
+                            Arc::clone(&schema),
+                            &name,
+                            &description,
+                            &sequence,
+                            projection.clone(),
+                        )?;
 
-                        if record_num.is_multiple_of(batch_size) {
-                            debug!("Record number: {record_num}");
-                            let batch = build_record_batch(
-                                Arc::clone(&schema),
-                                &name,
-                                &description,
-                                &sequence,
-                                projection.clone(),
-                            )?;
+                        yield batch;
 
-                            loop {
-                                match tx.try_send(Ok(batch.clone())) {
-                                    Ok(()) => break,
-                                    Err(e) if e.is_disconnected() => return Ok(()),
-                                    Err(_) => std::thread::yield_now(),
-                                }
-                            }
-
-                            name.clear();
-                            description.clear();
-                            sequence.clear();
-                        }
-                    }
-                    Err(e) => {
-                        return Err(DataFusionError::Execution(format!("FASTA read error: {e}")));
+                        name.clear();
+                        description.clear();
+                        sequence.clear();
                     }
                 }
-            }
-
-            // Remaining records
-            if !name.is_empty() {
-                let batch = build_record_batch(
-                    Arc::clone(&schema),
-                    &name,
-                    &description,
-                    &sequence,
-                    projection.clone(),
-                )?;
-                loop {
-                    match tx.try_send(Ok(batch.clone())) {
-                        Ok(()) => break,
-                        Err(e) if e.is_disconnected() => break,
-                        Err(_) => std::thread::yield_now(),
-                    }
+                Err(e) => {
+                    Err::<(), DataFusionError>(DataFusionError::Execution(format!(
+                        "FASTA read error: {e}"
+                    )))?;
                 }
             }
-
-            debug!("Local FASTA sync scan: {record_num} records");
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(datafusion::arrow::error::ArrowError::ExternalError(
-                Box::new(e),
-            )));
         }
-    });
 
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+        // Remaining records
+        if !name.is_empty() {
+            let batch = build_record_batch(
+                Arc::clone(&schema),
+                &name,
+                &description,
+                &sequence,
+                projection.clone(),
+            )?;
+            yield batch;
+        }
+
+        debug!("Local FASTA sync scan: {record_num} records");
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }
 

--- a/datafusion/bio-format-fastq/src/physical_exec.rs
+++ b/datafusion/bio-format-fastq/src/physical_exec.rs
@@ -3,7 +3,6 @@ use async_stream::__private::AsyncStream;
 use async_stream::try_stream;
 use datafusion::arrow::array::{Array, RecordBatch, StringBuilder};
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatchOptions;
 use datafusion::common::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -13,7 +12,7 @@ use datafusion_bio_format_core::object_storage::{
     ObjectStorageOptions, StorageType, get_storage_type,
 };
 
-use futures::channel::mpsc;
+use datafusion_bio_format_core::sync_stream::sync_batch_stream;
 use futures_util::{StreamExt, TryStreamExt};
 use log::{debug, info};
 use noodles_bgzf::{IndexedReader, gzi};
@@ -22,12 +21,6 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
-use std::thread;
-
-/// Number of RecordBatch items buffered in the mpsc channel between the reader thread
-/// and the async stream consumer. A small buffer (2) keeps memory usage low while still
-/// allowing the reader thread to stay ahead of the consumer by one batch.
-const PARTITION_CHANNEL_BUFFER: usize = 2;
 
 /// Strategy for partitioning a FASTQ file across multiple execution partitions.
 ///
@@ -254,6 +247,17 @@ fn synchronize_plain_reader<R: BufRead>(reader: &mut R) -> io::Result<()> {
     }
 }
 
+/// Physical execution plan for FASTQ scans.
+///
+/// # Thread usage (issue #212)
+///
+/// Each partition decodes (decompress + parse + build Arrow batches) **inline on
+/// the tokio worker that consumes it**, via [`sync_batch_stream`]. There is no
+/// dedicated reader thread and no channel, so a scan uses **one OS thread per
+/// partition** — i.e. `target_partitions` threads, not `~2×`. To use N cores,
+/// set `target_partitions = N`. Decompression parallelism is bounded by the
+/// caller's tokio runtime worker-thread count: if `target_partitions` exceeds
+/// the worker count, concurrent decode is capped at the worker count.
 #[allow(dead_code)]
 pub struct FastqExec {
     pub(crate) file_path: String,
@@ -353,7 +357,6 @@ impl ExecutionPlan for FastqExec {
                     end_comp,
                     self.limit,
                     batch_size,
-                    partition,
                 )
             }
             FastqPartitionStrategy::ByteRange { partitions } => {
@@ -366,7 +369,6 @@ impl ExecutionPlan for FastqExec {
                     end_byte,
                     self.limit,
                     batch_size,
-                    partition,
                 )
             }
             FastqPartitionStrategy::Sequential => {
@@ -384,87 +386,42 @@ impl ExecutionPlan for FastqExec {
     }
 }
 
-/// Read FASTQ records from a reader, build Arrow RecordBatches, and send them
-/// through an mpsc channel. This is the shared core loop used by both BGZF and
-/// byte-range partition strategies.
-///
-/// # Arguments
-///
-/// * `fastq_reader` - A FASTQ reader already positioned at the first record to read
-/// * `is_past_end` - Closure that returns `true` when the reader has passed the partition boundary
-/// * `schema` - Arrow schema for the output batches
-/// * `projection` - Optional column projection indices
-/// * `limit` - Optional row limit
-/// * `batch_size` - Maximum rows per RecordBatch
-/// * `tx` - Channel sender for dispatching completed batches
-fn read_and_send_batches<R: BufRead>(
-    fastq_reader: &mut fastq::io::Reader<R>,
-    is_past_end: &mut dyn FnMut(&mut fastq::io::Reader<R>) -> bool,
-    schema: &SchemaRef,
-    projection: &Option<Vec<usize>>,
+/// Build a closure that decodes one `RecordBatch` per call from a positioned
+/// FASTQ reader. All work is synchronous; the closure is driven by
+/// [`sync_batch_stream`], so it runs on the consuming tokio worker — one OS
+/// thread per partition, no reader thread, no channel (issue #212).
+fn batch_producer<R: BufRead + Send + 'static>(
+    mut fastq_reader: fastq::io::Reader<R>,
+    mut is_past_end: impl FnMut(&mut fastq::io::Reader<R>) -> bool + Send + 'static,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
     limit: Option<usize>,
     batch_size: usize,
-    tx: &mut mpsc::Sender<(Result<RecordBatch, ArrowError>, usize)>,
-) -> Result<(), ArrowError> {
+) -> impl FnMut() -> Option<Result<RecordBatch, DataFusionError>> + Send + 'static {
     let mut record = fastq::Record::default();
-    let mut total_records = 0;
-
-    // Fast path for empty projection (COUNT(*) queries)
-    if let Some(proj) = projection
-        && proj.is_empty()
-    {
-        let mut num_rows = 0;
-        loop {
-            if limit.is_some_and(|l| num_rows >= l) {
-                break;
-            }
-            if is_past_end(fastq_reader) {
-                break;
-            }
-            match fastq_reader.read_record(&mut record) {
-                Ok(0) => break,
-                Ok(_) => num_rows += 1,
-                Err(e) => return Err(ArrowError::ExternalError(Box::new(e))),
-            }
+    let mut total: usize = 0;
+    let mut done = false;
+    move || {
+        if done {
+            return None;
         }
-        let options = datafusion::arrow::record_batch::RecordBatchOptions::new()
-            .with_row_count(Some(num_rows));
-        let batch = RecordBatch::try_new_with_options(schema.clone(), vec![], &options)?;
-        tx.try_send((Ok(batch), num_rows)).ok();
-        return Ok(());
-    }
+        let proj = projection.as_ref();
+        let mut names = proj.is_none_or(|p| p.contains(&0)).then(StringBuilder::new);
+        let mut descriptions = proj.is_none_or(|p| p.contains(&1)).then(StringBuilder::new);
+        let mut sequences = proj.is_none_or(|p| p.contains(&2)).then(StringBuilder::new);
+        let mut quality_scores = proj.is_none_or(|p| p.contains(&3)).then(StringBuilder::new);
 
-    loop {
-        if limit.is_some_and(|l| total_records >= l) {
-            break;
-        }
-
-        let proj_indices = projection.as_ref();
-        let mut names = proj_indices
-            .is_none_or(|p| p.contains(&0))
-            .then(StringBuilder::new);
-        let mut descriptions = proj_indices
-            .is_none_or(|p| p.contains(&1))
-            .then(StringBuilder::new);
-        let mut sequences = proj_indices
-            .is_none_or(|p| p.contains(&2))
-            .then(StringBuilder::new);
-        let mut quality_scores = proj_indices
-            .is_none_or(|p| p.contains(&3))
-            .then(StringBuilder::new);
-
-        let mut count = 0;
+        let mut count = 0usize;
         while count < batch_size {
-            if limit.is_some_and(|l| total_records >= l) {
+            if limit.is_some_and(|l| total >= l) || is_past_end(&mut fastq_reader) {
+                done = true;
                 break;
             }
-
-            if is_past_end(fastq_reader) {
-                break;
-            }
-
             match fastq_reader.read_record(&mut record) {
-                Ok(0) => break,
+                Ok(0) => {
+                    done = true;
+                    break;
+                }
                 Ok(_) => {
                     if let Some(b) = &mut names {
                         b.append_value(std::str::from_utf8(record.name()).unwrap());
@@ -483,52 +440,32 @@ fn read_and_send_batches<R: BufRead>(
                         b.append_value(std::str::from_utf8(record.quality_scores()).unwrap());
                     }
                     count += 1;
-                    total_records += 1;
+                    total += 1;
                 }
-                Err(e) => return Err(ArrowError::ExternalError(Box::new(e))),
+                Err(e) => {
+                    done = true;
+                    return Some(Err(DataFusionError::External(Box::new(e))));
+                }
             }
         }
 
         if count == 0 {
-            break;
+            return None;
         }
-
-        let mut arrays: Vec<Arc<dyn Array>> = vec![];
-        if let Some(proj) = projection {
-            for &col_idx in proj.iter() {
-                match col_idx {
-                    0 => arrays.push(Arc::new(names.as_mut().unwrap().finish())),
-                    1 => arrays.push(Arc::new(descriptions.as_mut().unwrap().finish())),
-                    2 => arrays.push(Arc::new(sequences.as_mut().unwrap().finish())),
-                    3 => arrays.push(Arc::new(quality_scores.as_mut().unwrap().finish())),
-                    _ => unreachable!(),
-                }
-            }
-        } else {
-            arrays.push(Arc::new(names.unwrap().finish()));
-            arrays.push(Arc::new(descriptions.unwrap().finish()));
-            arrays.push(Arc::new(sequences.unwrap().finish()));
-            arrays.push(Arc::new(quality_scores.unwrap().finish()));
-        }
-
-        let batch = RecordBatch::try_new(schema.clone(), arrays)?;
-        let num_rows = batch.num_rows();
-        let mut msg = (Ok(batch), num_rows);
-        loop {
-            match tx.try_send(msg) {
-                Ok(()) => break,
-                Err(e) if e.is_disconnected() => return Ok(()),
-                Err(e) => {
-                    msg = e.into_inner();
-                    thread::yield_now();
-                }
-            }
-        }
+        Some(build_batch_from_builders(
+            &schema,
+            &projection,
+            &mut names,
+            &mut descriptions,
+            &mut sequences,
+            &mut quality_scores,
+            count,
+        ))
     }
-    Ok(())
 }
 
-/// Execute a BGZF partition using a background thread + mpsc channel.
+/// Execute a BGZF partition by decoding inline on the consuming tokio worker:
+/// one OS thread per partition, no reader thread, no channel (issue #212).
 #[allow(clippy::too_many_arguments)]
 fn execute_bgzf_partition(
     path: String,
@@ -539,60 +476,36 @@ fn execute_bgzf_partition(
     end_comp: u64,
     limit: Option<usize>,
     batch_size: usize,
-    partition: usize,
 ) -> datafusion::common::Result<SendableRecordBatchStream> {
-    let (mut tx, rx) =
-        mpsc::channel::<(Result<RecordBatch, ArrowError>, usize)>(PARTITION_CHANNEL_BUFFER);
+    let file = std::fs::File::open(&path)
+        .map_err(|e| DataFusionError::Execution(format!("open {path}: {e}")))?;
+    let mut reader = IndexedReader::new(BufReader::new(file), index);
+    reader
+        .seek(SeekFrom::Start(start_uncomp))
+        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    if start_uncomp > 0 {
+        synchronize_bgzf_reader(&mut reader, end_comp)
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    }
 
-    let schema_clone = schema.clone();
-    let _handle = thread::spawn(move || {
-        let read_and_send = || -> Result<(), ArrowError> {
-            let file =
-                std::fs::File::open(&path).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-            let mut reader = IndexedReader::new(BufReader::new(file), index);
+    let fastq_reader = fastq::io::Reader::new(reader);
+    let is_past_end = move |r: &mut fastq::io::Reader<IndexedReader<BufReader<std::fs::File>>>| {
+        r.get_ref().virtual_position().compressed() >= end_comp
+    };
 
-            reader
-                .seek(SeekFrom::Start(start_uncomp))
-                .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-
-            if start_uncomp > 0 {
-                synchronize_bgzf_reader(&mut reader, end_comp)
-                    .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-            }
-
-            let mut fastq_reader = fastq::io::Reader::new(reader);
-            let mut is_past_end =
-                |r: &mut fastq::io::Reader<IndexedReader<BufReader<std::fs::File>>>| {
-                    r.get_ref().virtual_position().compressed() >= end_comp
-                };
-
-            read_and_send_batches(
-                &mut fastq_reader,
-                &mut is_past_end,
-                &schema_clone,
-                &projection,
-                limit,
-                batch_size,
-                &mut tx,
-            )
-        };
-
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send((Err(e), 0));
-        }
-    });
-
-    Ok(Box::pin(RecordBatchStreamAdapter::new(
+    let producer = batch_producer(
+        fastq_reader,
+        is_past_end,
         schema.clone(),
-        rx.map(move |(item, count)| {
-            debug!("Partition {partition}: processed {count} rows");
-            item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-        }),
-    )))
+        projection,
+        limit,
+        batch_size,
+    );
+    Ok(sync_batch_stream(schema, producer))
 }
 
-/// Execute a byte-range partition of an uncompressed FASTQ file.
-#[allow(clippy::too_many_arguments)]
+/// Execute a byte-range partition of an uncompressed FASTQ file, decoding
+/// inline on the consuming tokio worker (issue #212).
 fn execute_byte_range_partition(
     path: String,
     schema: SchemaRef,
@@ -601,58 +514,35 @@ fn execute_byte_range_partition(
     end_byte: u64,
     limit: Option<usize>,
     batch_size: usize,
-    partition: usize,
 ) -> datafusion::common::Result<SendableRecordBatchStream> {
-    let (mut tx, rx) =
-        mpsc::channel::<(Result<RecordBatch, ArrowError>, usize)>(PARTITION_CHANNEL_BUFFER);
+    let file = std::fs::File::open(&path)
+        .map_err(|e| DataFusionError::Execution(format!("open {path}: {e}")))?;
+    let mut reader = BufReader::new(file);
+    reader
+        .seek(SeekFrom::Start(start_byte))
+        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    if start_byte > 0 {
+        synchronize_plain_reader(&mut reader)
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    }
 
-    let schema_clone = schema.clone();
-    let _handle = thread::spawn(move || {
-        let mut read_and_send = || -> Result<(), ArrowError> {
-            let file =
-                std::fs::File::open(&path).map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-            let mut reader = BufReader::new(file);
+    let fastq_reader = fastq::io::Reader::new(reader);
+    let is_past_end = move |r: &mut fastq::io::Reader<BufReader<std::fs::File>>| {
+        r.get_mut()
+            .stream_position()
+            .map(|pos| pos >= end_byte)
+            .unwrap_or(true)
+    };
 
-            reader
-                .seek(SeekFrom::Start(start_byte))
-                .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-
-            if start_byte > 0 {
-                synchronize_plain_reader(&mut reader)
-                    .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-            }
-
-            let mut fastq_reader = fastq::io::Reader::new(reader);
-            let mut is_past_end = |r: &mut fastq::io::Reader<BufReader<std::fs::File>>| {
-                r.get_mut()
-                    .stream_position()
-                    .map(|pos| pos >= end_byte)
-                    .unwrap_or(true)
-            };
-
-            read_and_send_batches(
-                &mut fastq_reader,
-                &mut is_past_end,
-                &schema_clone,
-                &projection,
-                limit,
-                batch_size,
-                &mut tx,
-            )
-        };
-
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send((Err(e), 0));
-        }
-    });
-
-    Ok(Box::pin(RecordBatchStreamAdapter::new(
+    let producer = batch_producer(
+        fastq_reader,
+        is_past_end,
         schema.clone(),
-        rx.map(move |(item, count)| {
-            debug!("Partition {partition}: processed {count} rows");
-            item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-        }),
-    )))
+        projection,
+        limit,
+        batch_size,
+    );
+    Ok(sync_batch_stream(schema, producer))
 }
 
 /// Build a RecordBatch from optional StringBuilder columns.

--- a/datafusion/bio-format-fastq/tests/parallel_read_test.rs
+++ b/datafusion/bio-format-fastq/tests/parallel_read_test.rs
@@ -184,6 +184,53 @@ async fn test_bgzf_no_gzi_falls_back_to_sequential() {
     );
 }
 
+/// Guard for the issue #212 fold refactor: the exact set of (name, sequence,
+/// quality_scores) rows must be identical regardless of `target_partitions`.
+#[tokio::test]
+async fn test_bgzf_values_identical_across_partition_counts() {
+    let file_path = format!("{}/data/sample.fastq.bgz", env!("CARGO_MANIFEST_DIR"));
+
+    async fn read_rows(file_path: &str, partitions: usize) -> Vec<(String, String, String)> {
+        let config = SessionConfig::new().with_target_partitions(partitions);
+        let ctx = SessionContext::new_with_config(config);
+        let provider = FastqTableProvider::new(file_path.to_string(), None).expect("provider");
+        ctx.register_table("fastq", Arc::new(provider))
+            .expect("register");
+        let batches = ctx
+            .sql("SELECT name, sequence, quality_scores FROM fastq")
+            .await
+            .expect("sql")
+            .collect()
+            .await
+            .expect("collect");
+        let mut rows = Vec::new();
+        for batch in &batches {
+            let col = |i: usize| {
+                batch
+                    .column(i)
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::StringArray>()
+                    .unwrap()
+            };
+            let (n, s, q) = (col(0), col(1), col(2));
+            for i in 0..batch.num_rows() {
+                rows.push((
+                    n.value(i).to_string(),
+                    s.value(i).to_string(),
+                    q.value(i).to_string(),
+                ));
+            }
+        }
+        rows.sort();
+        rows
+    }
+
+    let one = read_rows(&file_path, 1).await;
+    let four = read_rows(&file_path, 4).await;
+    assert_eq!(one.len(), 2000);
+    assert_eq!(one, four, "row values differ between 1 and 4 partitions");
+}
+
 // ---- Uncompressed parallel read tests ----
 
 #[tokio::test]

--- a/datafusion/bio-format-gff/src/physical_exec.rs
+++ b/datafusion/bio-format-gff/src/physical_exec.rs
@@ -1261,8 +1261,9 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
 /// Get a streaming RecordBatch stream from an indexed GFF file for one or more regions.
 ///
-/// Uses `thread::spawn` + `mpsc::channel(2)` for streaming I/O with backpressure.
-/// Each partition processes its assigned regions sequentially, keeping only ~3 batches
+/// Decodes inline on the consuming tokio worker via an `async_stream::try_stream!`
+/// generator (no per-partition reader thread).
+/// Each partition processes its assigned regions sequentially, keeping only ~1 batch
 /// in memory at a time (constant memory regardless of data volume).
 #[allow(clippy::too_many_arguments)]
 async fn get_indexed_gff_stream(
@@ -1276,247 +1277,188 @@ async fn get_indexed_gff_stream(
     attr_fields: Option<Vec<String>>,
     residual_filters: Vec<Expr>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
-    use datafusion::arrow::error::ArrowError;
-
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<RecordBatch, ArrowError>>(2);
 
-    std::thread::spawn(move || {
-        let mut read_and_send = || -> Result<(), DataFusionError> {
-            let mut indexed_reader =
-                IndexedGffReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed GFF: {e}"))
-                })?;
+    let stream = try_stream! {
+        let mut indexed_reader =
+            IndexedGffReader::new(&file_path, &index_path).map_err(|e| {
+                DataFusionError::Execution(format!("Failed to open indexed GFF: {e}"))
+            })?;
 
-            // Determine which fields are needed
-            let needs_chrom = projection.as_ref().is_none_or(|proj| proj.contains(&0));
-            let needs_start = projection.as_ref().is_none_or(|proj| proj.contains(&1));
-            let needs_end = projection.as_ref().is_none_or(|proj| proj.contains(&2));
-            let needs_type = projection.as_ref().is_none_or(|proj| proj.contains(&3));
-            let needs_source = projection.as_ref().is_none_or(|proj| proj.contains(&4));
-            let needs_score = projection.as_ref().is_none_or(|proj| proj.contains(&5));
-            let needs_strand = projection.as_ref().is_none_or(|proj| proj.contains(&6));
-            let needs_phase = projection.as_ref().is_none_or(|proj| proj.contains(&7));
+        // Determine which fields are needed
+        let needs_chrom = projection.as_ref().is_none_or(|proj| proj.contains(&0));
+        let needs_start = projection.as_ref().is_none_or(|proj| proj.contains(&1));
+        let needs_end = projection.as_ref().is_none_or(|proj| proj.contains(&2));
+        let needs_type = projection.as_ref().is_none_or(|proj| proj.contains(&3));
+        let needs_source = projection.as_ref().is_none_or(|proj| proj.contains(&4));
+        let needs_score = projection.as_ref().is_none_or(|proj| proj.contains(&5));
+        let needs_strand = projection.as_ref().is_none_or(|proj| proj.contains(&6));
+        let needs_phase = projection.as_ref().is_none_or(|proj| proj.contains(&7));
 
-            // Initialize accumulators
-            let mut chroms: Vec<String> = Vec::with_capacity(batch_size);
-            let mut poss: Vec<u32> = Vec::with_capacity(batch_size);
-            let mut pose: Vec<u32> = Vec::with_capacity(batch_size);
-            let mut types: Vec<String> = Vec::with_capacity(batch_size);
-            let mut sources: Vec<String> = Vec::with_capacity(batch_size);
-            let mut scores: Vec<Option<f32>> = Vec::with_capacity(batch_size);
-            let mut strands: Vec<String> = Vec::with_capacity(batch_size);
-            let mut phases: Vec<Option<u32>> = Vec::with_capacity(batch_size);
+        // Initialize accumulators
+        let mut chroms: Vec<String> = Vec::with_capacity(batch_size);
+        let mut poss: Vec<u32> = Vec::with_capacity(batch_size);
+        let mut pose: Vec<u32> = Vec::with_capacity(batch_size);
+        let mut types: Vec<String> = Vec::with_capacity(batch_size);
+        let mut sources: Vec<String> = Vec::with_capacity(batch_size);
+        let mut scores: Vec<Option<f32>> = Vec::with_capacity(batch_size);
+        let mut strands: Vec<String> = Vec::with_capacity(batch_size);
+        let mut phases: Vec<Option<u32>> = Vec::with_capacity(batch_size);
 
-            // Initialize attribute builders
-            let unnest_enable = attr_fields.is_some();
-            let mut attribute_builders: (Vec<String>, Vec<DataType>, Vec<OptionalField>) =
-                (Vec::new(), Vec::new(), Vec::new());
-            if let Some(ref attrs) = attr_fields {
-                set_attribute_builders(batch_size, attrs, &mut attribute_builders);
+        // Initialize attribute builders
+        let unnest_enable = attr_fields.is_some();
+        let mut attribute_builders: (Vec<String>, Vec<DataType>, Vec<OptionalField>) =
+            (Vec::new(), Vec::new(), Vec::new());
+        if let Some(ref attrs) = attr_fields {
+            set_attribute_builders(batch_size, attrs, &mut attribute_builders);
+        }
+
+        let builder_field = OptionalField::new(
+            &DataType::List(FieldRef::new(Field::new(
+                "attribute",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("tag", DataType::Utf8, false),
+                    Field::new("value", DataType::Utf8, true),
+                ])),
+                true,
+            ))),
+            batch_size,
+        )
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        let mut builder = vec![builder_field];
+
+        let mut total_records = 0usize;
+
+        for region in &regions {
+            // Skip unmapped_tail regions — not applicable to GFF
+            if region.unmapped_tail {
+                continue;
             }
 
-            let mut builder = vec![
-                OptionalField::new(
-                    &DataType::List(FieldRef::new(Field::new(
-                        "attribute",
-                        DataType::Struct(Fields::from(vec![
-                            Field::new("tag", DataType::Utf8, false),
-                            Field::new("value", DataType::Utf8, true),
-                        ])),
-                        true,
-                    ))),
-                    batch_size,
-                )
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
-            ];
+            // Sub-region bounds for deduplication (1-based, from partition balancer)
+            let region_start_1based = region.start.map(|s| s as u32);
+            let region_end_1based = region.end.map(|e| e as u32);
 
-            let mut total_records = 0usize;
+            let noodles_region = build_noodles_region(region)?;
 
-            for region in &regions {
-                // Skip unmapped_tail regions — not applicable to GFF
-                if region.unmapped_tail {
+            let records = indexed_reader.query(&noodles_region).map_err(|e| {
+                DataFusionError::Execution(format!("GFF region query failed: {e}"))
+            })?;
+
+            for result in records {
+                let raw_record = result.map_err(|e| {
+                    DataFusionError::Execution(format!("GFF indexed record read error: {e}"))
+                })?;
+
+                // Parse the raw GFF line (tab-separated, 9 fields)
+                let line: &str = raw_record.as_ref();
+                let fields: Vec<&str> = line.split('\t').collect();
+                if fields.len() < 9 {
+                    continue; // Skip malformed lines
+                }
+
+                let chrom = fields[0].to_string();
+                let source_str = fields[1].to_string();
+                let type_str = fields[2].to_string();
+                let start_1based: u32 = fields[3].parse().unwrap_or(0);
+                let end_1based: u32 = fields[4].parse().unwrap_or(0);
+
+                // Skip records outside the sub-region bounds (TBI/CSI bins may return
+                // overlapping records at sub-region boundaries)
+                if let Some(rs) = region_start_1based
+                    && start_1based < rs
+                {
                     continue;
                 }
+                if let Some(re) = region_end_1based
+                    && start_1based > re
+                {
+                    continue;
+                }
+                let score_val: Option<f32> = if fields[5] == "." {
+                    None
+                } else {
+                    fields[5].parse().ok()
+                };
+                let strand_str = fields[6].to_string();
+                let phase_val: Option<u8> = if fields[7] == "." {
+                    None
+                } else {
+                    fields[7].parse().ok()
+                };
+                let attributes_str = fields[8].to_string();
 
-                // Sub-region bounds for deduplication (1-based, from partition balancer)
-                let region_start_1based = region.start.map(|s| s as u32);
-                let region_end_1based = region.end.map(|e| e as u32);
-
-                let noodles_region = build_noodles_region(region)?;
-
-                let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("GFF region query failed: {e}"))
-                })?;
-
-                for result in records {
-                    let raw_record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("GFF indexed record read error: {e}"))
-                    })?;
-
-                    // Parse the raw GFF line (tab-separated, 9 fields)
-                    let line: &str = raw_record.as_ref();
-                    let fields: Vec<&str> = line.split('\t').collect();
-                    if fields.len() < 9 {
-                        continue; // Skip malformed lines
-                    }
-
-                    let chrom = fields[0].to_string();
-                    let source_str = fields[1].to_string();
-                    let type_str = fields[2].to_string();
-                    let start_1based: u32 = fields[3].parse().unwrap_or(0);
-                    let end_1based: u32 = fields[4].parse().unwrap_or(0);
-
-                    // Skip records outside the sub-region bounds (TBI/CSI bins may return
-                    // overlapping records at sub-region boundaries)
-                    if let Some(rs) = region_start_1based
-                        && start_1based < rs
-                    {
+                // Apply residual filters
+                if !residual_filters.is_empty() {
+                    let temp_record = RemoteGffRecordWrapper {
+                        chrom: chrom.clone(),
+                        start: start_1based,
+                        end: end_1based,
+                        ty: type_str.clone(),
+                        source: source_str.clone(),
+                        score: score_val,
+                        strand: strand_str.clone(),
+                        phase: phase_val,
+                        attributes: attributes_str.clone(),
+                    };
+                    if !crate::filter_utils::evaluate_filters_against_record(
+                        &temp_record,
+                        &residual_filters,
+                        &attributes_str,
+                    ) {
                         continue;
-                    }
-                    if let Some(re) = region_end_1based
-                        && start_1based > re
-                    {
-                        continue;
-                    }
-                    let score_val: Option<f32> = if fields[5] == "." {
-                        None
-                    } else {
-                        fields[5].parse().ok()
-                    };
-                    let strand_str = fields[6].to_string();
-                    let phase_val: Option<u8> = if fields[7] == "." {
-                        None
-                    } else {
-                        fields[7].parse().ok()
-                    };
-                    let attributes_str = fields[8].to_string();
-
-                    // Apply residual filters
-                    if !residual_filters.is_empty() {
-                        let temp_record = RemoteGffRecordWrapper {
-                            chrom: chrom.clone(),
-                            start: start_1based,
-                            end: end_1based,
-                            ty: type_str.clone(),
-                            source: source_str.clone(),
-                            score: score_val,
-                            strand: strand_str.clone(),
-                            phase: phase_val,
-                            attributes: attributes_str.clone(),
-                        };
-                        if !crate::filter_utils::evaluate_filters_against_record(
-                            &temp_record,
-                            &residual_filters,
-                            &attributes_str,
-                        ) {
-                            continue;
-                        }
-                    }
-
-                    // Convert coordinates
-                    let start_val = if coordinate_system_zero_based {
-                        start_1based - 1
-                    } else {
-                        start_1based
-                    };
-
-                    if needs_chrom {
-                        chroms.push(chrom);
-                    }
-                    if needs_start {
-                        poss.push(start_val);
-                    }
-                    if needs_end {
-                        pose.push(end_1based);
-                    }
-                    if needs_type {
-                        types.push(type_str);
-                    }
-                    if needs_source {
-                        sources.push(source_str);
-                    }
-                    if needs_score {
-                        scores.push(score_val);
-                    }
-                    if needs_strand {
-                        strands.push(strand_str);
-                    }
-                    if needs_phase {
-                        phases.push(phase_val.map(|p| p as u32));
-                    }
-
-                    // Handle attributes
-                    if unnest_enable && !attribute_builders.0.is_empty() {
-                        load_attributes_unnest_from_string(
-                            &attributes_str,
-                            &mut attribute_builders,
-                            projection.clone(),
-                        )
-                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                    } else if !unnest_enable {
-                        let attributes = parse_gff_attributes_to_vec(&attributes_str);
-                        load_attributes_from_vec(attributes, &mut builder)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                    }
-
-                    total_records += 1;
-
-                    if total_records.is_multiple_of(batch_size) {
-                        let batch = build_record_batch_optimized(
-                            Arc::clone(&schema),
-                            &chroms,
-                            &poss,
-                            &pose,
-                            &types,
-                            &sources,
-                            &scores,
-                            &strands,
-                            &phases,
-                            Some(&builders_to_arrays(if unnest_enable {
-                                &mut attribute_builders.2
-                            } else {
-                                &mut builder
-                            })),
-                            projection.clone(),
-                            needs_chrom,
-                            needs_start,
-                            needs_end,
-                            needs_type,
-                            needs_source,
-                            needs_score,
-                            needs_strand,
-                            needs_phase,
-                            batch_size,
-                        )?;
-
-                        // Send batch with backpressure
-                        loop {
-                            match tx.try_send(Ok(batch.clone())) {
-                                Ok(()) => break,
-                                Err(e) if e.is_disconnected() => return Ok(()),
-                                Err(_) => std::thread::yield_now(),
-                            }
-                        }
-
-                        chroms.clear();
-                        poss.clear();
-                        pose.clear();
-                        types.clear();
-                        sources.clear();
-                        scores.clear();
-                        strands.clear();
-                        phases.clear();
                     }
                 }
-            }
 
-            // Remaining records
-            if !chroms.is_empty()
-                || (!total_records.is_multiple_of(batch_size) && total_records > 0)
-            {
-                let remaining = total_records % batch_size;
-                if remaining > 0 {
+                // Convert coordinates
+                let start_val = if coordinate_system_zero_based {
+                    start_1based - 1
+                } else {
+                    start_1based
+                };
+
+                if needs_chrom {
+                    chroms.push(chrom);
+                }
+                if needs_start {
+                    poss.push(start_val);
+                }
+                if needs_end {
+                    pose.push(end_1based);
+                }
+                if needs_type {
+                    types.push(type_str);
+                }
+                if needs_source {
+                    sources.push(source_str);
+                }
+                if needs_score {
+                    scores.push(score_val);
+                }
+                if needs_strand {
+                    strands.push(strand_str);
+                }
+                if needs_phase {
+                    phases.push(phase_val.map(|p| p as u32));
+                }
+
+                // Handle attributes
+                if unnest_enable && !attribute_builders.0.is_empty() {
+                    load_attributes_unnest_from_string(
+                        &attributes_str,
+                        &mut attribute_builders,
+                        projection.clone(),
+                    )
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                } else if !unnest_enable {
+                    let attributes = parse_gff_attributes_to_vec(&attributes_str);
+                    load_attributes_from_vec(attributes, &mut builder)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                }
+
+                total_records += 1;
+
+                if total_records.is_multiple_of(batch_size) {
                     let batch = build_record_batch_optimized(
                         Arc::clone(&schema),
                         &chroms,
@@ -1541,31 +1483,64 @@ async fn get_indexed_gff_stream(
                         needs_score,
                         needs_strand,
                         needs_phase,
-                        remaining,
+                        batch_size,
                     )?;
-                    loop {
-                        match tx.try_send(Ok(batch.clone())) {
-                            Ok(()) => break,
-                            Err(e) if e.is_disconnected() => break,
-                            Err(_) => std::thread::yield_now(),
-                        }
-                    }
+
+                    yield batch;
+
+                    chroms.clear();
+                    poss.clear();
+                    pose.clear();
+                    types.clear();
+                    sources.clear();
+                    scores.clear();
+                    strands.clear();
+                    phases.clear();
                 }
             }
-
-            debug!(
-                "Indexed GFF scan: {} records for {} regions",
-                total_records,
-                regions.len()
-            );
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(ArrowError::ExternalError(Box::new(e))));
         }
-    });
 
-    // Stream batches from the channel
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+        // Remaining records
+        if !chroms.is_empty()
+            || (!total_records.is_multiple_of(batch_size) && total_records > 0)
+        {
+            let remaining = total_records % batch_size;
+            if remaining > 0 {
+                let batch = build_record_batch_optimized(
+                    Arc::clone(&schema),
+                    &chroms,
+                    &poss,
+                    &pose,
+                    &types,
+                    &sources,
+                    &scores,
+                    &strands,
+                    &phases,
+                    Some(&builders_to_arrays(if unnest_enable {
+                        &mut attribute_builders.2
+                    } else {
+                        &mut builder
+                    })),
+                    projection.clone(),
+                    needs_chrom,
+                    needs_start,
+                    needs_end,
+                    needs_type,
+                    needs_source,
+                    needs_score,
+                    needs_strand,
+                    needs_phase,
+                    remaining,
+                )?;
+                yield batch;
+            }
+        }
+
+        debug!(
+            "Indexed GFF scan: {} records for {} regions",
+            total_records,
+            regions.len()
+        );
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }

--- a/datafusion/bio-format-gtf/src/physical_exec.rs
+++ b/datafusion/bio-format-gtf/src/physical_exec.rs
@@ -18,7 +18,7 @@ use datafusion_bio_format_core::{
     partition_balancer::PartitionAssignment,
     table_utils::{Attribute, OptionalField, builders_to_arrays},
 };
-use futures_util::{StreamExt, TryStreamExt};
+use futures_util::TryStreamExt;
 use log::debug;
 use std::any::Any;
 use std::collections::HashMap;
@@ -708,7 +708,8 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
 /// Get a streaming RecordBatch stream from an indexed GTF file for one or more regions.
 ///
-/// Uses `thread::spawn` + `mpsc::channel(2)` for streaming I/O with backpressure.
+/// Batches are produced by an `async_stream::try_stream!` generator that decodes
+/// inline on the consuming tokio worker (no per-partition reader thread).
 #[allow(clippy::too_many_arguments)]
 async fn get_indexed_gtf_stream(
     file_path: String,
@@ -721,114 +722,92 @@ async fn get_indexed_gtf_stream(
     attr_fields: Option<Vec<String>>,
     residual_filters: Vec<Expr>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
-    use datafusion::arrow::error::ArrowError;
-
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<RecordBatch, ArrowError>>(2);
 
-    std::thread::spawn(move || {
-        let read_and_send = || -> Result<(), DataFusionError> {
-            let mut indexed_reader =
-                IndexedGtfReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed GTF: {e}"))
+    let stream = try_stream! {
+        let mut indexed_reader =
+            IndexedGtfReader::new(&file_path, &index_path).map_err(|e| {
+                DataFusionError::Execution(format!("Failed to open indexed GTF: {e}"))
+            })?;
+
+        let mut collector = GtfBatchCollector::new(
+            schema.clone(),
+            batch_size,
+            projection,
+            attr_fields.as_deref(),
+            coordinate_system_zero_based,
+        )?;
+
+        for region in &regions {
+            if region.unmapped_tail {
+                continue;
+            }
+
+            let region_start_1based = region.start.map(|s| s as u32);
+            let region_end_1based = region.end.map(|e| e as u32);
+
+            let noodles_region = build_noodles_region(region)?;
+
+            let records = indexed_reader.query(&noodles_region).map_err(|e| {
+                DataFusionError::Execution(format!("GTF region query failed: {e}"))
+            })?;
+
+            for result in records {
+                let raw_record = result.map_err(|e| {
+                    DataFusionError::Execution(format!("GTF indexed record read error: {e}"))
                 })?;
 
-            let mut collector = GtfBatchCollector::new(
-                schema.clone(),
-                batch_size,
-                projection,
-                attr_fields.as_deref(),
-                coordinate_system_zero_based,
-            )?;
+                let line: &str = raw_record.as_ref();
+                let record = parse_gtf_line(line)
+                    .map_err(|e| DataFusionError::Execution(format!("GTF parse error: {e}")))?;
 
-            for region in &regions {
-                if region.unmapped_tail {
+                // Skip records outside the sub-region bounds
+                if let Some(rs) = region_start_1based
+                    && record.start < rs
+                {
+                    continue;
+                }
+                if let Some(re) = region_end_1based
+                    && record.start > re
+                {
                     continue;
                 }
 
-                let region_start_1based = region.start.map(|s| s as u32);
-                let region_end_1based = region.end.map(|e| e as u32);
+                // Apply residual filters
+                if !residual_filters.is_empty()
+                    && !crate::filter_utils::evaluate_filters_against_record(
+                        &record,
+                        &residual_filters,
+                        &record.attributes,
+                        coordinate_system_zero_based,
+                    )
+                {
+                    continue;
+                }
 
-                let noodles_region = build_noodles_region(region)?;
+                collector
+                    .push_record(&record)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
 
-                let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("GTF region query failed: {e}"))
-                })?;
-
-                for result in records {
-                    let raw_record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("GTF indexed record read error: {e}"))
-                    })?;
-
-                    let line: &str = raw_record.as_ref();
-                    let record = parse_gtf_line(line)
-                        .map_err(|e| DataFusionError::Execution(format!("GTF parse error: {e}")))?;
-
-                    // Skip records outside the sub-region bounds
-                    if let Some(rs) = region_start_1based
-                        && record.start < rs
-                    {
-                        continue;
-                    }
-                    if let Some(re) = region_end_1based
-                        && record.start > re
-                    {
-                        continue;
-                    }
-
-                    // Apply residual filters
-                    if !residual_filters.is_empty()
-                        && !crate::filter_utils::evaluate_filters_against_record(
-                            &record,
-                            &residual_filters,
-                            &record.attributes,
-                            coordinate_system_zero_based,
-                        )
-                    {
-                        continue;
-                    }
-
-                    collector
-                        .push_record(&record)
-                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-
-                    if collector.is_full() {
-                        let batch = collector.take_batch()?;
-                        loop {
-                            match tx.try_send(Ok(batch.clone())) {
-                                Ok(()) => break,
-                                Err(e) if e.is_disconnected() => return Ok(()),
-                                Err(_) => std::thread::yield_now(),
-                            }
-                        }
-                    }
+                if collector.is_full() {
+                    let batch = collector.take_batch()?;
+                    yield batch;
                 }
             }
-
-            if collector.has_pending() {
-                let batch = collector.take_batch()?;
-                loop {
-                    match tx.try_send(Ok(batch.clone())) {
-                        Ok(()) => break,
-                        Err(e) if e.is_disconnected() => break,
-                        Err(_) => std::thread::yield_now(),
-                    }
-                }
-            }
-
-            debug!(
-                "Indexed GTF scan: {} records for {} regions",
-                collector.record_num,
-                regions.len()
-            );
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(ArrowError::ExternalError(Box::new(e))));
         }
-    });
 
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+        if collector.has_pending() {
+            let batch = collector.take_batch()?;
+            yield batch;
+        }
+
+        debug!(
+            "Indexed GTF scan: {} records for {} regions",
+            collector.record_num,
+            regions.len()
+        );
+    };
+
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }
 

--- a/datafusion/bio-format-pairs/src/physical_exec.rs
+++ b/datafusion/bio-format-pairs/src/physical_exec.rs
@@ -19,7 +19,7 @@ use datafusion_bio_format_core::{
     partition_balancer::PartitionAssignment,
     record_filter::{RecordFieldAccessor, evaluate_record_filters},
 };
-use futures_util::{StreamExt, TryStreamExt};
+use futures_util::TryStreamExt;
 use log::{debug, info};
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
@@ -432,177 +432,155 @@ async fn get_indexed_pairs_stream(
     coord_zero_based: bool,
     residual_filters: Vec<Expr>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
-    use datafusion::arrow::error::ArrowError;
-
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<RecordBatch, ArrowError>>(2);
 
-    std::thread::spawn(move || {
-        let mut read_and_send = || -> Result<(), DataFusionError> {
-            let mut indexed_reader =
-                IndexedPairsReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed Pairs: {e}"))
+    let stream = try_stream! {
+        let mut indexed_reader =
+            IndexedPairsReader::new(&file_path, &index_path).map_err(|e| {
+                DataFusionError::Execution(format!("Failed to open indexed Pairs: {e}"))
+            })?;
+
+        let num_columns = columns.len();
+
+        // Determine which columns are needed
+        let needs: Vec<bool> = (0..num_columns)
+            .map(|i| projection.as_ref().is_none_or(|proj| proj.contains(&i)))
+            .collect();
+
+        // Accumulator vectors per column (owned strings)
+        let mut string_cols: Vec<Vec<String>> = (0..num_columns)
+            .map(|_| Vec::with_capacity(batch_size))
+            .collect();
+        let mut u32_cols: Vec<Vec<Option<u32>>> = (0..num_columns)
+            .map(|_| Vec::with_capacity(batch_size))
+            .collect();
+
+        let mut total_records = 0usize;
+
+        for region in &regions {
+            if region.unmapped_tail {
+                continue;
+            }
+
+            let region_start_1based = region.start.map(|s| s as u32);
+            let region_end_1based = region.end.map(|e| e as u32);
+
+            let noodles_region = build_noodles_region(region)?;
+            let records = indexed_reader.query(&noodles_region).map_err(|e| {
+                DataFusionError::Execution(format!("Pairs region query failed: {e}"))
+            })?;
+
+            for result in records {
+                let raw_record = result.map_err(|e| {
+                    DataFusionError::Execution(format!("Pairs indexed record read error: {e}"))
                 })?;
 
-            let num_columns = columns.len();
-
-            // Determine which columns are needed
-            let needs: Vec<bool> = (0..num_columns)
-                .map(|i| projection.as_ref().is_none_or(|proj| proj.contains(&i)))
-                .collect();
-
-            // Accumulator vectors per column (owned strings)
-            let mut string_cols: Vec<Vec<String>> = (0..num_columns)
-                .map(|_| Vec::with_capacity(batch_size))
-                .collect();
-            let mut u32_cols: Vec<Vec<Option<u32>>> = (0..num_columns)
-                .map(|_| Vec::with_capacity(batch_size))
-                .collect();
-
-            let mut total_records = 0usize;
-
-            for region in &regions {
-                if region.unmapped_tail {
+                let line: &str = raw_record.as_ref();
+                if line.starts_with('#') {
+                    continue;
+                }
+                let fields: Vec<&str> = line.split('\t').collect();
+                if fields.len() < num_columns.min(2) {
                     continue;
                 }
 
-                let region_start_1based = region.start.map(|s| s as u32);
-                let region_end_1based = region.end.map(|e| e as u32);
-
-                let noodles_region = build_noodles_region(region)?;
-                let records = indexed_reader.query(&noodles_region).map_err(|e| {
-                    DataFusionError::Execution(format!("Pairs region query failed: {e}"))
-                })?;
-
-                for result in records {
-                    let raw_record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("Pairs indexed record read error: {e}"))
-                    })?;
-
-                    let line: &str = raw_record.as_ref();
-                    if line.starts_with('#') {
-                        continue;
-                    }
-                    let fields: Vec<&str> = line.split('\t').collect();
-                    if fields.len() < num_columns.min(2) {
-                        continue;
-                    }
-
-                    // Get pos1 for sub-region dedup (pos1 is typically column index 2)
-                    let pos1_idx = columns.iter().position(|c| c == "pos1");
-                    if let Some(idx) = pos1_idx
-                        && idx < fields.len()
-                        && let Ok(pos1_val) = fields[idx].parse::<u32>()
+                // Get pos1 for sub-region dedup (pos1 is typically column index 2)
+                let pos1_idx = columns.iter().position(|c| c == "pos1");
+                if let Some(idx) = pos1_idx
+                    && idx < fields.len()
+                    && let Ok(pos1_val) = fields[idx].parse::<u32>()
+                {
+                    if let Some(rs) = region_start_1based
+                        && pos1_val < rs
                     {
-                        if let Some(rs) = region_start_1based
-                            && pos1_val < rs
-                        {
-                            continue;
-                        }
-                        if let Some(re) = region_end_1based
-                            && pos1_val > re
-                        {
-                            continue;
-                        }
+                        continue;
                     }
-
-                    // Apply residual filters
-                    if !residual_filters.is_empty() {
-                        let record_fields = PairsRecordFields::new(&columns, &fields);
-                        if !evaluate_record_filters(&record_fields, &residual_filters) {
-                            continue;
-                        }
+                    if let Some(re) = region_end_1based
+                        && pos1_val > re
+                    {
+                        continue;
                     }
+                }
 
-                    // Accumulate values
-                    for (i, col) in columns.iter().enumerate() {
-                        if !needs[i] {
-                            continue;
-                        }
-                        let raw = if i < fields.len() { fields[i] } else { "" };
-                        match col.as_str() {
-                            "pos1" | "pos2" => {
-                                let parsed = raw.parse::<u32>().ok().map(|v| {
-                                    if coord_zero_based {
-                                        v.saturating_sub(1)
-                                    } else {
-                                        v
-                                    }
-                                });
-                                u32_cols[i].push(parsed);
-                            }
-                            "frag1" | "frag2" | "mapq1" | "mapq2" => {
-                                u32_cols[i].push(raw.parse().ok());
-                            }
-                            _ => {
-                                string_cols[i].push(raw.to_string());
-                            }
-                        }
+                // Apply residual filters
+                if !residual_filters.is_empty() {
+                    let record_fields = PairsRecordFields::new(&columns, &fields);
+                    if !evaluate_record_filters(&record_fields, &residual_filters) {
+                        continue;
                     }
+                }
 
-                    total_records += 1;
-
-                    if total_records.is_multiple_of(batch_size) {
-                        let batch = build_indexed_batch(
-                            &schema,
-                            &string_cols,
-                            &u32_cols,
-                            &columns,
-                            &projection,
-                            &needs,
-                            batch_size,
-                        )?;
-
-                        loop {
-                            match tx.try_send(Ok(batch.clone())) {
-                                Ok(()) => break,
-                                Err(e) if e.is_disconnected() => return Ok(()),
-                                Err(_) => std::thread::yield_now(),
-                            }
+                // Accumulate values
+                for (i, col) in columns.iter().enumerate() {
+                    if !needs[i] {
+                        continue;
+                    }
+                    let raw = if i < fields.len() { fields[i] } else { "" };
+                    match col.as_str() {
+                        "pos1" | "pos2" => {
+                            let parsed = raw.parse::<u32>().ok().map(|v| {
+                                if coord_zero_based {
+                                    v.saturating_sub(1)
+                                } else {
+                                    v
+                                }
+                            });
+                            u32_cols[i].push(parsed);
                         }
-
-                        for i in 0..num_columns {
-                            string_cols[i].clear();
-                            u32_cols[i].clear();
+                        "frag1" | "frag2" | "mapq1" | "mapq2" => {
+                            u32_cols[i].push(raw.parse().ok());
+                        }
+                        _ => {
+                            string_cols[i].push(raw.to_string());
                         }
                     }
                 }
-            }
 
-            // Remaining records
-            let remaining = total_records % batch_size;
-            if remaining > 0 {
-                let batch = build_indexed_batch(
-                    &schema,
-                    &string_cols,
-                    &u32_cols,
-                    &columns,
-                    &projection,
-                    &needs,
-                    remaining,
-                )?;
-                loop {
-                    match tx.try_send(Ok(batch.clone())) {
-                        Ok(()) => break,
-                        Err(e) if e.is_disconnected() => break,
-                        Err(_) => std::thread::yield_now(),
+                total_records += 1;
+
+                if total_records.is_multiple_of(batch_size) {
+                    let batch = build_indexed_batch(
+                        &schema,
+                        &string_cols,
+                        &u32_cols,
+                        &columns,
+                        &projection,
+                        &needs,
+                        batch_size,
+                    )?;
+
+                    yield batch;
+
+                    for i in 0..num_columns {
+                        string_cols[i].clear();
+                        u32_cols[i].clear();
                     }
                 }
             }
-
-            debug!(
-                "Indexed Pairs scan: {} records for {} regions",
-                total_records,
-                regions.len()
-            );
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(ArrowError::ExternalError(Box::new(e))));
         }
-    });
 
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+        // Remaining records
+        let remaining = total_records % batch_size;
+        if remaining > 0 {
+            let batch = build_indexed_batch(
+                &schema,
+                &string_cols,
+                &u32_cols,
+                &columns,
+                &projection,
+                &needs,
+                remaining,
+            )?;
+            yield batch;
+        }
+
+        debug!(
+            "Indexed Pairs scan: {} records for {} regions",
+            total_records,
+            regions.len()
+        );
+    };
+
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }
 

--- a/datafusion/bio-format-vcf/src/physical_exec.rs
+++ b/datafusion/bio-format-vcf/src/physical_exec.rs
@@ -70,7 +70,6 @@ const MULTISAMPLE_ESTIMATED_SAMPLE_ID_BYTES_PER_ENTRY: usize = 16;
 const MULTISAMPLE_ESTIMATED_VALUE_BYTES_PER_CELL: usize = 8;
 const MULTISAMPLE_MAX_INITIAL_BUILDER_ROWS: usize = 32;
 const MULTISAMPLE_BUILDER_RECYCLE_INTERVAL_BATCHES: usize = 8;
-const STREAM_CHANNEL_BUFFERED_BATCHES: usize = 4;
 
 fn count_requested_format_fields(format_fields: &Option<Vec<String>>, formats: &Formats) -> usize {
     match format_fields {
@@ -791,11 +790,12 @@ async fn get_local_vcf(
     Ok(stream)
 }
 
-/// Reads a local VCF file using a synchronous thread with buffer reuse.
+/// Reads a local VCF file with buffer reuse, decoding inline on the consuming task.
 ///
 /// Uses `read_record(&mut record)` to reuse a single record buffer across reads,
-/// avoiding per-record clone allocations. Sends batches via a bounded channel for
-/// backpressure. Falls back to the async `get_local_vcf` for GZIP compression.
+/// avoiding per-record clone allocations. Batches are produced by an
+/// `async_stream::try_stream!` generator that runs on the consuming tokio worker.
+/// Falls back to the async `get_local_vcf` for GZIP compression.
 #[allow(clippy::too_many_arguments)]
 async fn get_local_vcf_sync(
     file_path: String,
@@ -812,295 +812,264 @@ async fn get_local_vcf_sync(
     limit: Option<usize>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<
-        Result<RecordBatch, datafusion::arrow::error::ArrowError>,
-    >(STREAM_CHANNEL_BUFFERED_BATCHES);
 
-    std::thread::spawn(move || {
-        let read_and_send = || -> Result<(), DataFusionError> {
-            let (mut reader, header) = open_local_vcf_sync(&file_path, compression_type)
-                .map_err(|e| DataFusionError::Execution(format!("Failed to open VCF: {e}")))?;
+    let stream = async_stream::try_stream! {
+        let (mut reader, header) = open_local_vcf_sync(&file_path, compression_type)
+            .map_err(|e| DataFusionError::Execution(format!("Failed to open VCF: {e}")))?;
 
-            let infos = header.infos();
-            let formats = header.formats();
+        let infos = header.infos();
+        let formats = header.formats();
 
-            // Initialize INFO builders
-            let mut info_builders: (Vec<String>, Vec<DataType>, Vec<OptionalField>) =
-                (Vec::new(), Vec::new(), Vec::new());
-            set_info_builders(batch_size, info_fields.clone(), infos, &mut info_builders);
-            let mut num_info_fields = info_builders.0.len();
-            let flags = ProjectionFlags::new(&projection, num_info_fields);
-            let mut effective_batch_size = choose_effective_batch_size(
-                batch_size,
-                flags.any_format,
-                &format_fields,
-                &sample_names,
-                &source_sample_names,
-                formats,
-            );
-            let initial_builder_batch_size = choose_initial_builder_batch_size(
-                effective_batch_size,
-                flags.any_format,
-                &source_sample_names,
-            );
-            info_builders = (Vec::new(), Vec::new(), Vec::new());
-            set_info_builders(
-                initial_builder_batch_size,
-                info_fields.clone(),
-                infos,
-                &mut info_builders,
-            );
-            num_info_fields = info_builders.0.len();
+        // Initialize INFO builders
+        let mut info_builders: (Vec<String>, Vec<DataType>, Vec<OptionalField>) =
+            (Vec::new(), Vec::new(), Vec::new());
+        set_info_builders(batch_size, info_fields.clone(), infos, &mut info_builders);
+        let mut num_info_fields = info_builders.0.len();
+        let flags = ProjectionFlags::new(&projection, num_info_fields);
+        let mut effective_batch_size = choose_effective_batch_size(
+            batch_size,
+            flags.any_format,
+            &format_fields,
+            &sample_names,
+            &source_sample_names,
+            formats,
+        );
+        let initial_builder_batch_size = choose_initial_builder_batch_size(
+            effective_batch_size,
+            flags.any_format,
+            &source_sample_names,
+        );
+        info_builders = (Vec::new(), Vec::new(), Vec::new());
+        set_info_builders(
+            initial_builder_batch_size,
+            info_fields.clone(),
+            infos,
+            &mut info_builders,
+        );
+        num_info_fields = info_builders.0.len();
 
-            let info_name_to_index: HashMap<String, usize> = info_builders
-                .0
-                .iter()
-                .enumerate()
-                .map(|(i, name)| (name.clone(), i))
-                .collect();
-            let mut info_populated = vec![false; num_info_fields];
+        let info_name_to_index: HashMap<String, usize> = info_builders
+            .0
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        let mut info_populated = vec![false; num_info_fields];
 
-            let mut format_mode = init_format_mode(
-                initial_builder_batch_size,
-                format_fields.clone(),
-                &sample_names,
-                &source_sample_names,
-                formats,
-            )
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-            let has_format_fields = format_mode.has_fields();
+        let mut format_mode = init_format_mode(
+            initial_builder_batch_size,
+            format_fields.clone(),
+            &sample_names,
+            &source_sample_names,
+            formats,
+        )
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        let has_format_fields = format_mode.has_fields();
 
-            let mut builders = CoreBatchBuilders::new(&flags, initial_builder_batch_size);
-            let mut join_buf = String::with_capacity(64);
+        let mut builders = CoreBatchBuilders::new(&flags, initial_builder_batch_size);
+        let mut join_buf = String::with_capacity(64);
 
-            let has_residual_filters = !residual_filters.is_empty();
-            let needs_start = flags.start || has_residual_filters;
-            let mut record = noodles_vcf::Record::default();
-            let mut record_num = 0usize;
-            let mut batch_row_count: usize = 0;
+        let has_residual_filters = !residual_filters.is_empty();
+        let needs_start = flags.start || has_residual_filters;
+        let mut record = noodles_vcf::Record::default();
+        let mut record_num = 0usize;
+        let mut batch_row_count: usize = 0;
 
-            loop {
-                match reader.read_record(&mut record) {
-                    Ok(0) => break, // EOF
-                    Ok(_) => {
-                        let start_val = if needs_start {
-                            let start_pos_1based = record
-                                .variant_start()
-                                .ok_or_else(|| {
-                                    DataFusionError::Execution("Missing variant start".to_string())
-                                })?
+        loop {
+            match reader.read_record(&mut record) {
+                Ok(0) => break, // EOF
+                Ok(_) => {
+                    let start_val = if needs_start {
+                        let start_pos_1based = record
+                            .variant_start()
+                            .ok_or_else(|| {
+                                DataFusionError::Execution("Missing variant start".to_string())
+                            })?
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!("VCF position error: {e}"))
+                            })?
+                            .get() as u32;
+                        Some(if coordinate_system_zero_based {
+                            start_pos_1based - 1
+                        } else {
+                            start_pos_1based
+                        })
+                    } else {
+                        None
+                    };
+
+                    let chrom_for_filters = if has_residual_filters {
+                        Some(record.reference_sequence_name().to_string())
+                    } else {
+                        None
+                    };
+                    let end_val = if flags.end || has_residual_filters {
+                        Some(get_variant_end(&record, &header))
+                    } else {
+                        None
+                    };
+
+                    if has_residual_filters {
+                        let fields = VcfRecordFields {
+                            chrom: chrom_for_filters.clone(),
+                            start: start_val,
+                            end: end_val,
+                        };
+                        if !evaluate_record_filters(&fields, &residual_filters) {
+                            continue;
+                        }
+                    }
+
+                    if flags.chrom {
+                        if let Some(chrom) = chrom_for_filters.as_deref() {
+                            builders.append_chrom(chrom);
+                        } else {
+                            builders.append_chrom(record.reference_sequence_name());
+                        }
+                    }
+                    if flags.start {
+                        builders.append_start(start_val.unwrap());
+                    }
+                    if flags.end {
+                        builders.append_end(end_val.unwrap());
+                    }
+                    if flags.id {
+                        join_into(&mut join_buf, record.ids().iter(), ';');
+                        builders.append_id(&join_buf);
+                    }
+                    if flags.reference {
+                        builders.append_ref(record.reference_bases());
+                    }
+                    if flags.alt {
+                        join_into(
+                            &mut join_buf,
+                            record.alternate_bases().iter().map(|v| v.unwrap_or(".")),
+                            '|',
+                        );
+                        builders.append_alt(&join_buf);
+                    }
+                    if flags.qual {
+                        builders.append_qual(
+                            record
+                                .quality_score()
+                                .transpose()
                                 .map_err(|e| {
-                                    DataFusionError::Execution(format!("VCF position error: {e}"))
+                                    DataFusionError::Execution(format!("VCF qual error: {e}"))
                                 })?
-                                .get() as u32;
-                            Some(if coordinate_system_zero_based {
-                                start_pos_1based - 1
-                            } else {
-                                start_pos_1based
-                            })
-                        } else {
-                            None
-                        };
-
-                        let chrom_for_filters = if has_residual_filters {
-                            Some(record.reference_sequence_name().to_string())
-                        } else {
-                            None
-                        };
-                        let end_val = if flags.end || has_residual_filters {
-                            Some(get_variant_end(&record, &header))
-                        } else {
-                            None
-                        };
-
-                        if has_residual_filters {
-                            let fields = VcfRecordFields {
-                                chrom: chrom_for_filters.clone(),
-                                start: start_val,
-                                end: end_val,
-                            };
-                            if !evaluate_record_filters(&fields, &residual_filters) {
-                                continue;
-                            }
-                        }
-
-                        if flags.chrom {
-                            if let Some(chrom) = chrom_for_filters.as_deref() {
-                                builders.append_chrom(chrom);
-                            } else {
-                                builders.append_chrom(record.reference_sequence_name());
-                            }
-                        }
-                        if flags.start {
-                            builders.append_start(start_val.unwrap());
-                        }
-                        if flags.end {
-                            builders.append_end(end_val.unwrap());
-                        }
-                        if flags.id {
-                            join_into(&mut join_buf, record.ids().iter(), ';');
-                            builders.append_id(&join_buf);
-                        }
-                        if flags.reference {
-                            builders.append_ref(record.reference_bases());
-                        }
-                        if flags.alt {
-                            join_into(
-                                &mut join_buf,
-                                record.alternate_bases().iter().map(|v| v.unwrap_or(".")),
-                                '|',
-                            );
-                            builders.append_alt(&join_buf);
-                        }
-                        if flags.qual {
-                            builders.append_qual(
-                                record
-                                    .quality_score()
-                                    .transpose()
-                                    .map_err(|e| {
-                                        DataFusionError::Execution(format!("VCF qual error: {e}"))
-                                    })?
-                                    .map(|v| v as f64),
-                            );
-                        }
-                        if flags.filter {
-                            join_into(
-                                &mut join_buf,
-                                record.filters().iter(&header).map(|v| v.unwrap_or(".")),
-                                ';',
-                            );
-                            builders.append_filter(&join_buf);
-                        }
-                        if flags.any_info {
-                            load_infos_single_pass(
-                                &record,
-                                &header,
-                                &info_builders.1,
-                                &mut info_builders.2,
-                                &info_name_to_index,
-                                &mut info_populated,
-                            )
+                                .map(|v| v as f64),
+                        );
+                    }
+                    if flags.filter {
+                        join_into(
+                            &mut join_buf,
+                            record.filters().iter(&header).map(|v| v.unwrap_or(".")),
+                            ';',
+                        );
+                        builders.append_filter(&join_buf);
+                    }
+                    if flags.any_info {
+                        load_infos_single_pass(
+                            &record,
+                            &header,
+                            &info_builders.1,
+                            &mut info_builders.2,
+                            &info_name_to_index,
+                            &mut info_populated,
+                        )
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                    }
+                    if has_format_fields && flags.any_format {
+                        format_mode
+                            .append_record(&record, &header)
                             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                        }
-                        if has_format_fields && flags.any_format {
-                            format_mode
-                                .append_record(&record, &header)
-                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                        }
+                    }
 
-                        record_num += 1;
-                        batch_row_count += 1;
+                    record_num += 1;
+                    batch_row_count += 1;
 
-                        if limit.is_some_and(|lim| record_num >= lim) {
-                            break;
-                        }
+                    if limit.is_some_and(|lim| record_num >= lim) {
+                        break;
+                    }
 
-                        if batch_row_count == effective_batch_size {
-                            debug!("Record number: {record_num}");
-                            let info_arrays = if flags.any_info {
-                                Some(builders_to_arrays(&mut info_builders.2))
+                    if batch_row_count == effective_batch_size {
+                        debug!("Record number: {record_num}");
+                        let info_arrays = if flags.any_info {
+                            Some(builders_to_arrays(&mut info_builders.2))
+                        } else {
+                            None
+                        };
+                        let format_arrays =
+                            if has_format_fields && flags.any_format {
+                                Some(format_mode.finish_arrays().map_err(|e| {
+                                    DataFusionError::ArrowError(Box::new(e), None)
+                                })?)
                             } else {
                                 None
                             };
-                            let format_arrays =
-                                if has_format_fields && flags.any_format {
-                                    Some(format_mode.finish_arrays().map_err(|e| {
-                                        DataFusionError::ArrowError(Box::new(e), None)
-                                    })?)
-                                } else {
-                                    None
-                                };
-                            effective_batch_size =
-                                adjust_effective_batch_size_by_observed_format_bytes(
-                                    batch_size,
-                                    effective_batch_size,
-                                    flags.any_format,
-                                    &source_sample_names,
-                                    batch_row_count,
-                                    format_arrays.as_ref(),
-                                );
-                            let core_arrays = builders.finish();
-                            let batch = build_record_batch_from_builders(
-                                Arc::clone(&schema),
-                                core_arrays,
-                                info_arrays.as_ref(),
-                                format_arrays.as_ref(),
-                                num_info_fields,
-                                &projection,
+                        effective_batch_size =
+                            adjust_effective_batch_size_by_observed_format_bytes(
+                                batch_size,
+                                effective_batch_size,
+                                flags.any_format,
+                                &source_sample_names,
                                 batch_row_count,
-                            )?;
+                                format_arrays.as_ref(),
+                            );
+                        let core_arrays = builders.finish();
+                        let batch = build_record_batch_from_builders(
+                            Arc::clone(&schema),
+                            core_arrays,
+                            info_arrays.as_ref(),
+                            format_arrays.as_ref(),
+                            num_info_fields,
+                            &projection,
+                            batch_row_count,
+                        )?;
 
-                            let mut pending = Ok(batch);
-                            loop {
-                                match tx.try_send(pending) {
-                                    Ok(()) => break,
-                                    Err(e) if e.is_disconnected() => return Ok(()),
-                                    Err(e) => {
-                                        pending = e.into_inner();
-                                        std::thread::yield_now();
-                                    }
-                                }
-                            }
+                        yield batch;
 
-                            batch_row_count = 0;
-                        }
-                    }
-                    Err(e) => {
-                        return Err(DataFusionError::Execution(format!("VCF read error: {e}")));
+                        batch_row_count = 0;
                     }
                 }
-            }
-
-            // Remaining records
-            if batch_row_count > 0 {
-                let info_arrays = if flags.any_info {
-                    Some(builders_to_arrays(&mut info_builders.2))
-                } else {
-                    None
-                };
-                let format_arrays = if has_format_fields && flags.any_format {
-                    Some(
-                        format_mode
-                            .finish_arrays()
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
-                    )
-                } else {
-                    None
-                };
-                let core_arrays = builders.finish();
-                let batch = build_record_batch_from_builders(
-                    Arc::clone(&schema),
-                    core_arrays,
-                    info_arrays.as_ref(),
-                    format_arrays.as_ref(),
-                    num_info_fields,
-                    &projection,
-                    batch_row_count,
-                )?;
-                let mut pending = Ok(batch);
-                loop {
-                    match tx.try_send(pending) {
-                        Ok(()) => break,
-                        Err(e) if e.is_disconnected() => break,
-                        Err(e) => {
-                            pending = e.into_inner();
-                            std::thread::yield_now();
-                        }
-                    }
+                Err(e) => {
+                    Err::<(), DataFusionError>(DataFusionError::Execution(format!(
+                        "VCF read error: {e}"
+                    )))?;
                 }
             }
-
-            debug!("Local VCF sync scan: {record_num} records");
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(datafusion::arrow::error::ArrowError::ExternalError(
-                Box::new(e),
-            )));
         }
-    });
 
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+        // Remaining records
+        if batch_row_count > 0 {
+            let info_arrays = if flags.any_info {
+                Some(builders_to_arrays(&mut info_builders.2))
+            } else {
+                None
+            };
+            let format_arrays = if has_format_fields && flags.any_format {
+                Some(
+                    format_mode
+                        .finish_arrays()
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+                )
+            } else {
+                None
+            };
+            let core_arrays = builders.finish();
+            let batch = build_record_batch_from_builders(
+                Arc::clone(&schema),
+                core_arrays,
+                info_arrays.as_ref(),
+                format_arrays.as_ref(),
+                num_info_fields,
+                &projection,
+                batch_row_count,
+            )?;
+            yield batch;
+        }
+
+        debug!("Local VCF sync scan: {record_num} records");
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }
 
@@ -2632,8 +2601,9 @@ fn build_noodles_region(region: &GenomicRegion) -> Result<noodles_core::Region, 
 
 /// Get a streaming RecordBatch stream from an indexed VCF file for one or more regions.
 ///
-/// Uses `thread::spawn` + `mpsc::channel(1)` for streaming I/O with backpressure.
-/// Each partition processes its assigned regions sequentially, keeping only ~2 batches
+/// Decodes inline on the consuming tokio worker via an `async_stream::try_stream!`
+/// generator (no per-partition reader thread).
+/// Each partition processes its assigned regions sequentially, keeping only ~1 batch
 /// in memory at a time (constant memory regardless of data volume).
 #[allow(clippy::too_many_arguments)]
 async fn get_indexed_vcf_stream(
@@ -2652,341 +2622,308 @@ async fn get_indexed_vcf_stream(
     limit: Option<usize>,
 ) -> datafusion::error::Result<SendableRecordBatchStream> {
     let schema = schema_ref.clone();
-    let (mut tx, rx) = futures::channel::mpsc::channel::<
-        Result<RecordBatch, datafusion::arrow::error::ArrowError>,
-    >(STREAM_CHANNEL_BUFFERED_BATCHES);
 
-    std::thread::spawn(move || {
-        let mut read_and_send = || -> Result<(), DataFusionError> {
-            let mut indexed_reader =
-                IndexedVcfReader::new(&file_path, &index_path).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to open indexed VCF: {e}"))
+    let stream = async_stream::try_stream! {
+        let mut indexed_reader =
+            IndexedVcfReader::new(&file_path, &index_path).map_err(|e| {
+                DataFusionError::Execution(format!("Failed to open indexed VCF: {e}"))
+            })?;
+
+        let header = indexed_reader.header().clone();
+        let infos = header.infos();
+        let formats = header.formats();
+
+        // Initialize INFO builders
+        let mut info_builders: (Vec<String>, Vec<DataType>, Vec<OptionalField>) =
+            (Vec::new(), Vec::new(), Vec::new());
+        set_info_builders(batch_size, info_fields.clone(), infos, &mut info_builders);
+        let mut num_info_fields = info_builders.0.len();
+        let flags = ProjectionFlags::new(&projection, num_info_fields);
+        let mut effective_batch_size = choose_effective_batch_size(
+            batch_size,
+            flags.any_format,
+            &format_fields,
+            &sample_names,
+            &source_sample_names,
+            formats,
+        );
+        let initial_builder_batch_size = choose_initial_builder_batch_size(
+            effective_batch_size,
+            flags.any_format,
+            &source_sample_names,
+        );
+        info_builders = (Vec::new(), Vec::new(), Vec::new());
+        set_info_builders(
+            initial_builder_batch_size,
+            info_fields.clone(),
+            infos,
+            &mut info_builders,
+        );
+        num_info_fields = info_builders.0.len();
+
+        // Build INFO name→index HashMap for single-pass iteration
+        let info_name_to_index: HashMap<String, usize> = info_builders
+            .0
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        let mut info_populated = vec![false; num_info_fields];
+
+        let mut format_mode = init_format_mode(
+            initial_builder_batch_size,
+            format_fields.clone(),
+            &sample_names,
+            &source_sample_names,
+            formats,
+        )
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        let has_format_fields = format_mode.has_fields();
+
+        let mut builders = CoreBatchBuilders::new(&flags, initial_builder_batch_size);
+        let mut join_buf = String::with_capacity(64);
+        let has_residual_filters = !residual_filters.is_empty();
+        let needs_start_for_filters = flags.start || has_residual_filters;
+
+        let mut total_records = 0usize;
+        let mut batch_record_count = 0usize;
+
+        'regions: for region in &regions {
+            if region.unmapped_tail {
+                continue;
+            }
+
+            let region_start_1based = region.start.map(|s| s as u32);
+            let region_end_1based = region.end.map(|e| e as u32);
+
+            let noodles_region = build_noodles_region(region)?;
+
+            let records = match indexed_reader.query(&noodles_region) {
+                Ok(records) => records,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("does not exist in reference sequences") {
+                        debug!(
+                            "Skipping region {:?}: chromosome not in VCF reference sequences",
+                            region.chrom
+                        );
+                        continue;
+                    }
+                    Err::<(), DataFusionError>(DataFusionError::Execution(format!(
+                        "VCF region query failed: {e}"
+                    )))?;
+                    unreachable!();
+                }
+            };
+
+            for result in records {
+                let record = result.map_err(|e| {
+                    DataFusionError::Execution(format!("VCF record read error: {e}"))
                 })?;
 
-            let header = indexed_reader.header().clone();
-            let infos = header.infos();
-            let formats = header.formats();
+                let needs_start_for_region =
+                    region_start_1based.is_some() || region_end_1based.is_some();
+                let needs_start = needs_start_for_filters || needs_start_for_region;
+                let (start_pos, start_val) = if needs_start {
+                    let start_pos = record
+                        .variant_start()
+                        .ok_or_else(|| {
+                            DataFusionError::Execution("Missing variant start".to_string())
+                        })?
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!("VCF position error: {e}"))
+                        })?
+                        .get() as u32;
+                    let start_val = if coordinate_system_zero_based {
+                        start_pos - 1
+                    } else {
+                        start_pos
+                    };
+                    (Some(start_pos), Some(start_val))
+                } else {
+                    (None, None)
+                };
 
-            // Initialize INFO builders
-            let mut info_builders: (Vec<String>, Vec<DataType>, Vec<OptionalField>) =
-                (Vec::new(), Vec::new(), Vec::new());
-            set_info_builders(batch_size, info_fields.clone(), infos, &mut info_builders);
-            let mut num_info_fields = info_builders.0.len();
-            let flags = ProjectionFlags::new(&projection, num_info_fields);
-            let mut effective_batch_size = choose_effective_batch_size(
-                batch_size,
-                flags.any_format,
-                &format_fields,
-                &sample_names,
-                &source_sample_names,
-                formats,
-            );
-            let initial_builder_batch_size = choose_initial_builder_batch_size(
-                effective_batch_size,
-                flags.any_format,
-                &source_sample_names,
-            );
-            info_builders = (Vec::new(), Vec::new(), Vec::new());
-            set_info_builders(
-                initial_builder_batch_size,
-                info_fields.clone(),
-                infos,
-                &mut info_builders,
-            );
-            num_info_fields = info_builders.0.len();
-
-            // Build INFO name→index HashMap for single-pass iteration
-            let info_name_to_index: HashMap<String, usize> = info_builders
-                .0
-                .iter()
-                .enumerate()
-                .map(|(i, name)| (name.clone(), i))
-                .collect();
-            let mut info_populated = vec![false; num_info_fields];
-
-            let mut format_mode = init_format_mode(
-                initial_builder_batch_size,
-                format_fields.clone(),
-                &sample_names,
-                &source_sample_names,
-                formats,
-            )
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-            let has_format_fields = format_mode.has_fields();
-
-            let mut builders = CoreBatchBuilders::new(&flags, initial_builder_batch_size);
-            let mut join_buf = String::with_capacity(64);
-            let has_residual_filters = !residual_filters.is_empty();
-            let needs_start_for_filters = flags.start || has_residual_filters;
-
-            let mut total_records = 0usize;
-            let mut batch_record_count = 0usize;
-
-            'regions: for region in &regions {
-                if region.unmapped_tail {
+                if let Some(rs) = region_start_1based
+                    && start_pos.unwrap() < rs
+                {
+                    continue;
+                }
+                if let Some(re) = region_end_1based
+                    && start_pos.unwrap() > re
+                {
                     continue;
                 }
 
-                let region_start_1based = region.start.map(|s| s as u32);
-                let region_end_1based = region.end.map(|e| e as u32);
-
-                let noodles_region = build_noodles_region(region)?;
-
-                let records = match indexed_reader.query(&noodles_region) {
-                    Ok(records) => records,
-                    Err(e) => {
-                        let msg = e.to_string();
-                        if msg.contains("does not exist in reference sequences") {
-                            debug!(
-                                "Skipping region {:?}: chromosome not in VCF reference sequences",
-                                region.chrom
-                            );
-                            continue;
-                        }
-                        return Err(DataFusionError::Execution(format!(
-                            "VCF region query failed: {e}"
-                        )));
-                    }
+                let chrom_for_filters = if has_residual_filters {
+                    Some(record.reference_sequence_name().to_string())
+                } else {
+                    None
+                };
+                let end_val = if flags.end || has_residual_filters {
+                    Some(get_variant_end(&record, &header))
+                } else {
+                    None
                 };
 
-                for result in records {
-                    let record = result.map_err(|e| {
-                        DataFusionError::Execution(format!("VCF record read error: {e}"))
-                    })?;
+                if has_residual_filters {
+                    let fields = VcfRecordFields {
+                        chrom: chrom_for_filters.clone(),
+                        start: start_val,
+                        end: end_val,
+                    };
+                    if !evaluate_record_filters(&fields, &residual_filters) {
+                        continue;
+                    }
+                }
 
-                    let needs_start_for_region =
-                        region_start_1based.is_some() || region_end_1based.is_some();
-                    let needs_start = needs_start_for_filters || needs_start_for_region;
-                    let (start_pos, start_val) = if needs_start {
-                        let start_pos = record
-                            .variant_start()
-                            .ok_or_else(|| {
-                                DataFusionError::Execution("Missing variant start".to_string())
-                            })?
+                if flags.chrom {
+                    if let Some(chrom) = chrom_for_filters.as_deref() {
+                        builders.append_chrom(chrom);
+                    } else {
+                        builders.append_chrom(record.reference_sequence_name());
+                    }
+                }
+                if flags.start {
+                    builders.append_start(start_val.unwrap());
+                }
+                if flags.end {
+                    builders.append_end(end_val.unwrap());
+                }
+                if flags.id {
+                    join_into(&mut join_buf, record.ids().iter(), ';');
+                    builders.append_id(&join_buf);
+                }
+                if flags.reference {
+                    builders.append_ref(record.reference_bases());
+                }
+                if flags.alt {
+                    join_into(
+                        &mut join_buf,
+                        record.alternate_bases().iter().map(|v| v.unwrap_or(".")),
+                        '|',
+                    );
+                    builders.append_alt(&join_buf);
+                }
+                if flags.qual {
+                    builders.append_qual(
+                        record
+                            .quality_score()
+                            .transpose()
                             .map_err(|e| {
-                                DataFusionError::Execution(format!("VCF position error: {e}"))
+                                DataFusionError::Execution(format!("VCF qual error: {e}"))
                             })?
-                            .get() as u32;
-                        let start_val = if coordinate_system_zero_based {
-                            start_pos - 1
-                        } else {
-                            start_pos
-                        };
-                        (Some(start_pos), Some(start_val))
-                    } else {
-                        (None, None)
-                    };
-
-                    if let Some(rs) = region_start_1based
-                        && start_pos.unwrap() < rs
-                    {
-                        continue;
-                    }
-                    if let Some(re) = region_end_1based
-                        && start_pos.unwrap() > re
-                    {
-                        continue;
-                    }
-
-                    let chrom_for_filters = if has_residual_filters {
-                        Some(record.reference_sequence_name().to_string())
-                    } else {
-                        None
-                    };
-                    let end_val = if flags.end || has_residual_filters {
-                        Some(get_variant_end(&record, &header))
-                    } else {
-                        None
-                    };
-
-                    if has_residual_filters {
-                        let fields = VcfRecordFields {
-                            chrom: chrom_for_filters.clone(),
-                            start: start_val,
-                            end: end_val,
-                        };
-                        if !evaluate_record_filters(&fields, &residual_filters) {
-                            continue;
-                        }
-                    }
-
-                    if flags.chrom {
-                        if let Some(chrom) = chrom_for_filters.as_deref() {
-                            builders.append_chrom(chrom);
-                        } else {
-                            builders.append_chrom(record.reference_sequence_name());
-                        }
-                    }
-                    if flags.start {
-                        builders.append_start(start_val.unwrap());
-                    }
-                    if flags.end {
-                        builders.append_end(end_val.unwrap());
-                    }
-                    if flags.id {
-                        join_into(&mut join_buf, record.ids().iter(), ';');
-                        builders.append_id(&join_buf);
-                    }
-                    if flags.reference {
-                        builders.append_ref(record.reference_bases());
-                    }
-                    if flags.alt {
-                        join_into(
-                            &mut join_buf,
-                            record.alternate_bases().iter().map(|v| v.unwrap_or(".")),
-                            '|',
-                        );
-                        builders.append_alt(&join_buf);
-                    }
-                    if flags.qual {
-                        builders.append_qual(
-                            record
-                                .quality_score()
-                                .transpose()
-                                .map_err(|e| {
-                                    DataFusionError::Execution(format!("VCF qual error: {e}"))
-                                })?
-                                .map(|v| v as f64),
-                        );
-                    }
-                    if flags.filter {
-                        join_into(
-                            &mut join_buf,
-                            record.filters().iter(&header).map(|v| v.unwrap_or(".")),
-                            ';',
-                        );
-                        builders.append_filter(&join_buf);
-                    }
-                    if flags.any_info {
-                        load_infos_single_pass(
-                            &record,
-                            &header,
-                            &info_builders.1,
-                            &mut info_builders.2,
-                            &info_name_to_index,
-                            &mut info_populated,
-                        )
-                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                    }
-                    if has_format_fields && flags.any_format {
-                        format_mode
-                            .append_record(&record, &header)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                    }
-
-                    total_records += 1;
-                    batch_record_count += 1;
-
-                    if limit.is_some_and(|lim| total_records >= lim) {
-                        break 'regions;
-                    }
-
-                    if batch_record_count == effective_batch_size {
-                        let info_arrays = if flags.any_info {
-                            Some(builders_to_arrays(&mut info_builders.2))
-                        } else {
-                            None
-                        };
-                        let format_arrays = if has_format_fields && flags.any_format {
-                            Some(
-                                format_mode
-                                    .finish_arrays()
-                                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
-                            )
-                        } else {
-                            None
-                        };
-                        effective_batch_size = adjust_effective_batch_size_by_observed_format_bytes(
-                            batch_size,
-                            effective_batch_size,
-                            flags.any_format,
-                            &source_sample_names,
-                            batch_record_count,
-                            format_arrays.as_ref(),
-                        );
-                        let core_arrays = builders.finish();
-                        let batch = build_record_batch_from_builders(
-                            Arc::clone(&schema),
-                            core_arrays,
-                            info_arrays.as_ref(),
-                            format_arrays.as_ref(),
-                            num_info_fields,
-                            &projection,
-                            batch_record_count,
-                        )?;
-
-                        let mut pending = Ok(batch);
-                        loop {
-                            match tx.try_send(pending) {
-                                Ok(()) => break,
-                                Err(e) if e.is_disconnected() => return Ok(()),
-                                Err(e) => {
-                                    pending = e.into_inner();
-                                    std::thread::yield_now();
-                                }
-                            }
-                        }
-
-                        batch_record_count = 0;
-                    }
+                            .map(|v| v as f64),
+                    );
                 }
-            }
-
-            // Remaining records
-            if batch_record_count > 0 {
-                let info_arrays = if flags.any_info {
-                    Some(builders_to_arrays(&mut info_builders.2))
-                } else {
-                    None
-                };
-                let format_arrays = if has_format_fields && flags.any_format {
-                    Some(
-                        format_mode
-                            .finish_arrays()
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+                if flags.filter {
+                    join_into(
+                        &mut join_buf,
+                        record.filters().iter(&header).map(|v| v.unwrap_or(".")),
+                        ';',
+                    );
+                    builders.append_filter(&join_buf);
+                }
+                if flags.any_info {
+                    load_infos_single_pass(
+                        &record,
+                        &header,
+                        &info_builders.1,
+                        &mut info_builders.2,
+                        &info_name_to_index,
+                        &mut info_populated,
                     )
-                } else {
-                    None
-                };
-                let core_arrays = builders.finish();
-                let batch = build_record_batch_from_builders(
-                    Arc::clone(&schema),
-                    core_arrays,
-                    info_arrays.as_ref(),
-                    format_arrays.as_ref(),
-                    num_info_fields,
-                    &projection,
-                    batch_record_count,
-                )?;
-                let mut pending = Ok(batch);
-                loop {
-                    match tx.try_send(pending) {
-                        Ok(()) => break,
-                        Err(e) if e.is_disconnected() => break,
-                        Err(e) => {
-                            pending = e.into_inner();
-                            std::thread::yield_now();
-                        }
-                    }
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                }
+                if has_format_fields && flags.any_format {
+                    format_mode
+                        .append_record(&record, &header)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                }
+
+                total_records += 1;
+                batch_record_count += 1;
+
+                if limit.is_some_and(|lim| total_records >= lim) {
+                    break 'regions;
+                }
+
+                if batch_record_count == effective_batch_size {
+                    let info_arrays = if flags.any_info {
+                        Some(builders_to_arrays(&mut info_builders.2))
+                    } else {
+                        None
+                    };
+                    let format_arrays = if has_format_fields && flags.any_format {
+                        Some(
+                            format_mode
+                                .finish_arrays()
+                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+                        )
+                    } else {
+                        None
+                    };
+                    effective_batch_size = adjust_effective_batch_size_by_observed_format_bytes(
+                        batch_size,
+                        effective_batch_size,
+                        flags.any_format,
+                        &source_sample_names,
+                        batch_record_count,
+                        format_arrays.as_ref(),
+                    );
+                    let core_arrays = builders.finish();
+                    let batch = build_record_batch_from_builders(
+                        Arc::clone(&schema),
+                        core_arrays,
+                        info_arrays.as_ref(),
+                        format_arrays.as_ref(),
+                        num_info_fields,
+                        &projection,
+                        batch_record_count,
+                    )?;
+
+                    yield batch;
+
+                    batch_record_count = 0;
                 }
             }
-
-            debug!(
-                "Indexed VCF scan: {} records for {} regions",
-                total_records,
-                regions.len()
-            );
-            Ok(())
-        };
-        if let Err(e) = read_and_send() {
-            let _ = tx.try_send(Err(datafusion::arrow::error::ArrowError::ExternalError(
-                Box::new(e),
-            )));
         }
-    });
 
-    // Stream batches from the channel
-    let stream = rx.map(|item| item.map_err(|e| DataFusionError::ArrowError(Box::new(e), None)));
+        // Remaining records
+        if batch_record_count > 0 {
+            let info_arrays = if flags.any_info {
+                Some(builders_to_arrays(&mut info_builders.2))
+            } else {
+                None
+            };
+            let format_arrays = if has_format_fields && flags.any_format {
+                Some(
+                    format_mode
+                        .finish_arrays()
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+                )
+            } else {
+                None
+            };
+            let core_arrays = builders.finish();
+            let batch = build_record_batch_from_builders(
+                Arc::clone(&schema),
+                core_arrays,
+                info_arrays.as_ref(),
+                format_arrays.as_ref(),
+                num_info_fields,
+                &projection,
+                batch_record_count,
+            )?;
+            yield batch;
+        }
+
+        debug!(
+            "Indexed VCF scan: {} records for {} regions",
+            total_records,
+            regions.len()
+        );
+    };
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema_ref, stream)))
 }
 

--- a/datafusion/bio-format-vcf/src/storage.rs
+++ b/datafusion/bio-format-vcf/src/storage.rs
@@ -729,10 +729,17 @@ impl VcfReader {
 
 /// A local indexed VCF reader for region-based queries.
 ///
-/// Uses noodles' `IndexedReader::Builder` to support random-access queries using TBI/CSI indexes.
-/// This is used when an index file is available and genomic region filters are present.
+/// Holds a plain BGZF-backed VCF reader plus a concrete tabix index to support
+/// random-access queries. This is used when an index file is available and genomic
+/// region filters are present.
+///
+/// Unlike noodles' `IndexedReader` (which stores the index as a non-`Send`
+/// `Box<dyn BinningIndex>`), this keeps the concrete `noodles_tabix::Index` so the
+/// reader is `Send`. That lets the indexed scan decode inline on the consuming tokio
+/// worker via `async_stream::try_stream!` instead of a dedicated reader thread.
 pub struct IndexedVcfReader {
-    reader: vcf::io::IndexedReader<noodles_bgzf_vcf::io::Reader<File>>,
+    reader: vcf::io::Reader<noodles_bgzf_vcf::io::Reader<File>>,
+    index: noodles_tabix::Index,
     header: vcf::Header,
 }
 
@@ -744,12 +751,14 @@ impl IndexedVcfReader {
     /// * `index_path` - Path to the TBI or CSI index file
     pub fn new(file_path: &str, index_path: &str) -> Result<Self, std::io::Error> {
         let index = noodles_tabix::fs::read(index_path)?;
-        let mut reader = vcf::io::indexed_reader::Builder::default()
-            .set_index(index)
-            .build_from_path(file_path)
-            .map_err(std::io::Error::other)?;
+        let inner = noodles_bgzf_vcf::io::Reader::new(File::open(file_path)?);
+        let mut reader = vcf::io::Reader::new(inner);
         let header = reader.read_header()?;
-        Ok(Self { reader, header })
+        Ok(Self {
+            reader,
+            index,
+            header,
+        })
     }
 
     /// Returns a reference to the VCF header.
@@ -771,7 +780,7 @@ impl IndexedVcfReader {
         &mut self,
         region: &noodles_core::Region,
     ) -> Result<impl Iterator<Item = Result<Record, std::io::Error>> + '_, std::io::Error> {
-        self.reader.query(&self.header, region)
+        self.reader.query(&self.header, &self.index, region)
     }
 }
 

--- a/docs/superpowers/plans/2026-07-04-issue-212-fold-reader-threads.md
+++ b/docs/superpowers/plans/2026-07-04-issue-212-fold-reader-threads.md
@@ -1,0 +1,342 @@
+# Issue #212 — Fold Reader Threads Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each scan use exactly `target_partitions` OS threads (not ~2×) by folding decompress+parse into each partition's own stream, removing the per-partition off-runtime `std::thread` reader + `mpsc` channel across all format crates.
+
+**Architecture:** Introduce one shared helper in `bio-format-core` — `sync_batch_stream(schema, next_batch)` — that turns a synchronous, blocking "produce one RecordBatch" closure into a `SendableRecordBatchStream`. Each partition's decompress+parse runs on the consuming tokio worker inside `poll_next`, so no reader thread escapes the runtime. Every crate keeps its own batch-producing closure (different noodles readers) but shares the adapter. Roll out one crate per phase, committing and stopping after each.
+
+**Tech Stack:** Rust, DataFusion 52/53, noodles 0.93, `futures::stream::unfold`, Arrow.
+
+## Global Constraints
+
+- Rust toolchain 1.88.0 (`rust-toolchain.toml`); code must pass `cargo fmt --all -- --check` and `cargo clippy`.
+- The contract change is intentional and must be documented: **`target_partitions` == number of OS threads a scan uses.** To saturate N cores, set `target_partitions = N` (previously N gave ~2N). Callers whose tokio runtime has fewer worker threads than `target_partitions` cap decompression parallelism at the worker count (this is the desired bounded behavior — note it in docs).
+- No new non-dev dependencies. Remove the throwaway benchmark scaffolding (`FASTQ_EXEC_MODE`, `FASTQ_READER_POOL`, `libc` dev-dep, `examples/thread_model_bench.rs`) as part of Phase 1.
+- Behavior must be identical to today for row counts, values, projection, `COUNT(*)` empty-projection, and `LIMIT`. Only the threading model and per-`target_partitions` wall time change.
+- Each phase ends with `cargo fmt`, `cargo clippy`, `cargo test -p <crate>` green, one commit, then STOP for review.
+
+---
+
+## Design rationale (from benchmarking, issue #212)
+
+Measured on `partial_reads.fastq.bgz` (523 MB BGZF, 26.5M reads), release + `target-cpu=native`, runtime workers = `target_partitions`, balanced reader∥consumer workload:
+
+| target_partitions | baseline eff-cores | fold eff-cores |
+|---:|---:|---:|
+| 1 | 2.00 | 1.00 |
+| 2 | 3.99 | 2.00 |
+| 4 | 7.96 | 3.99 |
+| 8 | 13.83 | 7.93 |
+
+At **equal core budget**, fold is ~18–19% *faster* than baseline (fold t=8 @ 8 cores = 2.37s vs baseline t=4 @ 8 cores = 2.91s) and uses less total CPU (~18s vs ~22s) — it avoids the cross-thread channel handoff. Fold also fixes the root complaint: decompression no longer escapes the caller's tokio runtime. Chosen over the bounded-pool option (which preserves the 2× and only caps it) because fold is simpler ("N == N"), more CPU-efficient, and directly bounds the escape.
+
+---
+
+## File Structure
+
+- **Create** `datafusion/bio-format-core/src/sync_stream.rs` — `sync_batch_stream` helper (shared by all crates).
+- **Modify** `datafusion/bio-format-core/src/lib.rs` — export `sync_stream`.
+- **Modify** each crate's `physical_exec.rs` — replace `thread::spawn` + `mpsc` reader with a `sync_batch_stream` + batch-producer closure.
+- **Modify** docs: `CLAUDE.md`, per-crate `physical_exec.rs` module doc, README thread-usage note.
+
+---
+
+## Phase 1 — Core helper + FASTQ (fold), cleanup scaffolding
+
+**Files:**
+- Create: `datafusion/bio-format-core/src/sync_stream.rs`
+- Modify: `datafusion/bio-format-core/src/lib.rs`
+- Modify: `datafusion/bio-format-fastq/src/physical_exec.rs`
+- Modify: `datafusion/bio-format-fastq/Cargo.toml` (remove `libc` dev-dep + `thread_model_bench` example entry)
+- Delete: `datafusion/bio-format-fastq/examples/thread_model_bench.rs`
+- Test: `datafusion/bio-format-fastq/src/physical_exec.rs` (`#[cfg(test)]` mod) or existing test file
+
+**Interfaces:**
+- Produces (core): `pub fn sync_batch_stream<F>(schema: SchemaRef, next_batch: F) -> SendableRecordBatchStream where F: FnMut() -> Option<Result<RecordBatch, DataFusionError>> + Send + 'static`
+- Consumes (fastq): the above, plus existing `build_batch_from_builders`.
+
+- [ ] **Step 1: Write failing test for the core helper**
+
+Add `datafusion/bio-format-core/src/sync_stream.rs` test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use futures::StreamExt;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn yields_batches_then_stops() {
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]));
+        let s = schema.clone();
+        let mut remaining = vec![3, 2, 1];
+        let stream = sync_batch_stream(schema, move || {
+            remaining.pop().map(|v| {
+                Ok(RecordBatch::try_new(s.clone(), vec![Arc::new(Int32Array::from(vec![v]))]).unwrap())
+            })
+        });
+        let batches: Vec<_> = stream.collect().await;
+        assert_eq!(batches.len(), 3);
+        let total: i32 = batches.iter().map(|b| b.as_ref().unwrap().num_rows() as i32).sum();
+        assert_eq!(total, 3);
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails to compile (`sync_batch_stream` undefined)**
+
+Run: `cargo test -p datafusion-bio-format-core sync_stream`
+Expected: FAIL — `cannot find function sync_batch_stream`.
+
+- [ ] **Step 3: Implement the helper**
+
+Top of `datafusion/bio-format-core/src/sync_stream.rs`:
+
+```rust
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+/// Build a [`SendableRecordBatchStream`] that pulls batches **synchronously** on
+/// the consuming task's thread — no dedicated reader thread, no channel.
+///
+/// Each `poll_next` invokes `next_batch` exactly once. Because the closure does
+/// its (blocking) decompression/parse work inline, that work runs on the same
+/// tokio worker that consumes the partition. A scan therefore uses exactly
+/// `target_partitions` OS threads instead of ~2× (issue #212).
+///
+/// `next_batch` returns `Some(Ok(batch))` for each batch, `Some(Err(_))` to
+/// surface an error (after which it should return `None`), and `None` when the
+/// partition is exhausted.
+pub fn sync_batch_stream<F>(schema: SchemaRef, next_batch: F) -> SendableRecordBatchStream
+where
+    F: FnMut() -> Option<Result<RecordBatch, DataFusionError>> + Send + 'static,
+{
+    let stream = futures::stream::unfold(next_batch, |mut next_batch| async move {
+        let item = next_batch()?;
+        Some((item, next_batch))
+    });
+    Box::pin(RecordBatchStreamAdapter::new(schema, stream))
+}
+```
+
+Add `pub mod sync_stream;` to `datafusion/bio-format-core/src/lib.rs` (alongside the other `pub mod` lines).
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `cargo test -p datafusion-bio-format-core sync_stream`
+Expected: PASS.
+
+- [ ] **Step 5: Commit the core helper**
+
+```bash
+git add datafusion/bio-format-core/src/sync_stream.rs datafusion/bio-format-core/src/lib.rs
+git commit -m "feat(core): add sync_batch_stream helper for single-thread partition reads (#212)"
+```
+
+- [ ] **Step 6: Add a FASTQ multi-partition correctness test (guards the refactor)**
+
+In `datafusion/bio-format-fastq` tests, add a test that scans a BGZF+GZI fixture with `target_partitions = 4` and asserts the total row count equals a single-partition read. Use an existing fixture if present (search `datafusion/bio-format-fastq` for `*.bgz`/`*.gzi`); otherwise generate a small BGZF fixture in the test via `noodles_bgzf`. Assert: (a) total rows across partitions == expected; (b) `SELECT sequence FROM t` values concatenated are identical between 1-partition and 4-partition scans.
+
+Run: `cargo test -p datafusion-bio-format-fastq` — Expected: PASS on current (baseline) code, so it locks in behavior before the refactor.
+
+- [ ] **Step 7: Replace the FASTQ reader model with fold**
+
+In `datafusion/bio-format-fastq/src/physical_exec.rs`:
+
+1. Delete the experimental scaffolding added during benchmarking: the `ExecMode` enum, `exec_mode()`, `reader_gate()`, `GatePermit`, `gate_acquire()`, and the standalone `execute_bgzf_partition_fold`. Delete `PARTITION_CHANNEL_BUFFER`, `read_and_send_batches`, and the `use futures::channel::mpsc;`, `use std::sync::{Condvar, Mutex, OnceLock};`, and `use std::thread;` imports.
+2. Add a shared, generic batch-producer that both strategies use:
+
+```rust
+/// Build a closure that decodes one RecordBatch per call from a positioned
+/// FASTQ reader. All work is synchronous; the closure is driven by
+/// `sync_batch_stream`, so it runs on the consuming tokio worker (issue #212).
+fn batch_producer<R: BufRead + Send + 'static>(
+    mut fastq_reader: fastq::io::Reader<R>,
+    mut is_past_end: impl FnMut(&mut fastq::io::Reader<R>) -> bool + Send + 'static,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    limit: Option<usize>,
+    batch_size: usize,
+) -> impl FnMut() -> Option<Result<RecordBatch, DataFusionError>> + Send + 'static {
+    let mut record = fastq::Record::default();
+    let mut total: usize = 0;
+    let mut done = false;
+    move || {
+        if done {
+            return None;
+        }
+        let proj = projection.as_ref();
+        let mut names = proj.is_none_or(|p| p.contains(&0)).then(StringBuilder::new);
+        let mut descriptions = proj.is_none_or(|p| p.contains(&1)).then(StringBuilder::new);
+        let mut sequences = proj.is_none_or(|p| p.contains(&2)).then(StringBuilder::new);
+        let mut quality_scores = proj.is_none_or(|p| p.contains(&3)).then(StringBuilder::new);
+
+        let mut count = 0usize;
+        while count < batch_size {
+            if limit.is_some_and(|l| total >= l) || is_past_end(&mut fastq_reader) {
+                done = true;
+                break;
+            }
+            match fastq_reader.read_record(&mut record) {
+                Ok(0) => {
+                    done = true;
+                    break;
+                }
+                Ok(_) => {
+                    if let Some(b) = &mut names {
+                        b.append_value(std::str::from_utf8(record.name()).unwrap());
+                    }
+                    if let Some(b) = &mut descriptions {
+                        if record.description().is_empty() {
+                            b.append_null();
+                        } else {
+                            b.append_value(std::str::from_utf8(record.description()).unwrap());
+                        }
+                    }
+                    if let Some(b) = &mut sequences {
+                        b.append_value(std::str::from_utf8(record.sequence()).unwrap());
+                    }
+                    if let Some(b) = &mut quality_scores {
+                        b.append_value(std::str::from_utf8(record.quality_scores()).unwrap());
+                    }
+                    count += 1;
+                    total += 1;
+                }
+                Err(e) => {
+                    done = true;
+                    return Some(Err(DataFusionError::External(Box::new(e))));
+                }
+            }
+        }
+        if count == 0 {
+            return None;
+        }
+        Some(build_batch_from_builders(
+            &schema, &projection,
+            &mut names, &mut descriptions, &mut sequences, &mut quality_scores,
+            count,
+        ))
+    }
+}
+```
+
+3. Rewrite `execute_bgzf_partition` to open+seek+synchronize the reader (as today), then return `sync_batch_stream(schema, batch_producer(...))` with `is_past_end = |r| r.get_ref().virtual_position().compressed() >= end_comp`. Drop the `partition` and `gated` params. No `thread::spawn`, no channel.
+4. Rewrite `execute_byte_range_partition` likewise with `is_past_end = |r| r.get_mut().stream_position().map(|p| p >= end_byte).unwrap_or(true)`.
+5. Update `execute()`'s BGZF/ByteRange match arms to call the simplified signatures (remove the `exec_mode()` dispatch added during benchmarking).
+6. `use datafusion_bio_format_core::sync_stream::sync_batch_stream;`.
+
+Note: `build_batch_from_builders` already handles the empty-projection (`COUNT(*)`) case by emitting a zero-column batch with `row_count`. The unified loop above counts rows for empty projections too, so the fast path in the old `read_and_send_batches` is no longer needed.
+
+- [ ] **Step 8: Remove benchmark scaffolding from Cargo.toml + delete example**
+
+In `datafusion/bio-format-fastq/Cargo.toml` remove the `libc = "0.2"` dev-dep and the `[[example]] name = "thread_model_bench"` block. Then:
+
+```bash
+rm datafusion/bio-format-fastq/examples/thread_model_bench.rs
+```
+
+- [ ] **Step 9: fmt, clippy, test**
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy -p datafusion-bio-format-fastq --all-targets 2>&1 | grep -E "warning|error" || echo clean
+cargo test -p datafusion-bio-format-fastq
+```
+Expected: fmt clean, no new clippy warnings, all tests PASS (including Step 6's multi-partition test — proving fold matches baseline output).
+
+- [ ] **Step 10: Update FASTQ + top-level docs with the thread-usage contract**
+
+In `datafusion/bio-format-fastq/src/physical_exec.rs` module/`FastqExec` doc, and in `CLAUDE.md` (new "Thread usage" subsection), state: a scan uses one OS thread per partition (`target_partitions`); decompression runs on the consuming runtime worker; to use N cores set `target_partitions = N`; parallelism is capped by the caller's tokio worker-thread count.
+
+- [ ] **Step 11: Commit Phase 1**
+
+```bash
+git add -A
+git commit -m "feat(fastq): fold decompression into partition stream; drop per-partition reader thread (#212)"
+```
+
+**STOP — await review.**
+
+---
+
+## Phase 2 — VCF
+
+**Files:** Modify `datafusion/bio-format-vcf/src/physical_exec.rs` (indexed reader thread at `:2659` in `get_indexed_vcf_stream`; single-partition sync at `:819` in `get_local_vcf_sync`; `STREAM_CHANNEL_BUFFERED_BATCHES` at `:73`).
+
+Apply Phase 1's transformation: replace each `thread::spawn` + `futures::channel::mpsc` reader with a synchronous `batch_producer`-style closure driven by `bio-format-core`'s `sync_batch_stream`. The VCF closure owns the noodles indexed reader and iterates its assigned genomic regions, yielding one Arrow batch per call (persist region-iterator state across calls). Remove now-dead channel/thread imports and the buffer const if unused. Keep all schema/projection/`INFO`/`FORMAT` handling byte-identical.
+
+**Acceptance:** `cargo test -p datafusion-bio-format-vcf` green; a 4-partition indexed scan returns the same rows as a 1-partition scan; `cargo clippy`/`fmt` clean. Commit `feat(vcf): fold reader into partition stream (#212)`. **STOP.**
+
+> Detailed TDD steps for this phase to be expanded at execution start, after reading `get_indexed_vcf_stream` in full (region-iteration state machine differs from FASTQ's linear read).
+
+---
+
+## Phase 3 — BAM
+
+**Files:** `datafusion/bio-format-bam/src/physical_exec.rs` (indexed thread `:888` in `get_indexed_stream`; sync `:383` in `get_local_bam_sync`; `mpsc::channel(2)` at `:381`/`:886`).
+
+Same transformation as Phase 2. BAM's closure owns the noodles BAM indexed reader + region assignment and yields one batch per call (tags/CIGAR/flags handling unchanged). **Acceptance/commit/STOP** as Phase 2 (`feat(bam): ...`).
+
+> Detailed steps expanded at execution start.
+
+---
+
+## Phase 4 — CRAM
+
+**Files:** `datafusion/bio-format-cram/src/physical_exec.rs` (indexed thread `:867` in `get_indexed_stream`; `mpsc::channel(2)` `:865`). Full-scan `get_local_cram` is already async — leave it.
+
+Same transformation. CRAM decoding stays on the consuming worker. Watch the noodles-fork `no_ref` behavior noted in project memory — do not change decode logic, only the threading wrapper. **Acceptance/commit/STOP** (`feat(cram): ...`).
+
+> Detailed steps expanded at execution start.
+
+---
+
+## Phase 5 — GFF
+
+**Files:** `datafusion/bio-format-gff/src/physical_exec.rs` (indexed thread `:1284` in `get_indexed_gff_stream`; `mpsc::channel(2)` `:1282`). **Acceptance/commit/STOP** (`feat(gff): ...`).
+
+> Detailed steps expanded at execution start.
+
+---
+
+## Phase 6 — GTF
+
+**Files:** `datafusion/bio-format-gtf/src/physical_exec.rs` (indexed thread `:729` in `get_indexed_gtf_stream`; `mpsc::channel(2)` `:727`). **Acceptance/commit/STOP** (`feat(gtf): ...`).
+
+> Detailed steps expanded at execution start.
+
+---
+
+## Phase 7 — Pairs
+
+**Files:** `datafusion/bio-format-pairs/src/physical_exec.rs` (indexed thread `:440` in `get_indexed_pairs_stream`; `mpsc::channel(2)` `:438`). **Acceptance/commit/STOP** (`feat(pairs): ...`).
+
+> Detailed steps expanded at execution start.
+
+---
+
+## Phase 8 — FASTA single-partition + BED verify + repo-wide contract doc
+
+**Files:** `datafusion/bio-format-fasta/src/physical_exec.rs` (sync reader thread `:291` in `get_local_fasta_sync`, single partition); `datafusion/bio-format-bed` (already fully async — verify, no code change); `CLAUDE.md`, workspace `README`.
+
+Convert FASTA's single-partition sync reader to `sync_batch_stream` for consistency (removes its 1 extra reader thread). Confirm BED needs no change. Add a repo-wide "Thread usage" doc section stating the uniform contract now holds across FASTQ/VCF/BAM/CRAM/GFF/GTF/pairs/FASTA. **Acceptance:** `cargo test` workspace-wide green; `cargo clippy`/`fmt` clean. Commit `docs+feat(fasta): uniform one-thread-per-partition reader contract (#212)`. **STOP.**
+
+> Detailed steps expanded at execution start.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** every per-partition `thread::spawn` reader site from the issue's crate map (VCF `:2659`, BAM `:888`, CRAM `:867`, GFF `:1284`, GTF `:729`, pairs `:440`, FASTQ `:548`/`:610`) plus single-partition fallbacks (VCF `:819`, BAM `:383`, FASTA `:291`) is assigned to a phase. BED (no thread) is verified in Phase 8. ✓
+- **Contract documented:** Phase 1 Step 10 + Phase 8. ✓
+- **Scaffolding removed:** Phase 1 Steps 7–8 remove `FASTQ_EXEC_MODE`/`FASTQ_READER_POOL`/`libc`/bench example. ✓
+- **Type consistency:** `sync_batch_stream` signature is fixed in Phase 1 and reused verbatim by Phases 2–8. ✓
+- **Note:** Phases 2–8 intentionally carry a just-in-time expansion marker rather than fabricated per-crate code — each crate's read loop (region-iteration state) must be read before writing its exact TDD steps. The transformation and target sites are fully specified.

--- a/openspec/changes/refactor-single-thread-partition-reads/design.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/design.md
@@ -1,0 +1,54 @@
+## Context
+
+Confirmed via a repo-wide audit (issue #212): each format crate's `physical_exec.rs` spawns one raw `std::thread` per DataFusion partition inside `execute()` on the indexed path, plus a single-thread fallback on the full-scan path. The thread opens the file, seeks to its region/byte range, decodes BGZF/format records, builds Arrow batches, and pushes them through a bounded `futures::channel::mpsc` to a `RecordBatchStreamAdapter`. Per-partition reader-thread sites: VCF `physical_exec.rs:2659`, BAM `:888`, CRAM `:867`, GFF `:1284`, GTF `:729`, pairs `:440`, FASTQ `:548`/`:610`. Single-partition fallbacks: VCF `:819`, BAM `:383`, FASTA `:291`. BED spawns nothing (fully async). The only shared infrastructure today is `bio-format-core::partition_balancer::balance_partitions`; the reader/channel loop is copy-reimplemented per crate.
+
+Because the reader threads are `std::thread`s, they run outside the consumer's Tokio runtime and are not counted against its worker budget. A caller that sizes its runtime to `target_partitions` still gets `target_partitions` extra decompressor threads → ~2·N cores.
+
+## Goals / Non-Goals
+
+- Goals:
+  - `target_partitions == number of OS threads a scan uses` (predictable, cappable by the caller's runtime).
+  - No regression in per-core throughput; ideally an improvement.
+  - One shared mechanism reused by every crate; minimal per-crate diff.
+  - Byte-identical query results.
+- Non-Goals:
+  - Removing parallelism (parallel decompression stays — it is just bounded by the runtime).
+  - Guaranteeing global row order across partitions (already unordered today).
+  - Changing partition planning (`balance_partitions`, BGZF block/byte-range splitting) or any decode logic.
+
+## Decisions
+
+- **Decision: Fold decompress+parse into the partition's own stream (one thread per partition).** Each `poll_next` synchronously decodes one batch on the consuming Tokio worker via a shared `sync_batch_stream(schema, next_batch)` helper. No reader thread, no channel.
+- **Alternatives considered:**
+  - *Baseline (status quo):* reader `std::thread` + `mpsc` per partition. Rejected — the ~2·N escape is the reported defect.
+  - *Bounded pool (Option 1):* keep the two-stage design but draw reader threads from a shared semaphore-bounded pool (default sized to `target_partitions`). Caps total threads but keeps the channel-handoff overhead and, at default, still uses ~2·N. Rejected as the primary design; fold is simpler and more efficient. (Prototyped and measured for comparison.)
+  - *`spawn_blocking`:* move readers onto the Tokio blocking pool. Still a second pool, not inherently tied to `target_partitions`. Rejected.
+
+### Supporting data
+
+523 MB BGZF FASTQ (26.5M reads), release + `target-cpu=native`, runtime workers = `target_partitions`, balanced reader∥consumer workload:
+
+| target_partitions | baseline eff-cores / wall | fold eff-cores / wall |
+|---:|---:|---:|
+| 1 | 2.00 / 11.01s | 1.00 / 17.84s |
+| 2 | 3.99 / 5.76s | 2.00 / 9.14s |
+| 4 | 7.96 / 2.91s | 3.99 / 4.66s |
+| 8 | 13.83 / 1.52s | 7.93 / 2.37s |
+
+At equal **core budget**, fold wins: fold t=8 (8 cores, 2.37s) vs baseline t=4 (8 cores, 2.91s) — ~18% faster, and lower total CPU (~18s vs ~22s) because it drops the cross-thread channel handoff. The bounded-pool prototype reproduced baseline numbers at default and capped total cores to ≈2·pool_size when throttled (e.g. `pool=2, t=8 → 4 eff-cores`), confirming it only bounds the escape rather than removing it.
+
+## Risks / Trade-offs
+
+- **Behavior change: wall time at a fixed `target_partitions` rises ~1.6×** (one thread instead of two). → Mitigation: documented contract change — set `target_partitions` to the desired core count (previously half). At equal cores fold is faster, so no throughput regression.
+- **`target_partitions > runtime worker_threads`** caps effective decompression parallelism at the worker count (fold blocks a worker during decode). → This is the *intended* bounded behavior; documented. Callers wanting N-way scan parallelism must provide ≥ N worker threads.
+- **Blocking a Tokio worker with CPU-heavy sync decode** is undesirable if the same runtime serves latency-sensitive async work. → Acceptable for the scan-dedicated runtimes these providers target; documented.
+
+## Migration Plan
+
+- Rollout is phased, one crate per commit, each independently testable and revertable on the feature branch (`fix/212-fold-reader-threads`): core helper + FASTQ first, then VCF, BAM, CRAM, GFF, GTF, pairs, then FASTA + docs.
+- Rollback: revert the per-crate commit; crates are independent after the shared helper lands.
+- Consumer migration: callers relying on the implicit 2× (e.g. benchmarks comparing "-t N" against single-reader tools) should set `target_partitions` to the intended core count.
+
+## Open Questions
+
+- Should `bio-format-core` also expose a small generic "region-iterating batch producer" to further DRY the noodles-indexed crates, or is per-crate closure state clearer? (Lean: keep per-crate closures; only the stream adapter is shared.)

--- a/openspec/changes/refactor-single-thread-partition-reads/proposal.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/proposal.md
@@ -1,0 +1,31 @@
+# Fold Partition Decompression Into The Scan Stream (Single Thread Per Partition)
+
+## Why
+
+Every indexed/parallel format reader currently spawns a dedicated `std::thread` per DataFusion partition that decompresses and parses records off the caller's Tokio runtime, feeding batches to the async compute stream through a bounded `mpsc` channel. Because these reader threads are raw `std::thread`s, they are **not** bounded by the consumer's runtime worker count, so a scan with `target_partitions = N` uses ~**2·N** busy OS threads (N reader threads + N compute streams). A downstream consumer (e.g. polars-bio) cannot cap total cores by sizing its Tokio runtime, and `target_partitions = N` silently oversubscribes on shared/CI nodes (issue #212).
+
+Benchmarking on a 523 MB BGZF FASTQ (26.5M reads) confirmed effective cores ≈ 2·`target_partitions`, and that folding read+decompress+compute onto one thread per partition uses exactly `target_partitions` cores while being ~18% **faster per core** (it drops the cross-thread channel handoff).
+
+## What Changes
+
+- Add a shared `sync_batch_stream` helper in `bio-format-core` that turns a synchronous "produce one RecordBatch" closure into a `SendableRecordBatchStream`, decoding each batch inline on the consuming Tokio worker.
+- Replace the per-partition `std::thread` + `mpsc` reader in every affected crate (FASTQ, VCF, BAM, CRAM, GFF, GTF, pairs) and the single-partition sync fallbacks (VCF, BAM, FASTA) with `sync_batch_stream`.
+- **BREAKING (performance contract):** a scan now uses **one OS thread per partition** (`target_partitions`), not ~2·`target_partitions`. To saturate N cores, set `target_partitions = N` (previously N used ~2N). Decompression parallelism is bounded by the caller's Tokio worker-thread count.
+- Preserve byte-identical results (rows, values, projection, `COUNT(*)` empty-projection, `LIMIT`) — only the threading model and per-`target_partitions` wall time change.
+- Document the uniform thread-usage contract across all format crates.
+
+## Impact
+
+- Affected specs: **NEW** `partition-thread-model` capability.
+- Affected code:
+  - `datafusion/bio-format-core/src/sync_stream.rs` (new), `lib.rs`
+  - `datafusion/bio-format-fastq/src/physical_exec.rs`
+  - `datafusion/bio-format-vcf/src/physical_exec.rs`
+  - `datafusion/bio-format-bam/src/physical_exec.rs`
+  - `datafusion/bio-format-cram/src/physical_exec.rs`
+  - `datafusion/bio-format-gff/src/physical_exec.rs`
+  - `datafusion/bio-format-gtf/src/physical_exec.rs`
+  - `datafusion/bio-format-pairs/src/physical_exec.rs`
+  - `datafusion/bio-format-fasta/src/physical_exec.rs`
+  - Docs: `CLAUDE.md`, workspace `README`
+- No breaking API changes. Existing SQL queries remain valid; only physical execution threading and per-`target_partitions` wall time change. BED already executes fully async (no reader thread) and needs no code change.

--- a/openspec/changes/refactor-single-thread-partition-reads/specs/partition-thread-model/spec.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/specs/partition-thread-model/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Single OS Thread Per Scan Partition
+
+Format scans SHALL decode each DataFusion physical partition on the Tokio worker that consumes it, and SHALL NOT spawn a dedicated off-runtime `std::thread` reader per partition. Decompression and record parsing MUST run inline in the partition's stream (`poll_next`), not on a separate thread bridged by a channel.
+
+#### Scenario: No off-runtime reader thread on the indexed path
+- **WHEN** an indexed or block/byte-range partitioned file is scanned
+- **THEN** the partition's `SendableRecordBatchStream` produces batches by decoding synchronously on the consuming worker
+- **AND** no `std::thread` is spawned and no `mpsc` channel bridges a reader thread to the stream.
+
+#### Scenario: Single-partition fallback
+- **WHEN** a file is read through a single-partition fallback path (non-seekable compression, remote store, or `target_partitions = 1`)
+- **THEN** the scan uses at most one OS thread for that partition's read and decode.
+
+### Requirement: Shared Synchronous Batch Stream Helper
+
+`bio-format-core` SHALL provide `sync_batch_stream(schema, next_batch)` that adapts a synchronous batch-producing closure into a `SendableRecordBatchStream`. Each poll SHALL invoke `next_batch` exactly once; `Some(Ok(batch))` yields a batch, `Some(Err(_))` surfaces an error, and `None` ends the stream. Every affected format crate SHALL construct its partition streams through this helper.
+
+#### Scenario: Yields batches then terminates
+- **WHEN** `next_batch` returns two batches followed by `None`
+- **THEN** the resulting stream yields exactly those two batches and then completes.
+
+#### Scenario: Error propagation
+- **WHEN** `next_batch` returns `Some(Err(e))`
+- **THEN** the stream yields that error to the consumer.
+
+### Requirement: Target-Partition Core Contract
+
+A scan SHALL use one OS thread per physical partition, so that setting `target_partitions = N` uses N cores for decode+compute. Decompression parallelism SHALL be bounded by the caller's Tokio runtime worker-thread count; when `target_partitions` exceeds the worker count, effective parallelism is capped at the worker count.
+
+#### Scenario: N cores for N target partitions
+- **WHEN** a BGZF-indexed file is scanned with `target_partitions = N` on a runtime with at least N worker threads
+- **THEN** the scan uses approximately N busy OS threads (not approximately 2·N).
+
+#### Scenario: Parallelism bounded by runtime workers
+- **WHEN** `target_partitions` is greater than the runtime's worker-thread count
+- **THEN** concurrent partition decode is limited to the worker-thread count
+- **AND** results remain complete and correct.
+
+### Requirement: Result Parity Across Partition Counts
+
+The threading change SHALL NOT alter query results. Row set, column values, empty-projection `COUNT(*)`, and `LIMIT` behavior MUST be identical to the previous reader-thread model and independent of `target_partitions`.
+
+#### Scenario: Multi-partition equals single-partition
+- **WHEN** the same file is scanned with `target_partitions = 1` and with `target_partitions = 4`
+- **THEN** both produce the same total row count and the same set of row values.
+
+#### Scenario: Empty projection COUNT
+- **WHEN** a `COUNT(*)`-style scan with an empty projection runs over multiple partitions
+- **THEN** the summed batch row counts equal the file's record count.
+
+#### Scenario: Limit honored
+- **WHEN** a scan specifies a row `LIMIT`
+- **THEN** the total emitted rows do not exceed the limit.
+
+### Requirement: Uniform Contract Across Format Crates
+
+The single-thread-per-partition contract SHALL apply uniformly to every format crate that reads records: FASTQ, VCF, BAM, CRAM, GFF, GTF, pairs, and FASTA. BED, which already executes fully asynchronously without a reader thread, SHALL remain unchanged and already satisfies the contract.
+
+#### Scenario: Indexed readers use the shared helper
+- **WHEN** any of FASTQ, VCF, BAM, CRAM, GFF, GTF, pairs, or FASTA executes a partition read
+- **THEN** it produces its stream via `sync_batch_stream` with no per-partition `std::thread` reader.
+
+#### Scenario: BED already compliant
+- **WHEN** a BED table is scanned
+- **THEN** it decodes on the consuming runtime worker with no dedicated reader thread and requires no code change.

--- a/openspec/changes/refactor-single-thread-partition-reads/specs/partition-thread-model/spec.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/specs/partition-thread-model/spec.md
@@ -13,17 +13,22 @@ Format scans SHALL decode each DataFusion physical partition on the Tokio worker
 - **WHEN** a file is read through a single-partition fallback path (non-seekable compression, remote store, or `target_partitions = 1`)
 - **THEN** the scan uses at most one OS thread for that partition's read and decode.
 
-### Requirement: Shared Synchronous Batch Stream Helper
+### Requirement: Inline Decode Mechanisms
 
-`bio-format-core` SHALL provide `sync_batch_stream(schema, next_batch)` that adapts a synchronous batch-producing closure into a `SendableRecordBatchStream`. Each poll SHALL invoke `next_batch` exactly once; `Some(Ok(batch))` yields a batch, `Some(Err(_))` surfaces an error, and `None` ends the stream. Every affected format crate SHALL construct its partition streams through this helper.
+`bio-format-core` SHALL provide `sync_batch_stream(schema, next_batch)` that adapts a synchronous batch-producing closure into a `SendableRecordBatchStream`. Each poll SHALL invoke `next_batch` exactly once; `Some(Ok(batch))` yields a batch, `Some(Err(_))` surfaces an error, and `None` ends the stream. Format crates with a linear record reader SHALL construct their partition streams through this helper. Format crates whose partition read iterates multiple genomic regions MAY instead use an `async_stream` generator (`try_stream!`/`stream!`) that yields batches from the same synchronous loop; both mechanisms decode inline on the consuming worker with no per-partition reader thread and satisfy the single-thread-per-partition contract.
 
-#### Scenario: Yields batches then terminates
+#### Scenario: Helper yields batches then terminates
 - **WHEN** `next_batch` returns two batches followed by `None`
 - **THEN** the resulting stream yields exactly those two batches and then completes.
 
-#### Scenario: Error propagation
+#### Scenario: Helper error propagation
 - **WHEN** `next_batch` returns `Some(Err(e))`
 - **THEN** the stream yields that error to the consumer.
+
+#### Scenario: Generator form for region-iterating readers
+- **WHEN** a region-iterating partition read is expressed as an `async_stream` generator that yields one batch per completed batch buffer
+- **THEN** its decode work runs on the consuming worker with no spawned reader thread
+- **AND** it produces the same batches the channel-based reader produced.
 
 ### Requirement: Target-Partition Core Contract
 
@@ -58,9 +63,9 @@ The threading change SHALL NOT alter query results. Row set, column values, empt
 
 The single-thread-per-partition contract SHALL apply uniformly to every format crate that reads records: FASTQ, VCF, BAM, CRAM, GFF, GTF, pairs, and FASTA. BED, which already executes fully asynchronously without a reader thread, SHALL remain unchanged and already satisfies the contract.
 
-#### Scenario: Indexed readers use the shared helper
+#### Scenario: Indexed readers decode inline
 - **WHEN** any of FASTQ, VCF, BAM, CRAM, GFF, GTF, pairs, or FASTA executes a partition read
-- **THEN** it produces its stream via `sync_batch_stream` with no per-partition `std::thread` reader.
+- **THEN** it produces its stream via `sync_batch_stream` or an `async_stream` generator, with no per-partition `std::thread` reader.
 
 #### Scenario: BED already compliant
 - **WHEN** a BED table is scanned

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -1,0 +1,37 @@
+## 1. Core helper + FASTQ (Phase 1)
+- [ ] 1.1 Add `sync_batch_stream(schema, next_batch)` in `bio-format-core/src/sync_stream.rs` with a unit test; export from `lib.rs`
+- [ ] 1.2 Add a FASTQ multi-partition correctness test (4-partition scan == 1-partition scan) against current code
+- [ ] 1.3 Replace FASTQ `execute_bgzf_partition` / `execute_byte_range_partition` with a synchronous `batch_producer` closure driven by `sync_batch_stream`; remove `thread::spawn` + `mpsc`
+- [ ] 1.4 Remove benchmark scaffolding: `FASTQ_EXEC_MODE`/`FASTQ_READER_POOL` modes, `libc` dev-dep, `examples/thread_model_bench.rs`
+- [ ] 1.5 `cargo fmt` + `cargo clippy` + `cargo test -p datafusion-bio-format-fastq` green
+- [ ] 1.6 Document the thread-usage contract in FASTQ module doc + `CLAUDE.md`; commit; STOP for review
+
+## 2. VCF (Phase 2)
+- [ ] 2.1 Convert `get_indexed_vcf_stream` (`:2659`) and `get_local_vcf_sync` (`:819`) to `sync_batch_stream`; remove channel/thread
+- [ ] 2.2 4-partition == 1-partition parity test; `cargo test -p datafusion-bio-format-vcf` green; commit; STOP
+
+## 3. BAM (Phase 3)
+- [ ] 3.1 Convert `get_indexed_stream` (`:888`) and `get_local_bam_sync` (`:383`) to `sync_batch_stream`
+- [ ] 3.2 Parity test; `cargo test -p datafusion-bio-format-bam` green; commit; STOP
+
+## 4. CRAM (Phase 4)
+- [ ] 4.1 Convert `get_indexed_stream` (`:867`) to `sync_batch_stream` (leave already-async full scan; preserve `no_ref` decode)
+- [ ] 4.2 Parity test; `cargo test -p datafusion-bio-format-cram` green; commit; STOP
+
+## 5. GFF (Phase 5)
+- [ ] 5.1 Convert `get_indexed_gff_stream` (`:1284`) to `sync_batch_stream`
+- [ ] 5.2 Parity test; `cargo test -p datafusion-bio-format-gff` green; commit; STOP
+
+## 6. GTF (Phase 6)
+- [ ] 6.1 Convert `get_indexed_gtf_stream` (`:729`) to `sync_batch_stream`
+- [ ] 6.2 Parity test; `cargo test -p datafusion-bio-format-gtf` green; commit; STOP
+
+## 7. Pairs (Phase 7)
+- [ ] 7.1 Convert `get_indexed_pairs_stream` (`:440`) to `sync_batch_stream`
+- [ ] 7.2 Parity test; `cargo test -p datafusion-bio-format-pairs` green; commit; STOP
+
+## 8. FASTA + BED + repo-wide docs (Phase 8)
+- [ ] 8.1 Convert FASTA `get_local_fasta_sync` (`:291`, single partition) to `sync_batch_stream`
+- [ ] 8.2 Verify BED needs no change (already fully async)
+- [ ] 8.3 Add repo-wide "Thread usage" contract section to `CLAUDE.md` + `README`
+- [ ] 8.4 Workspace-wide `cargo test` + `clippy` + `fmt` green; commit; STOP

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -19,16 +19,16 @@
 - [x] 4.2 Parity test; `cargo test -p datafusion-bio-format-cram` green; commit; STOP
 
 ## 5. GFF (Phase 5)
-- [ ] 5.1 Convert `get_indexed_gff_stream` (`:1284`) to `sync_batch_stream`
-- [ ] 5.2 Parity test; `cargo test -p datafusion-bio-format-gff` green; commit; STOP
+- [x] 5.1 Convert `get_indexed_gff_stream` (`:1284`) to `sync_batch_stream`
+- [x] 5.2 Parity test; `cargo test -p datafusion-bio-format-gff` green; commit; STOP
 
 ## 6. GTF (Phase 6)
-- [ ] 6.1 Convert `get_indexed_gtf_stream` (`:729`) to `sync_batch_stream`
-- [ ] 6.2 Parity test; `cargo test -p datafusion-bio-format-gtf` green; commit; STOP
+- [x] 6.1 Convert `get_indexed_gtf_stream` (`:729`) to `sync_batch_stream`
+- [x] 6.2 Parity test; `cargo test -p datafusion-bio-format-gtf` green; commit; STOP
 
 ## 7. Pairs (Phase 7)
-- [ ] 7.1 Convert `get_indexed_pairs_stream` (`:440`) to `sync_batch_stream`
-- [ ] 7.2 Parity test; `cargo test -p datafusion-bio-format-pairs` green; commit; STOP
+- [x] 7.1 Convert `get_indexed_pairs_stream` (`:440`) to `sync_batch_stream`
+- [x] 7.2 Parity test; `cargo test -p datafusion-bio-format-pairs` green; commit; STOP
 
 ## 8. FASTA + BED + repo-wide docs (Phase 8)
 - [ ] 8.1 Convert FASTA `get_local_fasta_sync` (`:291`, single partition) to `sync_batch_stream`

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Core helper + FASTQ (Phase 1)
-- [ ] 1.1 Add `sync_batch_stream(schema, next_batch)` in `bio-format-core/src/sync_stream.rs` with a unit test; export from `lib.rs`
-- [ ] 1.2 Add a FASTQ multi-partition correctness test (4-partition scan == 1-partition scan) against current code
-- [ ] 1.3 Replace FASTQ `execute_bgzf_partition` / `execute_byte_range_partition` with a synchronous `batch_producer` closure driven by `sync_batch_stream`; remove `thread::spawn` + `mpsc`
-- [ ] 1.4 Remove benchmark scaffolding: `FASTQ_EXEC_MODE`/`FASTQ_READER_POOL` modes, `libc` dev-dep, `examples/thread_model_bench.rs`
-- [ ] 1.5 `cargo fmt` + `cargo clippy` + `cargo test -p datafusion-bio-format-fastq` green
-- [ ] 1.6 Document the thread-usage contract in FASTQ module doc + `CLAUDE.md`; commit; STOP for review
+- [x] 1.1 Add `sync_batch_stream(schema, next_batch)` in `bio-format-core/src/sync_stream.rs` with a unit test; export from `lib.rs`
+- [x] 1.2 Add a FASTQ multi-partition correctness test (4-partition scan == 1-partition scan) against current code
+- [x] 1.3 Replace FASTQ `execute_bgzf_partition` / `execute_byte_range_partition` with a synchronous `batch_producer` closure driven by `sync_batch_stream`; remove `thread::spawn` + `mpsc`
+- [x] 1.4 Remove benchmark scaffolding: `FASTQ_EXEC_MODE`/`FASTQ_READER_POOL` modes, `libc` dev-dep, `examples/thread_model_bench.rs`
+- [x] 1.5 `cargo fmt` + `cargo clippy` + `cargo test -p datafusion-bio-format-fastq` green
+- [x] 1.6 Document the thread-usage contract in FASTQ module doc + `CLAUDE.md`; commit; STOP for review
 
 ## 2. VCF (Phase 2)
 - [ ] 2.1 Convert `get_indexed_vcf_stream` (`:2659`) and `get_local_vcf_sync` (`:819`) to `sync_batch_stream`; remove channel/thread

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -15,8 +15,8 @@
 - [x] 3.2 Parity test; `cargo test -p datafusion-bio-format-bam` green; commit; STOP
 
 ## 4. CRAM (Phase 4)
-- [ ] 4.1 Convert `get_indexed_stream` (`:867`) to `sync_batch_stream` (leave already-async full scan; preserve `no_ref` decode)
-- [ ] 4.2 Parity test; `cargo test -p datafusion-bio-format-cram` green; commit; STOP
+- [x] 4.1 Convert `get_indexed_stream` (`:867`) to `sync_batch_stream` (leave already-async full scan; preserve `no_ref` decode)
+- [x] 4.2 Parity test; `cargo test -p datafusion-bio-format-cram` green; commit; STOP
 
 ## 5. GFF (Phase 5)
 - [ ] 5.1 Convert `get_indexed_gff_stream` (`:1284`) to `sync_batch_stream`

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -11,8 +11,8 @@
 - [x] 2.2 4-partition == 1-partition parity test; `cargo test -p datafusion-bio-format-vcf` green; commit; STOP
 
 ## 3. BAM (Phase 3)
-- [ ] 3.1 Convert `get_indexed_stream` (`:888`) and `get_local_bam_sync` (`:383`) to `sync_batch_stream`
-- [ ] 3.2 Parity test; `cargo test -p datafusion-bio-format-bam` green; commit; STOP
+- [x] 3.1 Convert `get_indexed_stream` (`:888`) and `get_local_bam_sync` (`:383`) to `sync_batch_stream`
+- [x] 3.2 Parity test; `cargo test -p datafusion-bio-format-bam` green; commit; STOP
 
 ## 4. CRAM (Phase 4)
 - [ ] 4.1 Convert `get_indexed_stream` (`:867`) to `sync_batch_stream` (leave already-async full scan; preserve `no_ref` decode)

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -7,8 +7,8 @@
 - [x] 1.6 Document the thread-usage contract in FASTQ module doc + `CLAUDE.md`; commit; STOP for review
 
 ## 2. VCF (Phase 2)
-- [ ] 2.1 Convert `get_indexed_vcf_stream` (`:2659`) and `get_local_vcf_sync` (`:819`) to `sync_batch_stream`; remove channel/thread
-- [ ] 2.2 4-partition == 1-partition parity test; `cargo test -p datafusion-bio-format-vcf` green; commit; STOP
+- [x] 2.1 Convert `get_indexed_vcf_stream` (`:2659`) and `get_local_vcf_sync` (`:819`) to `sync_batch_stream`; remove channel/thread
+- [x] 2.2 4-partition == 1-partition parity test; `cargo test -p datafusion-bio-format-vcf` green; commit; STOP
 
 ## 3. BAM (Phase 3)
 - [ ] 3.1 Convert `get_indexed_stream` (`:888`) and `get_local_bam_sync` (`:383`) to `sync_batch_stream`

--- a/openspec/changes/refactor-single-thread-partition-reads/tasks.md
+++ b/openspec/changes/refactor-single-thread-partition-reads/tasks.md
@@ -31,7 +31,7 @@
 - [x] 7.2 Parity test; `cargo test -p datafusion-bio-format-pairs` green; commit; STOP
 
 ## 8. FASTA + BED + repo-wide docs (Phase 8)
-- [ ] 8.1 Convert FASTA `get_local_fasta_sync` (`:291`, single partition) to `sync_batch_stream`
-- [ ] 8.2 Verify BED needs no change (already fully async)
-- [ ] 8.3 Add repo-wide "Thread usage" contract section to `CLAUDE.md` + `README`
-- [ ] 8.4 Workspace-wide `cargo test` + `clippy` + `fmt` green; commit; STOP
+- [x] 8.1 Convert FASTA `get_local_fasta_sync` (`:291`, single partition) to `sync_batch_stream`
+- [x] 8.2 Verify BED needs no change (already fully async)
+- [x] 8.3 Add repo-wide "Thread usage" contract section to `CLAUDE.md` + `README`
+- [x] 8.4 Workspace-wide `cargo test` + `clippy` + `fmt` green; commit; STOP


### PR DESCRIPTION
## Summary

Fixes #212. Every format reader crate now decodes each DataFusion partition **inline on the consuming tokio worker** — no per-partition off-runtime `std::thread` reader and no `mpsc` channel handoff. A scan uses **one OS thread per partition** (`target_partitions`) instead of `~2×`, so `target_partitions = N` means N cores and a downstream consumer can bound total cores by sizing its runtime.

### Why

Every indexed/parallel reader spawned a raw `std::thread` per partition that decompressed+parsed off the caller's tokio runtime and pushed batches through a bounded `mpsc` channel. Because the reader threads were raw `std::thread`s, they escaped the consumer's runtime worker budget → a scan with `target_partitions = N` used `~2·N` busy OS threads and silently oversubscribed shared/CI nodes.

### What changed

- New `bio-format-core::sync_stream::sync_batch_stream(schema, next_batch)` — adapts a synchronous batch-producing closure into a `SendableRecordBatchStream`.
- **fastq** / **fasta** (linear readers): use `sync_batch_stream`.
- **vcf** / **bam** / **cram** / **gff** / **gtf** / **pairs** (region-iterating readers): fold the existing read loop into an `async_stream::try_stream!` generator (channel sends → `yield`, thread dropped).
- **vcf** / **bam**: restructured their `Indexed*Reader` to hold the concrete (`Send`) index (`noodles_tabix::Index` / `bam::bai::Index`) instead of a boxed `dyn BinningIndex`, so the generator is `Send`. Query behavior identical.
- **bed** already executes fully async — no change.
- Docs: thread-usage contract in `CLAUDE.md`, `README` streaming-I/O section, and `FastqExec` doc.

Both mechanisms decode inline on the consuming worker and satisfy the same contract; the OpenSpec change (`openspec/changes/refactor-single-thread-partition-reads/`) documents it and was broadened to permit the generator form.

### Contract change (behavioral, not API)

`target_partitions == number of OS threads a scan uses`. To saturate N cores, set `target_partitions = N` (previously N used `~2N`). Decode parallelism is bounded by the caller's tokio worker-thread count. **No SQL/API changes** — existing queries are unaffected; only physical threading and per-`target_partitions` wall time change.

### Evidence (benchmark, 523 MB BGZF FASTQ, 26.5M reads, release + `target-cpu=native`)

| target_partitions | baseline eff-cores / wall | fold eff-cores / wall |
|---:|---:|---:|
| 1 | 2.00 / 11.01s | 1.00 / 17.84s |
| 2 | 3.99 / 5.76s | 2.00 / 9.14s |
| 4 | 7.96 / 2.91s | 3.99 / 4.66s |
| 8 | 13.83 / 1.52s | 7.93 / 2.37s |

At **equal core budget** fold is ~18% faster (fold t=8 @ 8 cores = 2.37s vs baseline t=4 @ 8 cores = 2.91s) and uses less total CPU — it drops the cross-thread channel handoff. A bounded-pool alternative was prototyped and rejected (it only caps the `~2×` rather than removing the escape).

## Testing

- Every crate's full test suite passes, including multi-partition indexed-scan parity tests and a new FASTQ cross-partition value-parity guard (`test_bgzf_values_identical_across_partition_counts`) asserting identical `(name, sequence, quality)` rows at `target_partitions` 1 vs 4.
- `cargo build --workspace`, `cargo clippy`, and `cargo fmt --all -- --check` clean.
- Repo-wide grep confirms zero `thread::spawn` remain in any `physical_exec.rs`.
- Results verified byte-identical; effective-cores figures above are from the prototype fold (functionally identical to the shipped code).

## Commits (one per phase)

core helper → fastq → vcf → bam → cram → gff → gtf → pairs → fasta+docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
