### PR TITLE
Add PLINK 1 genotype provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +794,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +829,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -950,6 +1014,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1398,6 +1500,24 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "datafusion-bio-format-plink1"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "criterion",
+ "datafusion",
+ "datafusion-bio-format-core",
+ "futures-util",
+ "opendal",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -2894,6 +3014,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3865,6 +3996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opendal"
 version = "0.55.0"
 source = "git+https://github.com/apache/opendal.git?rev=1755db1da44e0aad050cb1d62aebbb0b64266037#1755db1da44e0aad050cb1d62aebbb0b64266037"
@@ -4297,6 +4434,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -5545,6 +5710,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [ "datafusion/bio-format-bam", "datafusion/bio-format-bbi", "datafusio
     "datafusion/bio-format-core", "datafusion/bio-format-fastq", "datafusion/bio-format-gff",
     "datafusion/bio-format-gtf", "datafusion/bio-format-vcf", "datafusion/bio-format-fasta",
     "datafusion/bio-format-cram", "datafusion/bio-format-pairs", "datafusion/bio-format-ensembl-cache",
+    "datafusion/bio-format-plink1",
     "benchmarks/common", "benchmarks/runner",
 ]
 

--- a/datafusion/bio-format-plink1/CONFORMANCE.md
+++ b/datafusion/bio-format-plink1/CONFORMANCE.md
@@ -1,0 +1,41 @@
+# PLINK 1 conformance
+
+The test strategy has four layers:
+
+1. Unit tests exhaustively cover the four two-bit BED states, padding masks,
+   checked size arithmetic, and exact filter classification.
+2. Integration fixtures exercise DataFusion projection, exact BIM filters,
+   limits, selected and reordered samples, Arrow metadata, and contextual
+   malformed-input errors.
+3. A local HTTP range server verifies that registration reads only the BED
+   header, metadata-only queries read no BED payload, and sparse ID queries
+   fetch only the selected fixed-width payload.
+4. External-oracle tests read the same generated fileset with the independent
+   Apache-2.0 `bed-reader` implementation and PLINK `--recode A`, then compare
+   every A1 dosage and missing call.
+
+The normal test suite skips the external oracle when it is not installed:
+
+```shell
+cargo test -p datafusion-bio-format-plink1
+```
+
+CI conformance jobs install the pinned oracle and require it:
+
+```shell
+python3 -m pip install \
+  'bed-reader @ git+https://github.com/fastlmm/bed-reader.git@0128fc755745c8e1cbe49d677479e5cfc3b2f49e'
+REQUIRE_PLINK_ORACLE=1 \
+  cargo test -p datafusion-bio-format-plink1 differential_against_bed_reader
+```
+
+The PLINK CLI oracle is also opt-in:
+
+```shell
+REQUIRE_PLINK_CLI_ORACLE=1 \
+  cargo test -p datafusion-bio-format-plink1 differential_against_plink
+```
+
+`snputils` can be added as another process-level oracle over the same fixtures.
+All reference readers remain test-only executables and are not linked into the
+Rust provider.

--- a/datafusion/bio-format-plink1/Cargo.toml
+++ b/datafusion/bio-format-plink1/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "datafusion-bio-format-plink1"
+version = "0.1.0"
+description = "PLINK 1 BED/BIM/FAM genotype support for Apache DataFusion"
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+readme = "README.md"
+
+[dependencies]
+async-stream.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+datafusion.workspace = true
+datafusion-bio-format-core = { path = "../bio-format-core" }
+futures-util.workspace = true
+opendal.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util"] }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
+tempfile = "3"
+tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
+
+[[bench]]
+name = "plink1_scan"
+harness = false

--- a/datafusion/bio-format-plink1/README.md
+++ b/datafusion/bio-format-plink1/README.md
@@ -1,0 +1,42 @@
+# datafusion-bio-format-plink1
+
+Read-only Apache DataFusion table provider for current, variant-major PLINK 1
+binary filesets (`.bed`, `.bim`, and `.fam`).
+
+One output row represents one BIM variant. The `genotypes.GT` list contains
+nullable A1 dosages in selected FAM sample order:
+
+| BED code | A1 dosage |
+| --- | --- |
+| `00` | 2 |
+| `10` | 1 |
+| `11` | 0 |
+| `01` | null |
+
+```rust,no_run
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use datafusion_bio_format_plink1::{PlinkReadOptions, PlinkTableProvider};
+
+# async fn example() -> datafusion::common::Result<()> {
+let provider = PlinkTableProvider::try_new(
+    "cohort.bed",
+    PlinkReadOptions::default(),
+)
+.await?;
+
+let context = SessionContext::new();
+context.register_table("cohort", Arc::new(provider))?;
+let batches = context
+    .sql("SELECT id, genotypes FROM cohort WHERE chrom = '1'")
+    .await?
+    .collect()
+    .await?;
+# Ok(())
+# }
+```
+
+The default sample identifier is the FAM IID and must be unique. Use
+`SampleIdMode::FidIid` for an escaped `FID:IID` identifier when IIDs are
+ambiguous. Percent and colon characters are escaped as `%25` and `%3A`.

--- a/datafusion/bio-format-plink1/benches/plink1_scan.rs
+++ b/datafusion/bio-format-plink1/benches/plink1_scan.rs
@@ -1,0 +1,162 @@
+use std::fs;
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_plink1::{PlinkReadOptions, PlinkTableProvider};
+use tempfile::TempDir;
+
+const VARIANT_COUNT: usize = 4_096;
+const SAMPLE_COUNT: usize = 256;
+
+struct Fixture {
+    _directory: TempDir,
+    bed_path: String,
+}
+
+fn create_fixture() -> Fixture {
+    let directory = tempfile::tempdir().unwrap();
+    let prefix = directory.path().join("benchmark");
+    let bed = prefix.with_extension("bed");
+    let mut bim = String::new();
+    for variant in 0..VARIANT_COUNT {
+        let chrom = if variant < VARIANT_COUNT / 2 {
+            "1"
+        } else {
+            "2"
+        };
+        bim.push_str(&format!("{chrom} rs{variant} 0 {} A C\n", variant + 1));
+    }
+    let mut fam = String::new();
+    for sample in 0..SAMPLE_COUNT {
+        fam.push_str(&format!("f sample{sample} 0 0 0 -9\n"));
+    }
+    let bytes_per_variant = SAMPLE_COUNT.div_ceil(4);
+    let mut payload = vec![0x6c, 0x1b, 0x01];
+    payload.reserve(VARIANT_COUNT * bytes_per_variant);
+    for variant in 0..VARIANT_COUNT {
+        for byte_index in 0..bytes_per_variant {
+            let mut byte = 0_u8;
+            for slot in 0..4 {
+                let sample = byte_index * 4 + slot;
+                let code = [0b00, 0b10, 0b11, 0b01][(variant + sample) % 4];
+                byte |= code << (slot * 2);
+            }
+            payload.push(byte);
+        }
+    }
+    fs::write(prefix.with_extension("bim"), bim).unwrap();
+    fs::write(prefix.with_extension("fam"), fam).unwrap();
+    fs::write(&bed, payload).unwrap();
+    Fixture {
+        _directory: directory,
+        bed_path: bed.to_string_lossy().into_owned(),
+    }
+}
+
+async fn context(
+    fixture: &Fixture,
+    name: &str,
+    options: PlinkReadOptions,
+    target_partitions: usize,
+) -> SessionContext {
+    let provider = PlinkTableProvider::try_new(&fixture.bed_path, options)
+        .await
+        .unwrap();
+    let context = SessionContext::new_with_config(
+        SessionConfig::new().with_target_partitions(target_partitions),
+    );
+    context.register_table(name, Arc::new(provider)).unwrap();
+    context
+}
+
+async fn execute(context: &SessionContext, sql: &str) -> usize {
+    context
+        .sql(sql)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap()
+        .iter()
+        .map(|batch| batch.num_rows())
+        .sum()
+}
+
+fn benchmarks(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let fixture = create_fixture();
+    let dense = runtime.block_on(context(&fixture, "dense", PlinkReadOptions::default(), 1));
+    let sparse_samples = runtime.block_on(context(
+        &fixture,
+        "sparse_samples",
+        PlinkReadOptions {
+            samples: Some(vec![
+                "sample1".to_string(),
+                "sample127".to_string(),
+                "sample255".to_string(),
+            ]),
+            ..Default::default()
+        },
+        1,
+    ));
+    let coalesced = runtime.block_on(context(
+        &fixture,
+        "coalesced",
+        PlinkReadOptions {
+            max_range_gap: (SAMPLE_COUNT.div_ceil(4) * 7) as u64,
+            ..Default::default()
+        },
+        1,
+    ));
+    let parallel = runtime.block_on(context(
+        &fixture,
+        "parallel",
+        PlinkReadOptions::default(),
+        4,
+    ));
+    let sparse_ids = (0..VARIANT_COUNT)
+        .step_by(8)
+        .map(|variant| format!("'rs{variant}'"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let mut group = criterion.benchmark_group("plink1_scan");
+    group.bench_function("dense_genotypes", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&dense, "SELECT genotypes FROM dense").await) });
+    });
+    group.bench_function("metadata_only", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&dense, "SELECT chrom, id FROM dense").await) });
+    });
+    group.bench_function("sparse_samples", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            black_box(execute(&sparse_samples, "SELECT genotypes FROM sparse_samples").await)
+        });
+    });
+    let sparse_sql = format!("SELECT genotypes FROM dense WHERE id IN ({sparse_ids})");
+    group.bench_function("sparse_variants", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&dense, &sparse_sql).await) });
+    });
+    let coalesced_sql = format!("SELECT genotypes FROM coalesced WHERE id IN ({sparse_ids})");
+    group.bench_function("range_coalescing", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&coalesced, &coalesced_sql).await) });
+    });
+    group.bench_function("parallel_scan_4", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            black_box(execute(&parallel, "SELECT genotypes FROM parallel").await)
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmarks);
+criterion_main!(benches);

--- a/datafusion/bio-format-plink1/src/fileset.rs
+++ b/datafusion/bio-format-plink1/src/fileset.rs
@@ -1,0 +1,489 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use datafusion::common::{DataFusionError, Result};
+use datafusion_bio_format_core::companion::{CompanionRule, resolve_companion, sanitize_location};
+use datafusion_bio_format_core::genotype::{CoordinateSystem, SampleSelection};
+use datafusion_bio_format_core::object_storage::{
+    ObjectStorageOptions, RemoteObject, StorageType, get_storage_type,
+};
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+use crate::table_provider::{PlinkReadOptions, SampleIdMode};
+
+pub(crate) const BED_HEADER_LEN: u64 = 3;
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct FamIdentity {
+    pub(crate) fid: String,
+    pub(crate) iid: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BimVariant {
+    pub(crate) chrom: String,
+    pub(crate) id: Option<String>,
+    pub(crate) cm: f64,
+    pub(crate) start: u64,
+    pub(crate) end: u64,
+    pub(crate) a1: String,
+    pub(crate) a2: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PlinkFileset {
+    pub(crate) bed_path: String,
+    pub(crate) bim_path: String,
+    pub(crate) fam_path: String,
+    pub(crate) variants: Arc<Vec<BimVariant>>,
+    pub(crate) selected_samples: SampleSelection,
+    pub(crate) selected_identities: Arc<Vec<FamIdentity>>,
+    pub(crate) sample_count: usize,
+    pub(crate) bytes_per_variant: u64,
+    pub(crate) object_storage_options: ObjectStorageOptions,
+    pub(crate) companion_bytes: u64,
+}
+
+pub(crate) enum PlinkRangeReader {
+    Local(tokio::fs::File),
+    Remote(RemoteObject),
+}
+
+impl PlinkRangeReader {
+    pub(crate) async fn open(path: &str, options: &ObjectStorageOptions) -> Result<Self> {
+        match get_storage_type(path.to_string()) {
+            StorageType::LOCAL => tokio::fs::File::open(local_path(path)?)
+                .await
+                .map(Self::Local)
+                .map_err(|error| io_error("open", path, error)),
+            _ => RemoteObject::open(path.to_string(), options.clone())
+                .await
+                .map(Self::Remote)
+                .map_err(|error| external_error("open", path, error)),
+        }
+    }
+
+    pub(crate) async fn read_range(
+        &mut self,
+        path: &str,
+        range: std::ops::Range<u64>,
+    ) -> Result<Bytes> {
+        let expected = usize::try_from(range.end.saturating_sub(range.start)).map_err(|_| {
+            DataFusionError::Execution(
+                "PLINK byte range does not fit memory address space".to_string(),
+            )
+        })?;
+        match self {
+            Self::Local(file) => {
+                file.seek(std::io::SeekFrom::Start(range.start))
+                    .await
+                    .map_err(|error| io_error("seek", path, error))?;
+                let mut bytes = vec![0; expected];
+                file.read_exact(&mut bytes)
+                    .await
+                    .map_err(|error| io_error("read", path, error))?;
+                Ok(Bytes::from(bytes))
+            }
+            Self::Remote(object) => object
+                .read_range(range)
+                .await
+                .map_err(|error| external_error("read", path, error)),
+        }
+    }
+}
+
+impl PlinkFileset {
+    pub(crate) async fn open(bed_path: String, options: &PlinkReadOptions) -> Result<Self> {
+        let storage_options = options.object_storage_options.clone().unwrap_or_default();
+        let bim_path = resolve_member(
+            &bed_path,
+            "BIM",
+            options.bim_path.as_deref(),
+            "bim",
+            &storage_options,
+        )
+        .await?;
+        let fam_path = resolve_member(
+            &bed_path,
+            "FAM",
+            options.fam_path.as_deref(),
+            "fam",
+            &storage_options,
+        )
+        .await?;
+
+        let bim_bytes =
+            read_bounded(&bim_path, options.max_companion_bytes, &storage_options).await?;
+        let fam_bytes =
+            read_bounded(&fam_path, options.max_companion_bytes, &storage_options).await?;
+        let identities = parse_fam(&fam_path, &fam_bytes, options.sample_id_mode)?;
+        if identities.len() > options.max_samples {
+            return Err(DataFusionError::Plan(format!(
+                "FAM sample count {} exceeds configured max_samples {}",
+                identities.len(),
+                options.max_samples
+            )));
+        }
+        let source_names = sample_names(&identities, options.sample_id_mode)?;
+        let selected_samples = datafusion_bio_format_core::genotype::resolve_samples(
+            &source_names,
+            options.samples.as_deref(),
+            options.missing_sample_policy,
+        )?;
+        let selected_identities = selected_samples
+            .source_indices()
+            .iter()
+            .map(|&index| identities[index].clone())
+            .collect();
+
+        let variants = parse_bim(&bim_path, &bim_bytes, options.coordinate_system)?;
+        if variants.len() > options.max_variants {
+            return Err(DataFusionError::Plan(format!(
+                "BIM variant count {} exceeds configured max_variants {}",
+                variants.len(),
+                options.max_variants
+            )));
+        }
+
+        let sample_count = identities.len();
+        let sample_count_u64 = u64::try_from(sample_count)
+            .map_err(|_| DataFusionError::Plan("FAM sample count does not fit u64".to_string()))?;
+        let bytes_per_variant = sample_count_u64.checked_add(3).ok_or_else(|| {
+            DataFusionError::Plan("PLINK sample count arithmetic overflowed".to_string())
+        })? / 4;
+        let variant_count = u64::try_from(variants.len())
+            .map_err(|_| DataFusionError::Plan("BIM variant count does not fit u64".to_string()))?;
+        let expected_size = expected_bed_size(variant_count, sample_count_u64)?;
+
+        validate_bed(&bed_path, expected_size, &storage_options).await?;
+
+        Ok(Self {
+            bed_path,
+            bim_path,
+            fam_path,
+            variants: Arc::new(variants),
+            selected_samples,
+            selected_identities: Arc::new(selected_identities),
+            sample_count,
+            bytes_per_variant,
+            object_storage_options: storage_options,
+            companion_bytes: (bim_bytes.len() + fam_bytes.len()) as u64,
+        })
+    }
+}
+
+fn expected_bed_size(variant_count: u64, sample_count: u64) -> Result<u64> {
+    let bytes_per_variant = sample_count.checked_add(3).ok_or_else(|| {
+        DataFusionError::Plan("PLINK sample count arithmetic overflowed".to_string())
+    })? / 4;
+    variant_count
+        .checked_mul(bytes_per_variant)
+        .and_then(|value| value.checked_add(BED_HEADER_LEN))
+        .ok_or_else(|| {
+            DataFusionError::Plan("PLINK BED expected-length arithmetic overflowed".to_string())
+        })
+}
+
+async fn resolve_member(
+    bed_path: &str,
+    role: &str,
+    explicit: Option<&str>,
+    extension: &str,
+    options: &ObjectStorageOptions,
+) -> Result<String> {
+    resolve_companion(
+        bed_path,
+        role,
+        explicit,
+        &[CompanionRule::ReplaceExtension(extension.to_string())],
+        true,
+        |candidate| {
+            let options = options.clone();
+            async move { object_exists(&candidate, &options).await }
+        },
+    )
+    .await?
+    .ok_or_else(|| DataFusionError::Plan(format!("required {role} companion was not found")))
+}
+
+async fn object_exists(path: &str, options: &ObjectStorageOptions) -> Result<bool> {
+    match get_storage_type(path.to_string()) {
+        StorageType::LOCAL => Ok(Path::new(local_path(path)?).is_file()),
+        _ => match RemoteObject::open(path.to_string(), options.clone()).await {
+            Ok(object) => match object.size().await {
+                Ok(_) => Ok(true),
+                Err(error) if error.kind() == opendal::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(external_error("stat", path, error)),
+            },
+            Err(error) if error.kind() == opendal::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(external_error("open", path, error)),
+        },
+    }
+}
+
+async fn read_bounded(
+    path: &str,
+    max_bytes: usize,
+    options: &ObjectStorageOptions,
+) -> Result<Bytes> {
+    let size = object_size(path, options).await?;
+    if size > max_bytes as u64 {
+        return Err(DataFusionError::Plan(format!(
+            "companion {} is {size} bytes, exceeding configured max_companion_bytes {max_bytes}",
+            sanitize_location(path)
+        )));
+    }
+    if size == 0 {
+        return Ok(Bytes::new());
+    }
+    read_range(path, 0..size, options).await
+}
+
+pub(crate) async fn object_size(path: &str, options: &ObjectStorageOptions) -> Result<u64> {
+    match get_storage_type(path.to_string()) {
+        StorageType::LOCAL => std::fs::metadata(local_path(path)?)
+            .map(|metadata| metadata.len())
+            .map_err(|error| io_error("stat", path, error)),
+        _ => RemoteObject::open(path.to_string(), options.clone())
+            .await
+            .map_err(|error| external_error("open", path, error))?
+            .size()
+            .await
+            .map_err(|error| external_error("stat", path, error)),
+    }
+}
+
+pub(crate) async fn read_range(
+    path: &str,
+    range: std::ops::Range<u64>,
+    options: &ObjectStorageOptions,
+) -> Result<Bytes> {
+    let expected = usize::try_from(range.end.saturating_sub(range.start)).map_err(|_| {
+        DataFusionError::Execution("PLINK byte range does not fit memory address space".to_string())
+    })?;
+    match get_storage_type(path.to_string()) {
+        StorageType::LOCAL => {
+            let mut file = tokio::fs::File::open(local_path(path)?)
+                .await
+                .map_err(|error| io_error("open", path, error))?;
+            file.seek(std::io::SeekFrom::Start(range.start))
+                .await
+                .map_err(|error| io_error("seek", path, error))?;
+            let mut bytes = vec![0; expected];
+            file.read_exact(&mut bytes)
+                .await
+                .map_err(|error| io_error("read", path, error))?;
+            Ok(Bytes::from(bytes))
+        }
+        _ => RemoteObject::open(path.to_string(), options.clone())
+            .await
+            .map_err(|error| external_error("open", path, error))?
+            .read_range(range)
+            .await
+            .map_err(|error| external_error("read", path, error)),
+    }
+}
+
+fn local_path(path: &str) -> Result<&str> {
+    if let Some(path) = path.strip_prefix("file://") {
+        if path.is_empty() {
+            return Err(DataFusionError::Plan(
+                "local file URL has an empty path".to_string(),
+            ));
+        }
+        Ok(path)
+    } else {
+        Ok(path)
+    }
+}
+
+async fn validate_bed(
+    bed_path: &str,
+    expected_size: u64,
+    options: &ObjectStorageOptions,
+) -> Result<()> {
+    let observed_size = object_size(bed_path, options).await?;
+    if observed_size != expected_size {
+        return Err(DataFusionError::Plan(format!(
+            "PLINK BED length mismatch for {}: expected {expected_size} bytes from BIM/FAM counts, observed {observed_size}",
+            sanitize_location(bed_path)
+        )));
+    }
+    if observed_size < BED_HEADER_LEN {
+        return Err(DataFusionError::Plan(format!(
+            "PLINK BED {} is shorter than the 3-byte header",
+            sanitize_location(bed_path)
+        )));
+    }
+    let header = read_range(bed_path, 0..BED_HEADER_LEN, options).await?;
+    match header.as_ref() {
+        [0x6c, 0x1b, 0x01] => Ok(()),
+        [0x6c, 0x1b, 0x00] => Err(DataFusionError::Plan(
+            "PLINK BED uses unsupported sample-major layout; convert it to variant-major BED"
+                .to_string(),
+        )),
+        _ => Err(DataFusionError::Plan(format!(
+            "PLINK BED {} has invalid or legacy magic; expected 6c 1b 01",
+            sanitize_location(bed_path)
+        ))),
+    }
+}
+
+fn parse_fam(path: &str, bytes: &[u8], mode: SampleIdMode) -> Result<Vec<FamIdentity>> {
+    let text = std::str::from_utf8(bytes).map_err(|error| {
+        DataFusionError::Plan(format!(
+            "FAM {} is not valid UTF-8: {error}",
+            sanitize_location(path)
+        ))
+    })?;
+    let mut identities = Vec::new();
+    for (line_index, line) in text.lines().enumerate() {
+        let fields: Vec<_> = line.split_whitespace().collect();
+        if fields.len() != 6 {
+            return Err(DataFusionError::Plan(format!(
+                "FAM {} line {} has {} fields; expected 6",
+                sanitize_location(path),
+                line_index + 1,
+                fields.len()
+            )));
+        }
+        identities.push(FamIdentity {
+            fid: fields[0].to_string(),
+            iid: fields[1].to_string(),
+        });
+    }
+    if mode == SampleIdMode::Iid {
+        let mut seen = std::collections::HashSet::with_capacity(identities.len());
+        for identity in &identities {
+            if !seen.insert(identity.iid.as_str()) {
+                return Err(DataFusionError::Plan(format!(
+                    "FAM {} contains duplicate IID '{}'; use sample_id_mode = fid_iid",
+                    sanitize_location(path),
+                    identity.iid
+                )));
+            }
+        }
+    }
+    Ok(identities)
+}
+
+fn sample_names(identities: &[FamIdentity], mode: SampleIdMode) -> Result<Vec<String>> {
+    let names: Vec<_> = identities
+        .iter()
+        .map(|identity| match mode {
+            SampleIdMode::Iid => identity.iid.clone(),
+            SampleIdMode::FidIid => {
+                format!("{}:{}", escape_id(&identity.fid), escape_id(&identity.iid))
+            }
+        })
+        .collect();
+    let mut seen = std::collections::HashSet::with_capacity(names.len());
+    for name in &names {
+        if !seen.insert(name.as_str()) {
+            return Err(DataFusionError::Plan(format!(
+                "FAM sample identifier remains ambiguous in {mode:?} mode: {name}"
+            )));
+        }
+    }
+    Ok(names)
+}
+
+fn escape_id(value: &str) -> String {
+    value.replace('%', "%25").replace(':', "%3A")
+}
+
+fn parse_bim(path: &str, bytes: &[u8], coordinates: CoordinateSystem) -> Result<Vec<BimVariant>> {
+    let text = std::str::from_utf8(bytes).map_err(|error| {
+        DataFusionError::Plan(format!(
+            "BIM {} is not valid UTF-8: {error}",
+            sanitize_location(path)
+        ))
+    })?;
+    let mut variants = Vec::new();
+    for (line_index, line) in text.lines().enumerate() {
+        let row = line_index + 1;
+        let fields: Vec<_> = line.split_whitespace().collect();
+        if fields.len() != 6 {
+            return Err(DataFusionError::Plan(format!(
+                "BIM {} line {row} has {} fields; expected 6",
+                sanitize_location(path),
+                fields.len()
+            )));
+        }
+        let cm = fields[2].parse::<f64>().map_err(|error| {
+            DataFusionError::Plan(format!(
+                "BIM {} line {row} has invalid centimorgan value '{}': {error}",
+                sanitize_location(path),
+                fields[2]
+            ))
+        })?;
+        if !cm.is_finite() {
+            return Err(DataFusionError::Plan(format!(
+                "BIM {} line {row} centimorgan value must be finite",
+                sanitize_location(path)
+            )));
+        }
+        let position = fields[3].parse::<u64>().map_err(|error| {
+            DataFusionError::Plan(format!(
+                "BIM {} line {row} has invalid base-pair position '{}': {error}",
+                sanitize_location(path),
+                fields[3]
+            ))
+        })?;
+        let site = coordinates.site(position).map_err(|error| {
+            DataFusionError::Plan(format!(
+                "BIM {} line {row} has invalid base-pair position '{}': {error}",
+                sanitize_location(path),
+                fields[3]
+            ))
+        })?;
+        if fields[0].is_empty() || fields[4].is_empty() || fields[5].is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "BIM {} line {row} contains an empty required field",
+                sanitize_location(path)
+            )));
+        }
+        variants.push(BimVariant {
+            chrom: fields[0].to_string(),
+            id: (fields[1] != ".").then(|| fields[1].to_string()),
+            cm,
+            start: site.start,
+            end: site.end,
+            a1: fields[4].to_string(),
+            a2: fields[5].to_string(),
+        });
+    }
+    Ok(variants)
+}
+
+fn io_error(action: &str, path: &str, error: std::io::Error) -> DataFusionError {
+    DataFusionError::External(Box::new(std::io::Error::new(
+        error.kind(),
+        format!("{action} {}: {error}", sanitize_location(path)),
+    )))
+}
+
+fn external_error(
+    action: &str,
+    path: &str,
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(std::io::Error::other(format!(
+        "{action} {}: {error}",
+        sanitize_location(path)
+    ))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn computes_checked_bed_sizes() {
+        assert_eq!(expected_bed_size(4, 5).unwrap(), 11);
+        assert!(expected_bed_size(1, u64::MAX).is_err());
+        assert!(expected_bed_size(u64::MAX, 4).is_err());
+    }
+}

--- a/datafusion/bio-format-plink1/src/filter.rs
+++ b/datafusion/bio-format-plink1/src/filter.rs
@@ -1,0 +1,238 @@
+use datafusion::common::ScalarValue;
+use datafusion::logical_expr::{Between, Expr, Operator, expr::InList};
+
+use crate::fileset::BimVariant;
+
+pub(crate) fn supports_exact_filter(expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            supports_exact_filter(&binary.left) && supports_exact_filter(&binary.right)
+        }
+        Expr::BinaryExpr(binary) => {
+            let Expr::Column(column) = &*binary.left else {
+                return false;
+            };
+            let Expr::Literal(literal, _) = &*binary.right else {
+                return false;
+            };
+            supports_comparison(&column.name, literal, &binary.op)
+        }
+        Expr::Between(between) => supports_between(between),
+        Expr::InList(in_list) => supports_in_list(in_list),
+        _ => false,
+    }
+}
+
+pub(crate) fn evaluate_exact_filter(variant: &BimVariant, expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            evaluate_exact_filter(variant, &binary.left)
+                && evaluate_exact_filter(variant, &binary.right)
+        }
+        Expr::BinaryExpr(binary) => {
+            let (Expr::Column(column), Expr::Literal(literal, _)) = (&*binary.left, &*binary.right)
+            else {
+                return true;
+            };
+            evaluate_comparison(variant, &column.name, literal, &binary.op)
+        }
+        Expr::Between(between) => evaluate_between(variant, between),
+        Expr::InList(in_list) => evaluate_in_list(variant, in_list),
+        _ => true,
+    }
+}
+
+fn supports_comparison(name: &str, literal: &ScalarValue, operator: &Operator) -> bool {
+    match name {
+        "chrom" | "id" => is_string(literal) && matches!(operator, Operator::Eq | Operator::NotEq),
+        "start" | "end" => {
+            is_integer(literal)
+                && matches!(
+                    operator,
+                    Operator::Eq
+                        | Operator::NotEq
+                        | Operator::Lt
+                        | Operator::LtEq
+                        | Operator::Gt
+                        | Operator::GtEq
+                )
+        }
+        _ => false,
+    }
+}
+
+fn supports_between(between: &Between) -> bool {
+    let Expr::Column(column) = &*between.expr else {
+        return false;
+    };
+    matches!(column.name.as_str(), "start" | "end")
+        && matches!(&*between.low, Expr::Literal(value, _) if is_integer(value))
+        && matches!(&*between.high, Expr::Literal(value, _) if is_integer(value))
+}
+
+fn supports_in_list(in_list: &InList) -> bool {
+    let Expr::Column(column) = &*in_list.expr else {
+        return false;
+    };
+    match column.name.as_str() {
+        "chrom" | "id" => in_list
+            .list
+            .iter()
+            .all(|expr| matches!(expr, Expr::Literal(value, _) if is_string(value))),
+        "start" | "end" => in_list
+            .list
+            .iter()
+            .all(|expr| matches!(expr, Expr::Literal(value, _) if is_integer(value))),
+        _ => false,
+    }
+}
+
+fn evaluate_comparison(
+    variant: &BimVariant,
+    name: &str,
+    literal: &ScalarValue,
+    operator: &Operator,
+) -> bool {
+    match name {
+        "chrom" => compare_string(Some(variant.chrom.as_str()), literal, operator),
+        "id" => compare_string(variant.id.as_deref(), literal, operator),
+        "start" => compare_integer(variant.start, literal, operator),
+        "end" => compare_integer(variant.end, literal, operator),
+        _ => true,
+    }
+}
+
+fn evaluate_between(variant: &BimVariant, between: &Between) -> bool {
+    let (Expr::Column(column), Expr::Literal(low, _), Expr::Literal(high, _)) =
+        (&*between.expr, &*between.low, &*between.high)
+    else {
+        return true;
+    };
+    let value = match column.name.as_str() {
+        "start" => variant.start,
+        "end" => variant.end,
+        _ => return true,
+    };
+    let Some(low) = integer(low) else {
+        return true;
+    };
+    let Some(high) = integer(high) else {
+        return true;
+    };
+    let matches = value >= low && value <= high;
+    if between.negated { !matches } else { matches }
+}
+
+fn evaluate_in_list(variant: &BimVariant, in_list: &InList) -> bool {
+    let Expr::Column(column) = &*in_list.expr else {
+        return true;
+    };
+    let matches = match column.name.as_str() {
+        "chrom" => in_list.list.iter().any(|expr| {
+            matches!(expr, Expr::Literal(value, _) if string(value) == Some(variant.chrom.as_str()))
+        }),
+        "id" => variant.id.as_deref().is_some_and(|id| {
+            in_list.list.iter().any(
+                |expr| matches!(expr, Expr::Literal(value, _) if string(value) == Some(id)),
+            )
+        }),
+        "start" => in_list.list.iter().any(
+            |expr| matches!(expr, Expr::Literal(value, _) if integer(value) == Some(variant.start)),
+        ),
+        "end" => in_list.list.iter().any(
+            |expr| matches!(expr, Expr::Literal(value, _) if integer(value) == Some(variant.end)),
+        ),
+        _ => return true,
+    };
+    if in_list.negated { !matches } else { matches }
+}
+
+fn compare_string(value: Option<&str>, literal: &ScalarValue, operator: &Operator) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    let Some(literal) = string(literal) else {
+        return true;
+    };
+    match operator {
+        Operator::Eq => value == literal,
+        Operator::NotEq => value != literal,
+        _ => true,
+    }
+}
+
+fn compare_integer(value: u64, literal: &ScalarValue, operator: &Operator) -> bool {
+    let Some(literal) = integer(literal) else {
+        return true;
+    };
+    match operator {
+        Operator::Eq => value == literal,
+        Operator::NotEq => value != literal,
+        Operator::Lt => value < literal,
+        Operator::LtEq => value <= literal,
+        Operator::Gt => value > literal,
+        Operator::GtEq => value >= literal,
+        _ => true,
+    }
+}
+
+fn is_string(value: &ScalarValue) -> bool {
+    string(value).is_some()
+}
+
+fn string(value: &ScalarValue) -> Option<&str> {
+    match value {
+        ScalarValue::Utf8(Some(value)) | ScalarValue::LargeUtf8(Some(value)) => Some(value),
+        _ => None,
+    }
+}
+
+fn is_integer(value: &ScalarValue) -> bool {
+    integer(value).is_some()
+}
+
+fn integer(value: &ScalarValue) -> Option<u64> {
+    match value {
+        ScalarValue::UInt8(Some(value)) => Some((*value).into()),
+        ScalarValue::UInt16(Some(value)) => Some((*value).into()),
+        ScalarValue::UInt32(Some(value)) => Some((*value).into()),
+        ScalarValue::UInt64(Some(value)) => Some(*value),
+        ScalarValue::Int8(Some(value)) => u64::try_from(*value).ok(),
+        ScalarValue::Int16(Some(value)) => u64::try_from(*value).ok(),
+        ScalarValue::Int32(Some(value)) => u64::try_from(*value).ok(),
+        ScalarValue::Int64(Some(value)) => u64::try_from(*value).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::logical_expr::{col, lit};
+
+    use super::*;
+
+    fn variant() -> BimVariant {
+        BimVariant {
+            chrom: "1".to_string(),
+            id: Some("rs1".to_string()),
+            cm: 0.0,
+            start: 9,
+            end: 10,
+            a1: "A".to_string(),
+            a2: "C".to_string(),
+        }
+    }
+
+    #[test]
+    fn supports_and_evaluates_exact_catalog_filters() {
+        let filter = col("chrom")
+            .eq(lit("1"))
+            .and(col("start").between(lit(5_u64), lit(10_u64)));
+        assert!(supports_exact_filter(&filter));
+        assert!(evaluate_exact_filter(&variant(), &filter));
+        assert!(supports_exact_filter(
+            &col("id").in_list(vec![lit("rs1"), lit("rs2")], false)
+        ));
+        assert!(!supports_exact_filter(&col("a1").eq(lit("A"))));
+    }
+}

--- a/datafusion/bio-format-plink1/src/lib.rs
+++ b/datafusion/bio-format-plink1/src/lib.rs
@@ -1,0 +1,16 @@
+//! DataFusion support for current variant-major PLINK 1 binary filesets.
+//!
+//! The provider treats BIM as the variant catalog, FAM as the sample catalog,
+//! and BED as a fixed-width, variant-major genotype payload. It is read-only.
+
+#![warn(missing_docs)]
+
+mod fileset;
+mod filter;
+mod physical_exec;
+mod table_provider;
+
+pub use physical_exec::PlinkExec;
+pub use table_provider::{
+    PLINK_SAMPLE_IDENTITIES_KEY, PlinkReadOptions, PlinkTableProvider, SampleIdMode,
+};

--- a/datafusion/bio-format-plink1/src/physical_exec.rs
+++ b/datafusion/bio-format-plink1/src/physical_exec.rs
@@ -1,0 +1,401 @@
+use std::any::Any;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use async_stream::try_stream;
+use datafusion::arrow::array::{
+    ArrayRef, Float64Array, ListBuilder, StringArray, StructArray, UInt8Builder, UInt64Array,
+};
+use datafusion::arrow::datatypes::{DataType, SchemaRef};
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_bio_format_core::genotype::{
+    GenotypeBatchSizer, GenotypeMetric, GenotypeScanMetrics,
+};
+use datafusion_bio_format_core::range_planning::ByteRange;
+
+use crate::fileset::{BED_HEADER_LEN, PlinkFileset, PlinkRangeReader};
+
+#[derive(Clone, Debug)]
+pub(crate) struct PlinkReadRange {
+    pub(crate) range: ByteRange,
+    pub(crate) variants: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PlinkPartition {
+    pub(crate) variants: Vec<usize>,
+    pub(crate) ranges: Vec<PlinkReadRange>,
+}
+
+#[derive(Debug)]
+struct DecodedRow {
+    variant_index: usize,
+    genotypes: Option<Vec<Option<u8>>>,
+}
+
+/// Physical execution plan for a PLINK 1 scan.
+pub struct PlinkExec {
+    pub(crate) fileset: Arc<PlinkFileset>,
+    pub(crate) schema: SchemaRef,
+    pub(crate) projection: Option<Vec<usize>>,
+    pub(crate) partitions: Arc<Vec<PlinkPartition>>,
+    pub(crate) batch_soft_byte_limit: usize,
+    pub(crate) metrics: Arc<GenotypeScanMetrics>,
+    pub(crate) cache: Arc<PlanProperties>,
+}
+
+impl PlinkExec {
+    /// Returns a snapshot of PLINK genotype planning and execution counters.
+    pub fn metrics_snapshot(&self) -> [(GenotypeMetric, u64); 18] {
+        self.metrics.snapshot()
+    }
+}
+
+impl Debug for PlinkExec {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PlinkExec")
+            .field("bed_path", &self.fileset.bed_path)
+            .field("projection", &self.projection)
+            .field("partitions", &self.partitions.len())
+            .finish()
+    }
+}
+
+impl DisplayAs for PlinkExec {
+    fn fmt_as(
+        &self,
+        _format: DisplayFormatType,
+        formatter: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        let columns = self
+            .schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            formatter,
+            "PlinkExec: projection=[{columns}], partitions={}",
+            self.partitions.len()
+        )
+    }
+}
+
+impl ExecutionPlan for PlinkExec {
+    fn name(&self) -> &str {
+        "PlinkExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let assignment = self.partitions.get(partition).cloned().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "PLINK partition {partition} is out of bounds for {} partitions",
+                self.partitions.len()
+            ))
+        })?;
+        let fileset = self.fileset.clone();
+        let schema = self.schema.clone();
+        let metrics = self.metrics.clone();
+        let max_rows = context.session_config().batch_size();
+        let soft_bytes = self.batch_soft_byte_limit;
+        let genotypes_projected = schema.index_of("genotypes").is_ok();
+
+        let stream_schema = schema.clone();
+        let stream = try_stream! {
+            let estimated_row_bytes = if genotypes_projected {
+                fileset.selected_samples.source_indices().len().saturating_mul(2)
+            } else {
+                0
+            };
+            let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
+            let mut rows = Vec::with_capacity(max_rows);
+
+            if assignment.ranges.is_empty() {
+                for variant_index in assignment.variants {
+                    if sizer.should_flush_before(estimated_row_bytes) {
+                        let row_count = rows.len();
+                        let batch = build_batch(&fileset, schema.clone(), &rows)?;
+                        record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                        yield batch;
+                        rows.clear();
+                        sizer.reset();
+                    }
+                    rows.push(DecodedRow {
+                        variant_index,
+                        genotypes: genotypes_projected.then(Vec::new),
+                    });
+                    sizer.push_row(estimated_row_bytes);
+                }
+            } else {
+                let mut reader =
+                    PlinkRangeReader::open(&fileset.bed_path, &fileset.object_storage_options)
+                        .await?;
+                for planned in assignment.ranges {
+                    let payload = reader
+                    .read_range(
+                        &fileset.bed_path,
+                        planned.range.start..planned.range.end,
+                    )
+                    .await?;
+                    metrics.add(GenotypeMetric::RangeRequests, 1);
+                    metrics.add(GenotypeMetric::CoalescedRanges, 1);
+                    metrics.add(GenotypeMetric::PrimaryBytesRead, payload.len() as u64);
+
+                    for variant_index in planned.variants {
+                        if sizer.should_flush_before(estimated_row_bytes) {
+                            let row_count = rows.len();
+                            let batch = build_batch(&fileset, schema.clone(), &rows)?;
+                            record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                            yield batch;
+                            rows.clear();
+                            sizer.reset();
+                        }
+                        let variant_payload =
+                            variant_payload(&payload, planned.range, variant_index, fileset.bytes_per_variant)?;
+                        validate_padding(variant_payload, fileset.sample_count, variant_index)?;
+                        let genotypes = decode_selected_samples(
+                            variant_payload,
+                            fileset.selected_samples.source_indices(),
+                        );
+                        metrics.add(
+                            GenotypeMetric::SamplesDecoded,
+                            genotypes.len() as u64,
+                        );
+                        metrics.add(
+                            GenotypeMetric::SampleValuesSkipped,
+                            fileset.sample_count.saturating_sub(genotypes.len()) as u64,
+                        );
+                        rows.push(DecodedRow {
+                            variant_index,
+                            genotypes: Some(genotypes),
+                        });
+                        sizer.push_row(estimated_row_bytes);
+                    }
+                }
+            }
+
+            if !rows.is_empty() {
+                let row_count = rows.len();
+                let batch = build_batch(&fileset, schema.clone(), &rows)?;
+                record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                yield batch;
+            }
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            stream_schema,
+            stream,
+        )))
+    }
+}
+
+fn record_batch_metrics(metrics: &GenotypeScanMetrics, rows: usize, genotype_bytes: usize) {
+    metrics.add(GenotypeMetric::Batches, 1);
+    metrics.add(GenotypeMetric::BatchRows, rows as u64);
+    metrics.add(GenotypeMetric::EmittedVariants, rows as u64);
+    metrics.add(GenotypeMetric::GenotypeBytes, genotype_bytes as u64);
+}
+
+fn variant_payload(
+    bytes: &[u8],
+    range: ByteRange,
+    variant_index: usize,
+    bytes_per_variant: u64,
+) -> Result<&[u8]> {
+    let index = u64::try_from(variant_index).map_err(|_| {
+        DataFusionError::Execution("PLINK variant index does not fit u64".to_string())
+    })?;
+    let absolute_start = index
+        .checked_mul(bytes_per_variant)
+        .and_then(|offset| offset.checked_add(BED_HEADER_LEN))
+        .ok_or_else(|| {
+            DataFusionError::Execution("PLINK variant offset arithmetic overflowed".to_string())
+        })?;
+    let relative_start = absolute_start
+        .checked_sub(range.start)
+        .and_then(|offset| usize::try_from(offset).ok())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "PLINK variant {variant_index} is not contained in planned range"
+            ))
+        })?;
+    let width = usize::try_from(bytes_per_variant).map_err(|_| {
+        DataFusionError::Execution("PLINK variant width does not fit usize".to_string())
+    })?;
+    let relative_end = relative_start.checked_add(width).ok_or_else(|| {
+        DataFusionError::Execution("PLINK payload slice arithmetic overflowed".to_string())
+    })?;
+    bytes.get(relative_start..relative_end).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "PLINK BED range is truncated while reading variant {variant_index}"
+        ))
+    })
+}
+
+fn validate_padding(payload: &[u8], sample_count: usize, variant_index: usize) -> Result<()> {
+    let used_slots = sample_count % 4;
+    if used_slots == 0 {
+        return Ok(());
+    }
+    let Some(&last) = payload.last() else {
+        return Err(DataFusionError::Execution(format!(
+            "PLINK BED variant {variant_index} has no payload"
+        )));
+    };
+    let used_bits = used_slots * 2;
+    let unused_mask = !((1_u8 << used_bits) - 1);
+    if last & unused_mask != 0 {
+        return Err(DataFusionError::Execution(format!(
+            "PLINK BED variant {variant_index} has non-zero unused padding bits"
+        )));
+    }
+    Ok(())
+}
+
+fn decode_selected_samples(payload: &[u8], sample_indices: &[usize]) -> Vec<Option<u8>> {
+    sample_indices
+        .iter()
+        .map(|&sample_index| {
+            let byte = payload[sample_index / 4];
+            match (byte >> ((sample_index % 4) * 2)) & 0b11 {
+                0b00 => Some(2),
+                0b10 => Some(1),
+                0b11 => Some(0),
+                0b01 => None,
+                _ => unreachable!("a two-bit value has four states"),
+            }
+        })
+        .collect()
+}
+
+fn build_batch(
+    fileset: &PlinkFileset,
+    schema: SchemaRef,
+    rows: &[DecodedRow],
+) -> Result<RecordBatch> {
+    if schema.fields().is_empty() {
+        let options = RecordBatchOptions::new().with_row_count(Some(rows.len()));
+        return RecordBatch::try_new_with_options(schema, Vec::new(), &options)
+            .map_err(DataFusionError::from);
+    }
+
+    let arrays = schema
+        .fields()
+        .iter()
+        .map(|field| match field.name().as_str() {
+            "chrom" => Ok(Arc::new(StringArray::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].chrom.as_str()),
+            )) as ArrayRef),
+            "start" => Ok(Arc::new(UInt64Array::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].start),
+            )) as ArrayRef),
+            "end" => Ok(Arc::new(UInt64Array::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].end),
+            )) as ArrayRef),
+            "id" => Ok(Arc::new(StringArray::from(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].id.as_deref())
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef),
+            "cm" => Ok(Arc::new(Float64Array::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].cm),
+            )) as ArrayRef),
+            "a1" => Ok(Arc::new(StringArray::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].a1.as_str()),
+            )) as ArrayRef),
+            "a2" => Ok(Arc::new(StringArray::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].a2.as_str()),
+            )) as ArrayRef),
+            "genotypes" => build_genotypes(field.data_type(), rows),
+            name => Err(DataFusionError::Execution(format!(
+                "unsupported PLINK projected field {name}"
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RecordBatch::try_new(schema, arrays).map_err(DataFusionError::from)
+}
+
+fn build_genotypes(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    let DataType::Struct(fields) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PLINK genotypes field is not a struct".to_string(),
+        ));
+    };
+    let mut builder = ListBuilder::new(UInt8Builder::new());
+    for row in rows {
+        let genotypes = row.genotypes.as_deref().ok_or_else(|| {
+            DataFusionError::Execution(
+                "PLINK genotype projection was planned without decoded values".to_string(),
+            )
+        })?;
+        for value in genotypes {
+            builder.values().append_option(*value);
+        }
+        builder.append(true);
+    }
+    let gt = Arc::new(builder.finish()) as ArrayRef;
+    Ok(Arc::new(StructArray::try_new(
+        fields.clone(),
+        vec![gt],
+        None,
+    )?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_a1_dosage_and_missingness_in_requested_order() {
+        // sample codes in source order: 00, 10, 11, 01
+        let payload = [0b01_11_10_00];
+        assert_eq!(
+            decode_selected_samples(&payload, &[3, 0, 2, 1]),
+            vec![None, Some(2), Some(0), Some(1)]
+        );
+    }
+
+    #[test]
+    fn rejects_nonzero_high_padding_slots() {
+        assert!(validate_padding(&[0b00_00_00_11], 1, 7).is_ok());
+        let error = validate_padding(&[0b01_00_00_11], 1, 7)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("variant 7"));
+    }
+}

--- a/datafusion/bio-format-plink1/src/table_provider.rs
+++ b/datafusion/bio-format-plink1/src/table_provider.rs
@@ -1,0 +1,431 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::fileset::{BED_HEADER_LEN, PlinkFileset};
+use crate::filter::{evaluate_exact_filter, supports_exact_filter};
+use crate::physical_exec::{PlinkExec, PlinkPartition, PlinkReadRange};
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
+use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
+use datafusion_bio_format_core::genotype::{
+    CoordinateSystem, GENOTYPE_COUNTED_ALLELE_KEY, GENOTYPE_OUTPUT_MODE_KEY, GenotypeMetric,
+    GenotypeScanMetrics, MissingSamplePolicy, PredicateGuarantee, can_push_limit_below_filters,
+};
+use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
+use datafusion_bio_format_core::range_planning::{
+    ByteRange, balance_byte_ranges, coalesce_byte_ranges,
+};
+
+/// Field metadata containing selected original FAM `(FID, IID)` pairs as JSON.
+pub const PLINK_SAMPLE_IDENTITIES_KEY: &str = "bio.plink1.sample_identities";
+
+/// Policy used to construct selectable sample names from FAM rows.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SampleIdMode {
+    /// Use IID alone and reject duplicate IIDs.
+    #[default]
+    Iid,
+    /// Use the collision-free escaped representation `FID:IID`.
+    FidIid,
+}
+
+/// Read and planning options for a PLINK 1 fileset.
+#[derive(Debug, Clone)]
+pub struct PlinkReadOptions {
+    /// Explicit BIM location. The shared-basename `.bim` is used when absent.
+    pub bim_path: Option<String>,
+    /// Explicit FAM location. The shared-basename `.fam` is used when absent.
+    pub fam_path: Option<String>,
+    /// Requested sample names in output order, or all samples when absent.
+    pub samples: Option<Vec<String>>,
+    /// Behavior for requested samples absent from FAM.
+    pub missing_sample_policy: MissingSamplePolicy,
+    /// FAM identifier policy.
+    pub sample_id_mode: SampleIdMode,
+    /// Output coordinate presentation.
+    pub coordinate_system: CoordinateSystem,
+    /// Credentials and transport configuration for remote objects.
+    pub object_storage_options: Option<ObjectStorageOptions>,
+    /// Maximum bytes accepted for either text companion.
+    pub max_companion_bytes: usize,
+    /// Maximum accepted number of BIM variants.
+    pub max_variants: usize,
+    /// Maximum accepted number of FAM samples.
+    pub max_samples: usize,
+    /// Maximum unselected byte gap bridged by one BED range.
+    pub max_range_gap: u64,
+    /// Maximum size of a coalesced BED range.
+    pub max_range_bytes: u64,
+    /// Soft target for genotype bytes in one RecordBatch.
+    pub batch_soft_byte_limit: usize,
+}
+
+impl Default for PlinkReadOptions {
+    fn default() -> Self {
+        Self {
+            bim_path: None,
+            fam_path: None,
+            samples: None,
+            missing_sample_policy: MissingSamplePolicy::Error,
+            sample_id_mode: SampleIdMode::Iid,
+            coordinate_system: CoordinateSystem::ZeroBasedHalfOpen,
+            object_storage_options: None,
+            max_companion_bytes: 256 * 1024 * 1024,
+            max_variants: 100_000_000,
+            max_samples: 10_000_000,
+            max_range_gap: 0,
+            max_range_bytes: 8 * 1024 * 1024,
+            batch_soft_byte_limit: 64 * 1024 * 1024,
+        }
+    }
+}
+
+/// Read-only DataFusion table provider for a PLINK 1 BED/BIM/FAM fileset.
+#[derive(Clone, Debug)]
+pub struct PlinkTableProvider {
+    fileset: Arc<PlinkFileset>,
+    schema: SchemaRef,
+    options: PlinkReadOptions,
+}
+
+impl PlinkTableProvider {
+    /// Opens and validates a local or remote PLINK 1 fileset.
+    pub async fn try_new(bed_path: impl Into<String>, options: PlinkReadOptions) -> Result<Self> {
+        if options.max_companion_bytes == 0 {
+            return Err(DataFusionError::Plan(
+                "max_companion_bytes must be greater than zero".to_string(),
+            ));
+        }
+        if options.max_range_bytes == 0 {
+            return Err(DataFusionError::Plan(
+                "max_range_bytes must be greater than zero".to_string(),
+            ));
+        }
+        if options.batch_soft_byte_limit == 0 {
+            return Err(DataFusionError::Plan(
+                "batch_soft_byte_limit must be greater than zero".to_string(),
+            ));
+        }
+        let fileset = Arc::new(PlinkFileset::open(bed_path.into(), &options).await?);
+        let schema = build_schema(&fileset, options.coordinate_system)?;
+        Ok(Self {
+            fileset,
+            schema,
+            options,
+        })
+    }
+
+    /// Returns the resolved BIM companion location.
+    pub fn bim_path(&self) -> &str {
+        &self.fileset.bim_path
+    }
+
+    /// Returns the resolved FAM companion location.
+    pub fn fam_path(&self) -> &str {
+        &self.fileset.fam_path
+    }
+
+    /// Returns selected sample names in emitted list order.
+    pub fn sample_names(&self) -> &[String] {
+        self.fileset.selected_samples.names()
+    }
+}
+
+#[async_trait]
+impl TableProvider for PlinkTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if supports_exact_filter(filter) {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let schema = project_schema(&self.schema, projection)?;
+        let guarantees: Vec<_> = filters
+            .iter()
+            .map(|filter| {
+                if supports_exact_filter(filter) {
+                    PredicateGuarantee::Exact
+                } else {
+                    PredicateGuarantee::Unsupported
+                }
+            })
+            .collect();
+        let exact_filters: Vec<_> = filters
+            .iter()
+            .filter(|filter| supports_exact_filter(filter))
+            .collect();
+        let mut selected: Vec<usize> = self
+            .fileset
+            .variants
+            .iter()
+            .enumerate()
+            .filter(|(_, variant)| {
+                exact_filters
+                    .iter()
+                    .all(|filter| evaluate_exact_filter(variant, filter))
+            })
+            .map(|(index, _)| index)
+            .collect();
+        if can_push_limit_below_filters(&guarantees)
+            && let Some(limit) = limit
+        {
+            selected.truncate(limit);
+        }
+
+        if selected.is_empty() {
+            return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                schema,
+            )));
+        }
+
+        let needs_genotypes = projection
+            .map(|indices| indices.contains(&7))
+            .unwrap_or(true)
+            && !self.fileset.selected_samples.is_empty();
+        let partitions = if needs_genotypes {
+            plan_payload_partitions(
+                &selected,
+                self.fileset.bytes_per_variant,
+                state.config().target_partitions(),
+                self.options.max_range_gap,
+                self.options.max_range_bytes,
+            )?
+        } else {
+            plan_metadata_partitions(&selected, state.config().target_partitions())
+        };
+        let metrics = Arc::new(GenotypeScanMetrics::default());
+        metrics.add(
+            GenotypeMetric::CompanionBytesRead,
+            self.fileset.companion_bytes,
+        );
+        metrics.add(
+            GenotypeMetric::MetadataCandidates,
+            self.fileset.variants.len() as u64,
+        );
+        metrics.add(GenotypeMetric::SelectedVariants, selected.len() as u64);
+        metrics.add(
+            GenotypeMetric::SamplesRequested,
+            self.fileset.selected_samples.source_indices().len() as u64,
+        );
+        if !needs_genotypes {
+            metrics.add(GenotypeMetric::PayloadsSkipped, selected.len() as u64);
+        }
+
+        let partition_count = partitions.len();
+        Ok(Arc::new(PlinkExec {
+            fileset: self.fileset.clone(),
+            schema: schema.clone(),
+            projection: projection.cloned(),
+            partitions: Arc::new(partitions),
+            batch_soft_byte_limit: self.options.batch_soft_byte_limit,
+            metrics,
+            cache: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(partition_count),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )),
+        }))
+    }
+}
+
+fn build_schema(fileset: &PlinkFileset, coordinates: CoordinateSystem) -> Result<SchemaRef> {
+    let gt = Field::new(
+        "GT",
+        DataType::List(Arc::new(Field::new("item", DataType::UInt8, true))),
+        false,
+    )
+    .with_metadata(HashMap::from([
+        (GENOTYPE_COUNTED_ALLELE_KEY.to_string(), "A1".to_string()),
+        (
+            GENOTYPE_OUTPUT_MODE_KEY.to_string(),
+            "a1_dosage".to_string(),
+        ),
+    ]));
+    let selected_identities = serde_json::to_string(fileset.selected_identities.as_ref())
+        .map_err(|error| DataFusionError::Plan(format!("serialize FAM identities: {error}")))?;
+    let mut genotype_metadata = fileset.selected_samples.field_metadata();
+    genotype_metadata.insert(PLINK_SAMPLE_IDENTITIES_KEY.to_string(), selected_identities);
+    let genotypes = Field::new("genotypes", DataType::Struct(Fields::from(vec![gt])), false)
+        .with_metadata(genotype_metadata);
+
+    Ok(Arc::new(Schema::new_with_metadata(
+        vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt64, false),
+            Field::new("end", DataType::UInt64, false),
+            Field::new("id", DataType::Utf8, true),
+            Field::new("cm", DataType::Float64, false),
+            Field::new("a1", DataType::Utf8, false),
+            Field::new("a2", DataType::Utf8, false),
+            genotypes,
+        ],
+        HashMap::from([(
+            COORDINATE_SYSTEM_METADATA_KEY.to_string(),
+            coordinates.metadata_value().to_string(),
+        )]),
+    )))
+}
+
+fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> Result<SchemaRef> {
+    match projection {
+        Some(indices) => Ok(Arc::new(Schema::new_with_metadata(
+            indices
+                .iter()
+                .map(|&index| {
+                    schema.fields().get(index).cloned().ok_or_else(|| {
+                        DataFusionError::Plan(format!(
+                            "PLINK projection column index {index} is out of bounds"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+            schema.metadata().clone(),
+        ))),
+        None => Ok(schema.clone()),
+    }
+}
+
+fn plan_payload_partitions(
+    selected: &[usize],
+    bytes_per_variant: u64,
+    target_partitions: usize,
+    max_gap: u64,
+    max_range_size: u64,
+) -> Result<Vec<PlinkPartition>> {
+    let ranges = selected
+        .iter()
+        .map(|&index| variant_byte_range(index, bytes_per_variant))
+        .collect::<Result<Vec<_>>>()?;
+    let ranges = coalesce_byte_ranges(ranges, max_gap, max_range_size)?;
+    let balanced = balance_byte_ranges(ranges, target_partitions);
+    Ok(balanced
+        .into_iter()
+        .map(|partition| {
+            let ranges = partition
+                .ranges
+                .into_iter()
+                .map(|range| PlinkReadRange {
+                    range,
+                    variants: selected
+                        .iter()
+                        .copied()
+                        .filter(|&index| {
+                            variant_byte_range(index, bytes_per_variant).is_ok_and(|variant| {
+                                variant.start >= range.start && variant.end <= range.end
+                            })
+                        })
+                        .collect(),
+                })
+                .collect();
+            PlinkPartition {
+                variants: Vec::new(),
+                ranges,
+            }
+        })
+        .collect())
+}
+
+fn plan_metadata_partitions(selected: &[usize], target_partitions: usize) -> Vec<PlinkPartition> {
+    let partition_count = target_partitions.max(1).min(selected.len());
+    let chunk_size = selected.len().div_ceil(partition_count);
+    selected
+        .chunks(chunk_size)
+        .map(|variants| PlinkPartition {
+            variants: variants.to_vec(),
+            ranges: Vec::new(),
+        })
+        .collect()
+}
+
+fn variant_byte_range(index: usize, bytes_per_variant: u64) -> Result<ByteRange> {
+    let index = u64::try_from(index)
+        .map_err(|_| DataFusionError::Plan("PLINK variant index does not fit u64".to_string()))?;
+    let start = index
+        .checked_mul(bytes_per_variant)
+        .and_then(|offset| offset.checked_add(BED_HEADER_LEN))
+        .ok_or_else(|| {
+            DataFusionError::Plan("PLINK BED offset arithmetic overflowed".to_string())
+        })?;
+    let end = start.checked_add(bytes_per_variant).ok_or_else(|| {
+        DataFusionError::Plan("PLINK BED range arithmetic overflowed".to_string())
+    })?;
+    ByteRange::new(start, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesces_adjacent_variants_and_owns_every_selection_once() {
+        let partitions = plan_payload_partitions(&[0, 1, 3], 2, 2, 0, 8).unwrap();
+        assert_eq!(partitions.len(), 2);
+        let mut selected: Vec<_> = partitions
+            .iter()
+            .flat_map(|partition| partition.ranges.iter())
+            .flat_map(|range| range.variants.iter().copied())
+            .collect();
+        selected.sort_unstable();
+        assert_eq!(selected, vec![0, 1, 3]);
+
+        let mut ranges: Vec<_> = partitions
+            .iter()
+            .flat_map(|partition| partition.ranges.iter().map(|range| range.range))
+            .collect();
+        ranges.sort_unstable();
+        assert_eq!(
+            ranges,
+            vec![
+                ByteRange::new(3, 7).unwrap(),
+                ByteRange::new(9, 11).unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn bounded_gap_can_coalesce_sparse_variants() {
+        let partitions = plan_payload_partitions(&[0, 2], 2, 1, 2, 8).unwrap();
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(partitions[0].ranges.len(), 1);
+        assert_eq!(partitions[0].ranges[0].range, ByteRange::new(3, 9).unwrap());
+        assert_eq!(partitions[0].ranges[0].variants, vec![0, 2]);
+    }
+}

--- a/datafusion/bio-format-plink1/tests/provider_test.rs
+++ b/datafusion/bio-format-plink1/tests/provider_test.rs
@@ -1,0 +1,769 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use datafusion::arrow::array::{Array, ListArray, StringArray, StructArray, UInt8Array};
+use datafusion::catalog::TableProvider;
+use datafusion::logical_expr::{TableProviderFilterPushDown, col, lit};
+use datafusion::physical_plan::collect;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_core::genotype::{GenotypeMetric, MissingSamplePolicy};
+use datafusion_bio_format_core::metadata::{
+    GENOTYPE_COUNTED_ALLELE_KEY, GENOTYPE_SAMPLE_NAMES_KEY,
+};
+use datafusion_bio_format_plink1::{
+    PLINK_SAMPLE_IDENTITIES_KEY, PlinkExec, PlinkReadOptions, PlinkTableProvider, SampleIdMode,
+};
+use tempfile::TempDir;
+
+const FAM: &str = "\
+f1 s1 0 0 1 -9
+f1 s2 0 0 2 -9
+f2 s3 0 0 1 -9
+f:2 s%4 0 0 2 -9
+f3 s5 0 0 1 -9
+";
+
+const BIM: &str = "\
+1 rs1 0 10 A C
+1 rs2 0.25 20 G T
+2 rs3 1.5 30 C A
+2 . 2 40 T G
+";
+
+// Source-order A1 dosages:
+// rs1: 2, 1, 0, missing, 2
+// rs2: 0, missing, 1, 2, 0
+// rs3: 1, 1, 2, 0, missing
+// row4: missing, 0, 0, 1, 1
+const CODES: [[u8; 5]; 4] = [
+    [0b00, 0b10, 0b11, 0b01, 0b00],
+    [0b11, 0b01, 0b10, 0b00, 0b11],
+    [0b10, 0b10, 0b00, 0b11, 0b01],
+    [0b01, 0b11, 0b11, 0b10, 0b10],
+];
+
+struct Fixture {
+    _dir: TempDir,
+    bed: PathBuf,
+    bim: PathBuf,
+    fam: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct HttpRequest {
+    path: String,
+    method: String,
+    range: Option<(usize, usize)>,
+}
+
+struct RangeServer {
+    address: std::net::SocketAddr,
+    requests: Arc<Mutex<Vec<HttpRequest>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl RangeServer {
+    fn start(bed: Vec<u8>, bim: Vec<u8>, fam: Vec<u8>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let server_requests = requests.clone();
+        let server_stop = stop.clone();
+        let thread = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while !server_stop.load(Ordering::Relaxed) && Instant::now() < deadline {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(connection) => connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(error) => panic!("range server failed: {error}"),
+                };
+                let mut request_bytes = [0_u8; 8192];
+                let size = stream.read(&mut request_bytes).unwrap();
+                let request = String::from_utf8_lossy(&request_bytes[..size]);
+                let mut lines = request.lines();
+                let mut request_line = lines.next().unwrap().split_whitespace();
+                let method = request_line.next().unwrap().to_string();
+                let path = request_line.next().unwrap().to_string();
+                let range = lines.find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    if !name.eq_ignore_ascii_case("range") {
+                        return None;
+                    }
+                    let value = value.trim().strip_prefix("bytes=")?;
+                    let (start, end) = value.split_once('-')?;
+                    Some((start.parse().ok()?, end.parse().ok()?))
+                });
+                server_requests.lock().unwrap().push(HttpRequest {
+                    path: path.clone(),
+                    method: method.clone(),
+                    range,
+                });
+
+                let body = match path.as_str() {
+                    "/cohort.bed" => &bed,
+                    "/cohort.bim" => &bim,
+                    "/cohort.fam" => &fam,
+                    _ => {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        );
+                        continue;
+                    }
+                };
+                if method == "HEAD" {
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                } else if let Some((start, end)) = range {
+                    let end = end.min(body.len() - 1);
+                    let selected = &body[start..=end];
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {}-{}/{}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        selected.len(),
+                        start,
+                        end,
+                        body.len()
+                    );
+                    let _ = stream.write_all(selected);
+                } else {
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(body);
+                }
+            }
+        });
+        Self {
+            address,
+            requests,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn url(&self, name: &str) -> String {
+        format!("http://{}/{name}", self.address)
+    }
+
+    fn bed_get_ranges(&self) -> Vec<Option<(usize, usize)>> {
+        self.requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| request.path == "/cohort.bed" && request.method == "GET")
+            .map(|request| request.range)
+            .collect()
+    }
+}
+
+impl Drop for RangeServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+fn fixture() -> Fixture {
+    let dir = TempDir::new().unwrap();
+    let bed = dir.path().join("cohort.bed");
+    let bim = dir.path().join("cohort.bim");
+    let fam = dir.path().join("cohort.fam");
+    fs::write(&bim, BIM).unwrap();
+    fs::write(&fam, FAM).unwrap();
+    fs::write(&bed, encode_bed(&CODES)).unwrap();
+    Fixture {
+        _dir: dir,
+        bed,
+        bim,
+        fam,
+    }
+}
+
+fn encode_bed<const V: usize, const S: usize>(codes: &[[u8; S]; V]) -> Vec<u8> {
+    let mut bytes = vec![0x6c, 0x1b, 0x01];
+    for row in codes {
+        for chunk in row.chunks(4) {
+            let mut byte = 0_u8;
+            for (slot, code) in chunk.iter().enumerate() {
+                byte |= code << (slot * 2);
+            }
+            bytes.push(byte);
+        }
+    }
+    bytes
+}
+
+fn path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn one_partition_context() -> SessionContext {
+    SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1))
+}
+
+fn gt_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+) -> Vec<Option<u8>> {
+    let genotypes = batch
+        .column(column)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let gt = genotypes
+        .column_by_name("GT")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    let values = gt.value(0);
+    let values = values.as_any().downcast_ref::<UInt8Array>().unwrap();
+    (0..values.len())
+        .map(|index| (!values.is_null(index)).then(|| values.value(index)))
+        .collect()
+}
+
+#[tokio::test]
+async fn resolves_conventional_fileset_and_decodes_reordered_samples() {
+    let fixture = fixture();
+    let options = PlinkReadOptions {
+        samples: Some(vec!["s%4".to_string(), "s1".to_string(), "s3".to_string()]),
+        ..Default::default()
+    };
+    let provider = PlinkTableProvider::try_new(path(&fixture.bed), options)
+        .await
+        .unwrap();
+    assert_eq!(provider.bim_path(), path(&fixture.bim));
+    assert_eq!(provider.fam_path(), path(&fixture.fam));
+    assert_eq!(provider.sample_names(), &["s%4", "s1", "s3"]);
+
+    let context = one_partition_context();
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT id, genotypes FROM p WHERE id = 'rs2'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0),
+        "rs2"
+    );
+    assert_eq!(gt_values(&batches[0], 1), vec![Some(2), Some(0), Some(1)]);
+}
+
+#[tokio::test]
+async fn exposes_coordinate_allele_and_sample_metadata() {
+    let fixture = fixture();
+    let provider = PlinkTableProvider::try_new(path(&fixture.bed), PlinkReadOptions::default())
+        .await
+        .unwrap();
+    let schema = provider.schema();
+    assert_eq!(
+        schema
+            .metadata()
+            .get("bio.coordinate_system_zero_based")
+            .map(String::as_str),
+        Some("true")
+    );
+    let genotype_field = schema.field_with_name("genotypes").unwrap();
+    assert_eq!(
+        genotype_field
+            .metadata()
+            .get(GENOTYPE_SAMPLE_NAMES_KEY)
+            .map(String::as_str),
+        Some(r#"["s1","s2","s3","s%4","s5"]"#)
+    );
+    assert!(
+        genotype_field
+            .metadata()
+            .contains_key(PLINK_SAMPLE_IDENTITIES_KEY)
+    );
+    let datafusion::arrow::datatypes::DataType::Struct(children) = genotype_field.data_type()
+    else {
+        panic!("genotypes must be a struct");
+    };
+    assert_eq!(
+        children[0]
+            .metadata()
+            .get(GENOTYPE_COUNTED_ALLELE_KEY)
+            .map(String::as_str),
+        Some("A1")
+    );
+
+    let context = one_partition_context();
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT start, \"end\", a1, a2 FROM p WHERE id = 'rs1'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let start = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::UInt64Array>()
+        .unwrap();
+    let end = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::UInt64Array>()
+        .unwrap();
+    assert_eq!((start.value(0), end.value(0)), (9, 10));
+}
+
+#[tokio::test]
+async fn reports_exact_catalog_pushdown_and_reads_only_selected_payload() {
+    let fixture = fixture();
+    let provider = PlinkTableProvider::try_new(path(&fixture.bed), PlinkReadOptions::default())
+        .await
+        .unwrap();
+    let filter = col("id").eq(lit("rs3"));
+    assert_eq!(
+        provider.supports_filters_pushdown(&[&filter]).unwrap(),
+        vec![TableProviderFilterPushDown::Exact]
+    );
+    assert_eq!(
+        provider
+            .supports_filters_pushdown(&[&col("a1").eq(lit("A"))])
+            .unwrap(),
+        vec![TableProviderFilterPushDown::Unsupported]
+    );
+
+    let context = one_partition_context();
+    let state = context.state();
+    let plan = provider
+        .scan(&state, Some(&vec![0, 7]), &[filter], None)
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PlinkExec>().unwrap();
+    let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+    let metrics = exec.metrics_snapshot();
+    let value = |metric| metrics[metric as usize].1;
+    assert_eq!(value(GenotypeMetric::PrimaryBytesRead), 2);
+    assert_eq!(value(GenotypeMetric::RangeRequests), 1);
+    assert_eq!(value(GenotypeMetric::SamplesDecoded), 5);
+    assert_eq!(value(GenotypeMetric::SelectedVariants), 1);
+}
+
+#[tokio::test]
+async fn exact_filtered_limit_restricts_payload_planning() {
+    let fixture = fixture();
+    let provider = PlinkTableProvider::try_new(path(&fixture.bed), PlinkReadOptions::default())
+        .await
+        .unwrap();
+    let context = one_partition_context();
+    let state = context.state();
+    let plan = provider
+        .scan(
+            &state,
+            Some(&vec![3, 7]),
+            &[col("chrom").eq(lit("1"))],
+            Some(1),
+        )
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PlinkExec>().unwrap();
+    let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+    assert_eq!(
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0),
+        "rs1"
+    );
+    let metrics = exec.metrics_snapshot();
+    assert_eq!(metrics[GenotypeMetric::SelectedVariants as usize].1, 1);
+    assert_eq!(metrics[GenotypeMetric::PrimaryBytesRead as usize].1, 2);
+}
+
+#[tokio::test]
+async fn metadata_only_and_count_scans_do_not_read_bed_payload() {
+    let fixture = fixture();
+    let provider = PlinkTableProvider::try_new(path(&fixture.bed), PlinkReadOptions::default())
+        .await
+        .unwrap();
+    let context = one_partition_context();
+    let state = context.state();
+    for projection in [vec![0, 3], Vec::new()] {
+        let plan = provider
+            .scan(&state, Some(&projection), &[], None)
+            .await
+            .unwrap();
+        let exec = plan.as_any().downcast_ref::<PlinkExec>().unwrap();
+        let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+        assert_eq!(
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            4
+        );
+        let metrics = exec.metrics_snapshot();
+        assert_eq!(
+            metrics[GenotypeMetric::PrimaryBytesRead as usize].1,
+            0,
+            "projection {projection:?}"
+        );
+        assert_eq!(metrics[GenotypeMetric::PayloadsSkipped as usize].1, 4);
+    }
+}
+
+#[tokio::test]
+async fn empty_sample_selection_emits_empty_lists_without_payload_reads() {
+    let fixture = fixture();
+    let provider = PlinkTableProvider::try_new(
+        path(&fixture.bed),
+        PlinkReadOptions {
+            samples: Some(vec!["absent".to_string()]),
+            missing_sample_policy: MissingSamplePolicy::Ignore,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = one_partition_context();
+    let state = context.state();
+    let plan = provider
+        .scan(&state, Some(&vec![7]), &[], Some(1))
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PlinkExec>().unwrap();
+    let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+    assert_eq!(gt_values(&batches[0], 0), Vec::<Option<u8>>::new());
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::PrimaryBytesRead as usize].1,
+        0
+    );
+}
+
+#[tokio::test]
+async fn remote_metadata_and_sparse_queries_use_bounded_bed_ranges() {
+    let server = RangeServer::start(
+        encode_bed(&CODES),
+        BIM.as_bytes().to_vec(),
+        FAM.as_bytes().to_vec(),
+    );
+    let provider =
+        PlinkTableProvider::try_new(server.url("cohort.bed"), PlinkReadOptions::default())
+            .await
+            .unwrap();
+    assert_eq!(server.bed_get_ranges(), vec![Some((0, 2))]);
+
+    let context = one_partition_context();
+    context
+        .register_table("remote_plink", Arc::new(provider))
+        .unwrap();
+    let metadata = context
+        .sql("SELECT id FROM remote_plink WHERE chrom = '2'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        metadata.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        2
+    );
+    assert_eq!(server.bed_get_ranges(), vec![Some((0, 2))]);
+
+    let genotype = context
+        .sql("SELECT genotypes FROM remote_plink WHERE id = 'rs3'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        gt_values(&genotype[0], 0),
+        vec![Some(1), Some(1), Some(2), Some(0), None]
+    );
+    assert_eq!(server.bed_get_ranges(), vec![Some((0, 2)), Some((7, 8))]);
+}
+
+#[tokio::test]
+async fn explicit_companions_override_basename_and_fid_iid_is_escaped() {
+    let fixture = fixture();
+    let provider = PlinkTableProvider::try_new(
+        path(&fixture.bed),
+        PlinkReadOptions {
+            bim_path: Some(path(&fixture.bim)),
+            fam_path: Some(path(&fixture.fam)),
+            sample_id_mode: SampleIdMode::FidIid,
+            samples: Some(vec!["f%3A2:s%254".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(provider.sample_names(), &["f%3A2:s%254"]);
+}
+
+#[tokio::test]
+async fn rejects_fileset_integrity_and_layout_errors_during_open() {
+    for (header, length_delta, expected) in [
+        ([0x6c, 0x1b, 0x00], 0_isize, "sample-major"),
+        ([0x00, 0x00, 0x00], 0, "invalid or legacy magic"),
+        ([0x6c, 0x1b, 0x01], -1, "length mismatch"),
+        ([0x6c, 0x1b, 0x01], 1, "length mismatch"),
+    ] {
+        let fixture = fixture();
+        let mut bytes = fs::read(&fixture.bed).unwrap();
+        bytes[..3].copy_from_slice(&header);
+        if length_delta < 0 {
+            bytes.pop();
+        } else if length_delta > 0 {
+            bytes.push(0);
+        }
+        fs::write(&fixture.bed, bytes).unwrap();
+        let error = PlinkTableProvider::try_new(path(&fixture.bed), Default::default())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(expected), "{error}");
+    }
+}
+
+#[tokio::test]
+async fn missing_companions_fail_with_the_fileset_role() {
+    let dir = TempDir::new().unwrap();
+    let bed = dir.path().join("missing.bed");
+    fs::write(&bed, [0x6c, 0x1b, 0x01]).unwrap();
+    let error = PlinkTableProvider::try_new(path(&bed), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("BIM"), "{error}");
+
+    let explicit = dir.path().join("not-there.bim");
+    let error = PlinkTableProvider::try_new(
+        path(&bed),
+        PlinkReadOptions {
+            bim_path: Some(path(&explicit)),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("explicit BIM companion"), "{error}");
+}
+
+#[tokio::test]
+async fn rejects_malformed_companions_duplicate_iids_limits_and_padding() {
+    let malformed_bim = fixture();
+    fs::write(&malformed_bim.bim, "1 rs1 nan 10 A C\n").unwrap();
+    let error = PlinkTableProvider::try_new(path(&malformed_bim.bed), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("centimorgan value must be finite"));
+
+    let duplicate_fam = fixture();
+    fs::write(&duplicate_fam.fam, "f1 s1 0 0 1 -9\nf2 s1 0 0 2 -9\n").unwrap();
+    fs::write(
+        &duplicate_fam.bed,
+        encode_bed(&[[0_u8, 0_u8], [0, 0], [0, 0], [0, 0]]),
+    )
+    .unwrap();
+    let error = PlinkTableProvider::try_new(path(&duplicate_fam.bed), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("duplicate IID"));
+
+    let limited = fixture();
+    let error = PlinkTableProvider::try_new(
+        path(&limited.bed),
+        PlinkReadOptions {
+            max_variants: 3,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("max_variants"));
+
+    let bad_padding = fixture();
+    let mut bytes = fs::read(&bad_padding.bed).unwrap();
+    bytes[4] |= 0b01_00_00_00;
+    fs::write(&bad_padding.bed, bytes).unwrap();
+    let provider = PlinkTableProvider::try_new(path(&bad_padding.bed), PlinkReadOptions::default())
+        .await
+        .unwrap();
+    let context = one_partition_context();
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let error = context
+        .sql("SELECT genotypes FROM p WHERE id = 'rs1'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("variant 0"));
+    assert!(error.contains("padding"));
+}
+
+#[tokio::test]
+async fn differential_against_bed_reader_when_available() {
+    let fixture = fixture();
+    let available = Command::new("python3")
+        .args(["-c", "import bed_reader"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success());
+    if !available {
+        assert!(
+            std::env::var_os("REQUIRE_PLINK_ORACLE").is_none(),
+            "bed-reader is required when REQUIRE_PLINK_ORACLE is set"
+        );
+        return;
+    }
+
+    let script = r#"
+import numpy as np
+from bed_reader import open_bed
+values = open_bed(__import__("sys").argv[1]).read(dtype="float64")
+expected = np.array([
+    [2, 1, 0, np.nan, 2],
+    [0, np.nan, 1, 2, 0],
+    [1, 1, 2, 0, np.nan],
+    [np.nan, 0, 0, 1, 1],
+], dtype="float64")
+assert values.shape == expected.shape, (values.shape, expected.shape)
+assert np.array_equal(np.isnan(values), np.isnan(expected))
+assert np.array_equal(np.nan_to_num(values), np.nan_to_num(expected))
+"#;
+    let status = Command::new("python3")
+        .args(["-c", script, &path(&fixture.bed)])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let provider = PlinkTableProvider::try_new(path(&fixture.bed), PlinkReadOptions::default())
+        .await
+        .unwrap();
+    let context = one_partition_context();
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM p WHERE id = 'rs1'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        gt_values(&batches[0], 0),
+        vec![Some(2), Some(1), Some(0), None, Some(2)]
+    );
+}
+
+#[test]
+fn differential_against_plink_when_available() {
+    let available = Command::new("plink")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success());
+    if !available {
+        assert!(
+            std::env::var_os("REQUIRE_PLINK_CLI_ORACLE").is_none(),
+            "PLINK is required when REQUIRE_PLINK_CLI_ORACLE is set"
+        );
+        return;
+    }
+
+    let fixture = fixture();
+    let prefix = fixture.bed.with_extension("");
+    let output = fixture._dir.path().join("plink-oracle");
+    let status = Command::new("plink")
+        .args([
+            "--bfile",
+            &path(&prefix),
+            "--keep-allele-order",
+            "--recode",
+            "A",
+            "--out",
+            &path(&output),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let raw = fs::read_to_string(output.with_extension("raw")).unwrap();
+    let mut lines = raw.lines();
+    let header: Vec<_> = lines.next().unwrap().split_whitespace().collect();
+    let rs1 = header
+        .iter()
+        .position(|name| name.starts_with("rs1_"))
+        .unwrap();
+    let rs2 = header
+        .iter()
+        .position(|name| name.starts_with("rs2_"))
+        .unwrap();
+    let rs3 = header
+        .iter()
+        .position(|name| name.starts_with("rs3_"))
+        .unwrap();
+    let rows: Vec<Vec<_>> = lines
+        .map(|line| line.split_whitespace().collect())
+        .collect();
+    let value = |row: usize, column: usize| match rows[row][column] {
+        "NA" => None,
+        value => Some(value.parse::<u8>().unwrap()),
+    };
+    assert_eq!(
+        (0..5).map(|row| value(row, rs1)).collect::<Vec<_>>(),
+        vec![Some(2), Some(1), Some(0), None, Some(2)]
+    );
+    assert_eq!(
+        (0..5).map(|row| value(row, rs2)).collect::<Vec<_>>(),
+        vec![Some(0), None, Some(1), Some(2), Some(0)]
+    );
+    assert_eq!(
+        (0..5).map(|row| value(row, rs3)).collect::<Vec<_>>(),
+        vec![Some(1), Some(1), Some(2), Some(0), None]
+    );
+}

--- a/openspec/changes/add-genotype-format-providers/tasks.md
+++ b/openspec/changes/add-genotype-format-providers/tasks.md
@@ -70,28 +70,28 @@
 
 ## 4. PLINK 1 Provider
 
-- [ ] 4.1 Create the `bio-format-plink1` crate and public read options.
-- [ ] 4.2 Resolve explicit and conventional BED/BIM/FAM filesets.
-- [ ] 4.3 Parse FAM sample IDs with an explicit documented identifier policy.
-- [ ] 4.4 Parse BIM columns, chromosome values, positions, IDs, centimorgan
+- [x] 4.1 Create the `bio-format-plink1` crate and public read options.
+- [x] 4.2 Resolve explicit and conventional BED/BIM/FAM filesets.
+- [x] 4.3 Parse FAM sample IDs with an explicit documented identifier policy.
+- [x] 4.4 Parse BIM columns, chromosome values, positions, IDs, centimorgan
   values, `A1`, and `A2` without assigning reference semantics.
-- [ ] 4.5 Validate BED magic bytes and require current variant-major mode.
-- [ ] 4.6 Validate BIM/FAM counts against exact BED length with checked
+- [x] 4.5 Validate BED magic bytes and require current variant-major mode.
+- [x] 4.6 Validate BIM/FAM counts against exact BED length with checked
   arithmetic.
-- [ ] 4.7 Reject non-zero unused padding bits in each variant's final BED byte.
-- [ ] 4.8 Decode two-bit calls to documented A1 dosage and null missingness.
-- [ ] 4.9 Apply sample selection directly to packed calls without materializing
+- [x] 4.7 Reject non-zero unused padding bits in each variant's final BED byte.
+- [x] 4.8 Decode two-bit calls to documented A1 dosage and null missingness.
+- [x] 4.9 Apply sample selection directly to packed calls without materializing
   unselected genotypes.
-- [ ] 4.10 Apply exact variant filters and limits to BIM rows before BED I/O.
-- [ ] 4.11 Skip BED entirely for metadata-only and empty-sample queries.
-- [ ] 4.12 Plan contiguous fixed-offset variant ranges and coalesce adjacent
+- [x] 4.10 Apply exact variant filters and limits to BIM rows before BED I/O.
+- [x] 4.11 Skip BED entirely for metadata-only and empty-sample queries.
+- [x] 4.12 Plan contiguous fixed-offset variant ranges and coalesce adjacent
   object-store requests.
-- [ ] 4.13 Partition selected variants by payload bytes up to target partitions.
-- [ ] 4.14 Add local and object-store fileset consistency tests.
-- [ ] 4.15 Add differential tests against PLINK and `bed-reader`.
-- [ ] 4.16 Add malformed BIM/FAM, sample-major, legacy BED, truncation, padding,
+- [x] 4.13 Partition selected variants by payload bytes up to target partitions.
+- [x] 4.14 Add local and object-store fileset consistency tests.
+- [x] 4.15 Add differential tests against PLINK and `bed-reader`.
+- [x] 4.16 Add malformed BIM/FAM, sample-major, legacy BED, truncation, padding,
   and overflow tests.
-- [ ] 4.17 Benchmark dense and sparse variants, sparse samples, metadata-only
+- [x] 4.17 Benchmark dense and sparse variants, sparse samples, metadata-only
   queries, range coalescing, and parallel scans.
 
 ## 5. BGEN Provider


### PR DESCRIPTION
## Summary

Adds a read-only DataFusion provider for current variant-major PLINK 1 BED/BIM/FAM filesets. This PR is stacked on #217 and uses the shared genotype selection, metadata, metrics, companion resolution, byte-range planning, and OpenDAL range-read infrastructure introduced there.

## Provider behavior

- resolves conventional shared-basename `.bim` and `.fam` companions, with explicit overrides
- validates the `6c 1b 01` BED header and rejects legacy or sample-major layouts
- validates exact BED length from checked BIM/FAM counts
- exposes `chrom`, `start`, `end`, `id`, `cm`, `a1`, `a2`, and nested `genotypes.GT`
- decodes nullable A1 dosage as `00 -> 2`, `10 -> 1`, `11 -> 0`, `01 -> null`
- validates unused high-order padding bits with variant-index context
- supports strict IID or escaped `FID:IID` sample identity and preserves original pairs in Arrow metadata
- decodes requested samples directly from packed lanes in caller order
- evaluates supported chromosome, coordinate, and ID filters exactly against BIM before BED I/O
- safely pushes limits below exact filters
- skips BED payloads for metadata-only, count, and empty-sample scans
- coalesces bounded fixed-offset ranges and byte-balances them across DataFusion partitions
- reuses one local file handle or remote OpenDAL object per execution partition
- exposes genotype planning and execution counters

## Conformance

The crate includes 19 unit/integration tests covering local and HTTP-range filesets, all two-bit states, sample reordering, exact filters and limits, zero-payload metadata scans, padding, malformed BIM/FAM, missing companions, legacy/sample-major layouts, truncation/trailing bytes, checked overflow, and Arrow metadata.

Independent process-level oracle tests support both pinned `bed-reader` and PLINK `--recode A`. They are optional locally and enforced in oracle CI by `REQUIRE_PLINK_ORACLE=1` and `REQUIRE_PLINK_CLI_ORACLE=1`.

## Benchmark smoke baseline

Criterion fixture: 4,096 variants x 256 samples, release build, 10-sample smoke run on the development machine.

| Query path | Time |
| --- | ---: |
| Dense genotypes | 3.42 ms |
| Metadata only | 113 us |
| Three selected samples | 274 us |
| Sparse 512-ID query, separate ranges | 11.8 ms |
| Same sparse query, bounded coalescing | 5.12 ms |
| Four-partition dense scan | 3.41 ms |

These values validate the harness and optimization paths; they are not intended as cross-machine performance claims.

## Validation

- `cargo test -p datafusion-bio-format-plink1`
- `cargo check -p datafusion-bio-format-plink1 --benches`
- `cargo clippy -p datafusion-bio-format-plink1 --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `openspec validate add-genotype-format-providers --strict`
- `cargo bench -p datafusion-bio-format-plink1 --bench plink1_scan -- --sample-size 10 --measurement-time 0.1 --warm-up-time 0.1`

## Dependency

- Base PR: #217
- Format spec: #216