### PR TITLE
Add PGEN genotype provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,6 +1573,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-bio-format-pgen"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "criterion",
+ "datafusion",
+ "datafusion-bio-format-core",
+ "flate2",
+ "opendal",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "zstd",
+]
+
+[[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.9.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [ "datafusion/bio-format-bam", "datafusion/bio-format-bbi", "datafusio
     "datafusion/bio-format-gtf", "datafusion/bio-format-vcf", "datafusion/bio-format-fasta",
     "datafusion/bio-format-cram", "datafusion/bio-format-pairs", "datafusion/bio-format-ensembl-cache",
     "datafusion/bio-format-bgen",
+    "datafusion/bio-format-pgen",
     "benchmarks/common", "benchmarks/runner",
 ]
 

--- a/datafusion/bio-format-core/src/range_planning.rs
+++ b/datafusion/bio-format-core/src/range_planning.rs
@@ -79,6 +79,54 @@ pub fn coalesce_byte_ranges(
     Ok(coalesced)
 }
 
+/// Coalesces an already-sorted fallible byte-range stream without staging it.
+///
+/// This is intended for large indexes whose record descriptors are decoded on
+/// demand. Input ranges must be ordered by nondecreasing start offset; lookup
+/// errors and unsorted input are returned immediately.
+pub fn try_coalesce_sorted_byte_ranges(
+    ranges: impl IntoIterator<Item = Result<ByteRange>>,
+    max_gap: u64,
+    max_range_size: u64,
+) -> Result<Vec<ByteRange>> {
+    if max_range_size == 0 {
+        return Err(DataFusionError::Plan(
+            "max_range_size must be greater than zero".to_string(),
+        ));
+    }
+
+    let mut coalesced: Vec<ByteRange> = Vec::new();
+    let mut previous_start = None;
+    for next in ranges {
+        let next = next?;
+        if previous_start.is_some_and(|start| next.start < start) {
+            return Err(DataFusionError::Plan(
+                "byte ranges supplied to the streaming coalescer are not sorted".to_string(),
+            ));
+        }
+        previous_start = Some(next.start);
+        let Some(current) = coalesced.last_mut() else {
+            coalesced.push(next);
+            continue;
+        };
+
+        let overlaps = next.start < current.end;
+        let gap = next.start.saturating_sub(current.end);
+        let combined_end = current.end.max(next.end);
+        let combined_size = combined_end.checked_sub(current.start).ok_or_else(|| {
+            DataFusionError::Plan("byte range size arithmetic overflowed".to_string())
+        })?;
+        let nearby = next.start >= current.end && gap <= max_gap && combined_size <= max_range_size;
+
+        if overlaps || nearby {
+            current.end = combined_end;
+        } else {
+            coalesced.push(next);
+        }
+    }
+    Ok(coalesced)
+}
+
 /// Byte ranges assigned to one DataFusion physical partition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ByteRangePartition {
@@ -232,6 +280,19 @@ mod tests {
             coalesce_byte_ranges(vec![range(0, 100), range(50, 150)], 0, 10).unwrap(),
             vec![range(0, 150)]
         );
+    }
+
+    #[test]
+    fn streams_fallible_sorted_ranges_without_staging() {
+        let ranges = vec![Ok(range(0, 10)), Ok(range(12, 20)), Ok(range(100, 110))];
+        assert_eq!(
+            try_coalesce_sorted_byte_ranges(ranges, 2, 50).unwrap(),
+            vec![range(0, 20), range(100, 110)]
+        );
+        let unsorted = vec![Ok(range(10, 20)), Ok(range(0, 5))];
+        assert!(try_coalesce_sorted_byte_ranges(unsorted, 0, 50).is_err());
+        let failed = vec![Err(DataFusionError::Plan("lookup failed".to_string()))];
+        assert!(try_coalesce_sorted_byte_ranges(failed, 0, 50).is_err());
     }
 
     #[test]

--- a/datafusion/bio-format-pgen/BENCHMARKS.md
+++ b/datafusion/bio-format-pgen/BENCHMARKS.md
@@ -28,3 +28,65 @@ cargo bench -p datafusion-bio-format-pgen --bench pgen_scan
 ```
 
 Treat these as same-machine regression baselines, not cross-machine targets.
+
+## Pinned `snputils` parity gate
+
+The release gate uses an official-`pgenlib` writer fixture with 16,384 fully
+phased biallelic variants, 1,024 samples, 0.5% missing calls, and RNG seed
+`20260816`. Both readers materialize all `GT` calls. DataFusion target
+partitions, Tokio workers, Polars, Rayon, OpenMP, and numerical-library pools
+are constrained to one for the single-thread comparison.
+
+Pinned oracle versions:
+
+- `snputils` `482c6d1dfd6c4001935dfaec81ae01a5e0ec3e53`;
+- `pgenlib` 0.94.1; and
+- NumPy 2.4.6.
+
+Apple M3 Max result from 2026-08-16, ten measured iterations after warmup:
+
+| Reader | Partitions/threads | Median | Output bytes | Maximum RSS |
+| --- | ---: | ---: | ---: | ---: |
+| `snputils` phased `GT` | 1 | 71.60 ms | 33,554,432 | 587,841,536 |
+| Rust PGEN `GT` | 1 | 32.92 ms | 69,272,392 | 163,889,152 |
+| Rust PGEN `GT` | 2 | 18.26 ms | 69,272,392 | not sampled |
+| Rust PGEN `GT` | 4 | 9.72 ms | 69,273,232 | not sampled |
+| Rust PGEN `GT` | 8 | 7.03 ms | 69,274,912 | not sampled |
+
+The Rust single-partition path is 2.18x faster despite emitting a nullable
+Arrow `UInt16` allele-pair representation. Four partitions reach 3.39x the
+one-partition throughput. The Rust and Python genotype digests were identical:
+
+```text
+16692912:8342602:8347936:560154221234404
+```
+
+Create an isolated oracle environment, generate the fixture, and run both
+readers with:
+
+```shell
+python -m venv .venv-pgen-parity
+.venv-pgen-parity/bin/pip install -r \
+  datafusion/bio-format-pgen/benchmark/requirements-pgen-parity.txt
+.venv-pgen-parity/bin/python \
+  datafusion/bio-format-pgen/benchmark/pgen_oracle.py \
+  generate /tmp/pgen-parity/fixture
+
+POLARS_MAX_THREADS=1 RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+VECLIB_MAXIMUM_THREADS=1 NUMEXPR_NUM_THREADS=1 \
+.venv-pgen-parity/bin/python \
+  datafusion/bio-format-pgen/benchmark/pgen_oracle.py \
+  benchmark /tmp/pgen-parity/fixture --iterations 10
+
+cargo run --release -p datafusion-bio-format-pgen \
+  --example pgen_parity -- /tmp/pgen-parity/fixture.pgen 10 1
+```
+
+Set `PGEN_PROFILE=1` on the Rust command to print per-partition read, decode,
+append, and Arrow-finalization timing together with record-representation
+counts. Profiling is disabled by default and does not create another thread
+pool.
+
+The Python dependencies are external benchmark/oracle tools. They are not
+linked, imported, or vendored by the Rust crate.

--- a/datafusion/bio-format-pgen/BENCHMARKS.md
+++ b/datafusion/bio-format-pgen/BENCHMARKS.md
@@ -83,10 +83,5 @@ cargo run --release -p datafusion-bio-format-pgen \
   --example pgen_parity -- /tmp/pgen-parity/fixture.pgen 10 1
 ```
 
-Set `PGEN_PROFILE=1` on the Rust command to print per-partition read, decode,
-append, and Arrow-finalization timing together with record-representation
-counts. Profiling is disabled by default and does not create another thread
-pool.
-
 The Python dependencies are external benchmark/oracle tools. They are not
 linked, imported, or vendored by the Rust crate.

--- a/datafusion/bio-format-pgen/BENCHMARKS.md
+++ b/datafusion/bio-format-pgen/BENCHMARKS.md
@@ -1,0 +1,30 @@
+# PGEN benchmark snapshot
+
+The Criterion fixture is generated at runtime and contains 2,048 biallelic
+variants by 128 samples. It commits no genotype data.
+
+The matrix measures dense, one-bit, difflist, and LD-heavy hardcalls; metadata
+projection; 1-in-16 sparse variant selection; three selected samples; dosage
+output; and a four-partition dense scan.
+
+Snapshot from Apple M3 Max, arm64, macOS 15.6, Rust 1.91.0:
+
+| Scan | Median |
+| --- | ---: |
+| Dense hardcalls | 6.84 ms |
+| One-bit hardcalls | 6.55 ms |
+| Difflist hardcalls | 6.56 ms |
+| LD-heavy hardcalls | 6.47 ms |
+| Metadata only | 112.00 us |
+| Sparse variants, 1/16 selected | 5.99 ms |
+| Three selected samples | 2.69 ms |
+| Dosage output | 5.37 ms |
+| Dense hardcalls, four partitions | 1.93 ms |
+
+Run it with:
+
+```shell
+cargo bench -p datafusion-bio-format-pgen --bench pgen_scan
+```
+
+Treat these as same-machine regression baselines, not cross-machine targets.

--- a/datafusion/bio-format-pgen/CONFORMANCE.md
+++ b/datafusion/bio-format-pgen/CONFORMANCE.md
@@ -1,0 +1,60 @@
+# PGEN conformance
+
+The normative baseline is the `plink-ng` PGEN specification at commit
+`9ee41ce224ea7cd091760d69392a98835715b5b2` (2026-07-27). Production code is an
+independent Rust decoder. It does not link or distribute PLINK 2, `pgenlib`,
+or `snputils`.
+
+The test strategy has four layers:
+
+1. Unit and deterministic property tests cover varint boundaries, packed
+   padding, difflist groups and deltas, phase tracks, dosage bounds, allele
+   patches, checked lengths, invalid LD chains, and partition ownership.
+2. Generated integration files cover all eight supported storage modes,
+   embedded and external indexes, dense, one-bit, difflist, LD/inverted-LD,
+   multiallelic hardcalls, sparse/all/bitarray dosage, phase-present and
+   phase-information tracks, explicit and implicit haplotype dosage, sample
+   reordering, filters, limits, and projection.
+3. Local and HTTP tests use the same fileset and assert exact query results,
+   metadata payload skipping, LD dependency reads, and bounded remote PGEN
+   range requests.
+4. Process-level differential tests have pinned Python reference readers
+   generate or read the same hardcall, phase, and dosage files. The Rust
+   output is compared sample by sample in PVAR allele order.
+
+The validated reference versions are:
+
+| Oracle | Version | Role |
+| --- | --- | --- |
+| PLINK `pgenlib` | 0.94.1 | Authoritative writer and hardcall/phase/dosage reader |
+| `snputils` | 1.1.0 | Independent high-level hardcall and phased-call reader |
+| PLINK 2 CLI | 2.0.0-a.7.1 (4 May 2026) | End-to-end PGEN-to-VCF hardcall export |
+
+External tools are test-only. The regular suite executes `pgenlib` and
+`snputils` when they are installed:
+
+```shell
+cargo test -p datafusion-bio-format-pgen
+```
+
+A conformance job makes absence fatal and supplies the isolated Python
+environment:
+
+```shell
+PGEN_REFERENCE_PYTHONPATH=/path/to/pinned/python/site-packages \
+PGEN_REQUIRE_REFERENCE_ORACLES=1 \
+PGEN_REFERENCE_PLINK2=/path/to/plink2 \
+PGEN_REQUIRE_PLINK2_ORACLE=1 \
+  cargo test -p datafusion-bio-format-pgen \
+    differential_pgenlib_and_snputils_oracles_when_installed
+```
+
+For randomized expansion, use a deterministic seed to generate calls through
+`pgenlib.PgenWriter`, read the result through all available oracles, and retain
+the seed and generated companions for every failure. Comparisons are exact for
+hardcall allele indices and phase. Dosage comparisons use the PGEN
+quantization step of `1 / 16384` plus floating conversion tolerance.
+
+Phased dosage is covered by specification-derived byte fixtures because the
+current `pgenlib` Python writer rejects `dosage_phase_present`; this is an
+explicit oracle gap rather than an inferred external comparison.

--- a/datafusion/bio-format-pgen/CONFORMANCE.md
+++ b/datafusion/bio-format-pgen/CONFORMANCE.md
@@ -27,7 +27,7 @@ The validated reference versions are:
 | Oracle | Version | Role |
 | --- | --- | --- |
 | PLINK `pgenlib` | 0.94.1 | Authoritative writer and hardcall/phase/dosage reader |
-| `snputils` | 1.1.0 | Independent high-level hardcall and phased-call reader |
+| `snputils` | 1.1.1.dev19+g482c6d1df | Independent high-level hardcall and phased-call reader |
 | PLINK 2 CLI | 2.0.0-a.7.1 (4 May 2026) | End-to-end PGEN-to-VCF hardcall export |
 
 External tools are test-only. The regular suite executes `pgenlib` and

--- a/datafusion/bio-format-pgen/Cargo.toml
+++ b/datafusion/bio-format-pgen/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "datafusion-bio-format-pgen"
+version = "0.1.0"
+description = "PLINK 2 PGEN/PVAR/PSAM genotype support for Apache DataFusion"
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+readme = "README.md"
+
+[dependencies]
+async-stream.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+datafusion.workspace = true
+datafusion-bio-format-core = { path = "../bio-format-core" }
+flate2.workspace = true
+opendal.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util"] }
+zstd = "0.13"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
+tempfile = "3"
+tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
+
+[[bench]]
+name = "pgen_scan"
+harness = false

--- a/datafusion/bio-format-pgen/README.md
+++ b/datafusion/bio-format-pgen/README.md
@@ -50,8 +50,9 @@ let batches = context
 ```
 
 The provider resolves `.pvar` (then `.pvar.zst`) and `.psam` beside the PGEN
-file unless explicit locations are supplied. Modes `0x01`, `0x02`, `0x03`,
-`0x04`, `0x10`, `0x11`, `0x20`, and `0x21` are supported, including
+file unless explicit locations are supplied. Explicit gzip/zstd PVAR and PSAM
+companions are decompressed within the configured bound. Modes `0x01`, `0x02`,
+`0x03`, `0x04`, `0x10`, `0x11`, `0x20`, and `0x21` are supported, including
 standard `.pgen.pgi` external indexes. BED/BIM/FAM hybrid companions are
 rejected.
 

--- a/datafusion/bio-format-pgen/README.md
+++ b/datafusion/bio-format-pgen/README.md
@@ -12,10 +12,15 @@ The nested `genotypes` struct can contain:
 
 | Field | Value |
 | --- | --- |
-| `GT` | Per-sample nullable raw allele-index pair |
+| `GT` | Per-sample nullable fixed-size pair of encoded allele slots (`UInt16`) |
 | `PHASED` | Per-sample nullable hardcall phase flag |
-| `DS` | Per-sample nullable dosage of ALT allele index 1 |
+| `DS` | Effective nullable dosage of ALT allele index 1 (stored value, then hardcall fallback) |
+| `DS_STORED` | Physically stored nullable dosage of ALT allele index 1 |
 | `HDS` | Per-sample nullable pair of ALT-1 haplotype dosages |
+
+PGEN does not carry biological ploidy. `GT` therefore exposes its two encoded
+allele slots with `bio.pgen.ploidy_semantics=encoded_diploid` metadata and does
+not infer chromosome-, sex-, build-, or PAR-dependent ploidy.
 
 ```rust,no_run
 use std::sync::Arc;

--- a/datafusion/bio-format-pgen/README.md
+++ b/datafusion/bio-format-pgen/README.md
@@ -1,0 +1,71 @@
+# datafusion-bio-format-pgen
+
+Read-only Apache DataFusion provider for standard PLINK 2
+PGEN/PVAR/PSAM filesets. The implementation is independent Rust and follows
+the `plink-ng` PGEN specification at commit
+`9ee41ce224ea7cd091760d69392a98835715b5b2` (2026-07-27).
+
+One row represents one PVAR variant. `start` and `end` use the configured
+coordinate system; the default is zero-based, half-open. PVAR `REF` is allele
+index 0 and each `ALT` is preserved in source order as indices 1 through N.
+The nested `genotypes` struct can contain:
+
+| Field | Value |
+| --- | --- |
+| `GT` | Per-sample nullable raw allele-index pair |
+| `PHASED` | Per-sample nullable hardcall phase flag |
+| `DS` | Per-sample nullable dosage of ALT allele index 1 |
+| `HDS` | Per-sample nullable pair of ALT-1 haplotype dosages |
+
+```rust,no_run
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use datafusion_bio_format_pgen::{PgenReadOptions, PgenTableProvider};
+
+# async fn example() -> datafusion::common::Result<()> {
+let provider = PgenTableProvider::try_new(
+    "cohort.pgen",
+    PgenReadOptions {
+        samples: Some(vec!["sample_3".to_string(), "sample_1".to_string()]),
+        genotype_fields: Some(vec!["GT".to_string(), "DS".to_string()]),
+        ..Default::default()
+    },
+)
+.await?;
+let context = SessionContext::new();
+context.register_table("cohort", Arc::new(provider))?;
+let batches = context
+    .sql("SELECT id, ref, alt, genotypes FROM cohort WHERE chrom = '1'")
+    .await?
+    .collect()
+    .await?;
+# Ok(())
+# }
+```
+
+The provider resolves `.pvar` (then `.pvar.zst`) and `.psam` beside the PGEN
+file unless explicit locations are supplied. Modes `0x01`, `0x02`, `0x03`,
+`0x04`, `0x10`, `0x11`, `0x20`, and `0x21` are supported, including
+standard `.pgen.pgi` external indexes. BED/BIM/FAM hybrid companions are
+rejected.
+
+`PsamIdMode` controls selectable sample names. IID is the strict default;
+`FidIid` and `FidIidSid` create escaped composite names. Requested samples are
+emitted in request order, and absent names fail unless
+`missing_sample_policy` is changed.
+
+Exact pushdown covers `chrom` and `id` equality, inequality, and `IN`, plus
+`start` and `end` comparisons, ranges, and `IN`. Conjunctions of exact
+predicates remain exact. Metadata-only projections and empty sample
+selections validate the fileset but do not read variant payloads. Sparse scans
+range-read only selected records and any required LD base; adjacent reads are
+coalesced within configured limits.
+
+Parallel partitions have no implicit global row order. Add an SQL `ORDER BY`
+when order is required. Multiallelic hardcalls are supported; multiallelic
+dosage tracks are rejected explicitly because their output contract is not yet
+implemented.
+
+See [CONFORMANCE.md](CONFORMANCE.md) for reference-oracle testing and
+[BENCHMARKS.md](BENCHMARKS.md) for the generated performance matrix.

--- a/datafusion/bio-format-pgen/benches/pgen_scan.rs
+++ b/datafusion/bio-format-pgen/benches/pgen_scan.rs
@@ -1,0 +1,293 @@
+use std::fs;
+use std::hint::black_box;
+use std::path::Path;
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_pgen::{PgenReadOptions, PgenTableProvider};
+use tempfile::TempDir;
+
+const VARIANT_COUNT: usize = 2_048;
+const SAMPLE_COUNT: usize = 128;
+
+struct Fixture {
+    _directory: TempDir,
+    dense: String,
+    onebit: String,
+    difflist: String,
+    ld: String,
+    dosage: String,
+}
+
+fn create_fixture() -> Fixture {
+    let directory = tempfile::tempdir().unwrap();
+    write_metadata(directory.path());
+    let dense = write_pgen(
+        directory.path(),
+        "dense",
+        &(0..VARIANT_COUNT)
+            .map(|variant| {
+                (
+                    0x00,
+                    pack_codes(
+                        &(0..SAMPLE_COUNT)
+                            .map(|sample| ((variant + sample) % 4) as u8)
+                            .collect::<Vec<_>>(),
+                    ),
+                )
+            })
+            .collect::<Vec<_>>(),
+    );
+    let onebit = write_pgen(
+        directory.path(),
+        "onebit",
+        &(0..VARIANT_COUNT)
+            .map(|variant| {
+                let bit_byte = if variant % 2 == 0 { 0x55 } else { 0xaa };
+                let mut record = vec![2];
+                record.extend(std::iter::repeat_n(bit_byte, SAMPLE_COUNT.div_ceil(8)));
+                record.push(0);
+                (0x01, record)
+            })
+            .collect::<Vec<_>>(),
+    );
+    let difflist = write_pgen(
+        directory.path(),
+        "difflist",
+        &(0..VARIANT_COUNT)
+            .map(|variant| {
+                let start = (variant % (SAMPLE_COUNT - 4)) as u8;
+                (0x04, vec![4, start, 0b11_10_01_01, 1, 1, 1])
+            })
+            .collect::<Vec<_>>(),
+    );
+    let ld = write_pgen(
+        directory.path(),
+        "ld",
+        &(0..VARIANT_COUNT)
+            .map(|variant| {
+                if variant % 16 == 0 {
+                    (
+                        0x00,
+                        pack_codes(
+                            &(0..SAMPLE_COUNT)
+                                .map(|sample| ((variant + sample) % 3) as u8)
+                                .collect::<Vec<_>>(),
+                        ),
+                    )
+                } else {
+                    (0x02, vec![0])
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+    let dosage = write_pgen(
+        directory.path(),
+        "dosage",
+        &(0..VARIANT_COUNT)
+            .map(|variant| {
+                let categories = (0..SAMPLE_COUNT)
+                    .map(|sample| ((variant + sample) % 4) as u8)
+                    .collect::<Vec<_>>();
+                let mut record = pack_codes(&categories);
+                for category in categories {
+                    let dosage = match category {
+                        0 => 0_u16,
+                        1 => 16_384,
+                        2 => 32_768,
+                        3 => u16::MAX,
+                        _ => unreachable!(),
+                    };
+                    record.extend(dosage.to_le_bytes());
+                }
+                (0x40, record)
+            })
+            .collect::<Vec<_>>(),
+    );
+    Fixture {
+        _directory: directory,
+        dense,
+        onebit,
+        difflist,
+        ld,
+        dosage,
+    }
+}
+
+fn write_metadata(directory: &Path) {
+    let mut pvar = "#CHROM\tPOS\tID\tREF\tALT\n".to_string();
+    for variant in 0..VARIANT_COUNT {
+        pvar.push_str(&format!(
+            "{}\t{}\tv{variant}\tA\tC\n",
+            if variant < VARIANT_COUNT / 2 {
+                "1"
+            } else {
+                "2"
+            },
+            variant + 1
+        ));
+    }
+    fs::write(directory.join("cohort.pvar"), pvar).unwrap();
+    let mut psam = "#IID\n".to_string();
+    for sample in 0..SAMPLE_COUNT {
+        psam.push_str(&format!("sample{sample}\n"));
+    }
+    fs::write(directory.join("cohort.psam"), psam).unwrap();
+}
+
+fn write_pgen(directory: &Path, name: &str, records: &[(u8, Vec<u8>)]) -> String {
+    let length_width = if records.iter().all(|(_, record)| record.len() < 256) {
+        1
+    } else {
+        2
+    };
+    let control = 4 + length_width - 1;
+    let header_len = 12 + 8 + records.len() + records.len() * length_width;
+    let mut bytes = vec![0x6c, 0x1b, 0x10];
+    bytes.extend((records.len() as u32).to_le_bytes());
+    bytes.extend((SAMPLE_COUNT as u32).to_le_bytes());
+    bytes.push(control as u8);
+    bytes.extend((header_len as u64).to_le_bytes());
+    bytes.extend(records.iter().map(|(record_type, _)| *record_type));
+    for (_, record) in records {
+        let encoded = (record.len() as u32).to_le_bytes();
+        bytes.extend_from_slice(&encoded[..length_width]);
+    }
+    for (_, record) in records {
+        bytes.extend(record);
+    }
+    let path = directory.join(format!("{name}.pgen"));
+    fs::write(&path, bytes).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn pack_codes(codes: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0; codes.len().div_ceil(4)];
+    for (index, code) in codes.iter().copied().enumerate() {
+        bytes[index / 4] |= code << ((index % 4) * 2);
+    }
+    bytes
+}
+
+async fn context(
+    pgen: &str,
+    name: &str,
+    options: PgenReadOptions,
+    partitions: usize,
+) -> SessionContext {
+    let directory = Path::new(pgen).parent().unwrap();
+    let provider = PgenTableProvider::try_new(
+        pgen,
+        PgenReadOptions {
+            pvar_path: Some(directory.join("cohort.pvar").to_string_lossy().into_owned()),
+            psam_path: Some(directory.join("cohort.psam").to_string_lossy().into_owned()),
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    let context =
+        SessionContext::new_with_config(SessionConfig::new().with_target_partitions(partitions));
+    context.register_table(name, Arc::new(provider)).unwrap();
+    context
+}
+
+async fn execute(context: &SessionContext, sql: &str) -> usize {
+    context
+        .sql(sql)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap()
+        .iter()
+        .map(|batch| batch.num_rows())
+        .sum()
+}
+
+fn benchmarks(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let fixture = create_fixture();
+    let dense = runtime.block_on(context(&fixture.dense, "dense", Default::default(), 1));
+    let onebit = runtime.block_on(context(&fixture.onebit, "onebit", Default::default(), 1));
+    let difflist = runtime.block_on(context(
+        &fixture.difflist,
+        "difflist",
+        Default::default(),
+        1,
+    ));
+    let ld = runtime.block_on(context(&fixture.ld, "ld", Default::default(), 1));
+    let dosage = runtime.block_on(context(
+        &fixture.dosage,
+        "dosage",
+        PgenReadOptions {
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        },
+        1,
+    ));
+    let sparse_samples = runtime.block_on(context(
+        &fixture.dense,
+        "sparse_samples",
+        PgenReadOptions {
+            samples: Some(vec![
+                "sample1".to_string(),
+                "sample63".to_string(),
+                "sample127".to_string(),
+            ]),
+            ..Default::default()
+        },
+        1,
+    ));
+    let parallel = runtime.block_on(context(&fixture.dense, "parallel", Default::default(), 4));
+    let sparse_ids = (0..VARIANT_COUNT)
+        .step_by(16)
+        .map(|variant| format!("'v{variant}'"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let sparse_sql = format!("SELECT genotypes FROM dense WHERE id IN ({sparse_ids})");
+
+    let mut group = criterion.benchmark_group("pgen_scan");
+    for (name, context, table) in [
+        ("dense", &dense, "dense"),
+        ("onebit", &onebit, "onebit"),
+        ("difflist", &difflist, "difflist"),
+        ("ld_heavy", &ld, "ld"),
+    ] {
+        group.bench_function(name, |bencher| {
+            bencher.to_async(&runtime).iter(|| async {
+                black_box(execute(context, &format!("SELECT genotypes FROM {table}")).await)
+            });
+        });
+    }
+    group.bench_function("metadata_only", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&dense, "SELECT chrom, id FROM dense").await) });
+    });
+    group.bench_function("sparse_variants", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&dense, &sparse_sql).await) });
+    });
+    group.bench_function("sparse_samples", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            black_box(execute(&sparse_samples, "SELECT genotypes FROM sparse_samples").await)
+        });
+    });
+    group.bench_function("dosage", |bencher| {
+        bencher
+            .to_async(&runtime)
+            .iter(|| async { black_box(execute(&dosage, "SELECT genotypes FROM dosage").await) });
+    });
+    group.bench_function("parallel_dense_4", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            black_box(execute(&parallel, "SELECT genotypes FROM parallel").await)
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmarks);
+criterion_main!(benches);

--- a/datafusion/bio-format-pgen/benchmark/pgen_oracle.py
+++ b/datafusion/bio-format-pgen/benchmark/pgen_oracle.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Generate and benchmark the pinned PGEN parity fixture.
+
+The production Rust crate does not import this file or link pgenlib. It is an
+external LGPL/BSD oracle harness used only for conformance and release timing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.metadata
+from pathlib import Path
+import statistics
+import time
+
+import numpy as np
+
+DEFAULT_VARIANTS = 16_384
+DEFAULT_SAMPLES = 1_024
+DEFAULT_SEED = 2_026_08_16
+DEFAULT_MISSING_RATE = 0.005
+
+
+def generate(prefix: Path, variants: int, samples: int, seed: int) -> None:
+    import pgenlib
+
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(seed)
+    with pgenlib.PgenWriter(
+        str(prefix.with_suffix(".pgen")).encode(),
+        sample_ct=samples,
+        variant_ct=variants,
+        nonref_flags=False,
+        hardcall_phase_present=True,
+    ) as writer:
+        for start in range(0, variants, 512):
+            count = min(512, variants - start)
+            alleles = rng.integers(
+                0,
+                2,
+                size=(count, samples * 2),
+                dtype=np.int32,
+            )
+            missing = rng.random((count, samples)) < DEFAULT_MISSING_RATE
+            allele_rows = alleles.reshape(count, samples, 2)
+            allele_rows[missing] = -9
+            writer.append_alleles_batch(alleles, all_phased=True)
+
+    pvar = prefix.with_suffix(".pvar")
+    with pvar.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("#CHROM\tPOS\tID\tREF\tALT\n")
+        for variant in range(variants):
+            handle.write(f"1\t{variant + 1}\tv{variant}\tA\tC\n")
+
+    psam = prefix.with_suffix(".psam")
+    with psam.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("#IID\n")
+        for sample in range(samples):
+            handle.write(f"sample{sample}\n")
+
+    print(f"prefix={prefix}")
+    print(f"variants={variants}")
+    print(f"samples={samples}")
+    print(f"seed={seed}")
+
+
+def benchmark(prefix: Path, iterations: int) -> None:
+    import snputils
+
+    if iterations < 10:
+        raise ValueError("release parity requires at least 10 iterations")
+    path = str(prefix)
+
+    expected_shape = None
+    expected_bytes = None
+    digest = None
+    for _ in range(2):
+        result = snputils.read_pgen(
+            path,
+            genotype_mode="phased",
+            fields=["GT"],
+            chromosome_ploidy="autosomal",
+        ).genotypes
+        expected_shape = result.shape
+        expected_bytes = result.nbytes
+        digest = genotype_digest(result)
+        del result
+        gc.collect()
+
+    timings = []
+    for _ in range(iterations):
+        started = time.perf_counter_ns()
+        result = snputils.read_pgen(
+            path,
+            genotype_mode="phased",
+            fields=["GT"],
+            chromosome_ploidy="autosomal",
+        ).genotypes
+        elapsed = time.perf_counter_ns() - started
+        if result.shape != expected_shape or result.nbytes != expected_bytes:
+            raise RuntimeError("oracle output changed across iterations")
+        timings.append(elapsed)
+        del result
+        gc.collect()
+
+    print(f"snputils_version={importlib.metadata.version('snputils')}")
+    print(f"pgenlib_version={importlib.metadata.version('pgenlib')}")
+    print(f"shape={'x'.join(map(str, expected_shape))}")
+    print(f"numpy_bytes={expected_bytes}")
+    print(f"digest={digest}")
+    print(f"iterations={iterations}")
+    print(f"scan_median_ns={int(statistics.median(timings))}")
+
+
+def genotype_digest(genotypes: np.ndarray) -> str:
+    pairs = genotypes.reshape(-1, 2)
+    valid = np.all(pairs >= 0, axis=1)
+    valid_count = int(np.count_nonzero(valid))
+    left_sum = int(np.sum(pairs[valid, 0], dtype=np.uint64))
+    right_sum = int(np.sum(pairs[valid, 1], dtype=np.uint64))
+    weighted_sum = np.uint64(0)
+    for start in range(0, pairs.shape[0], 1_048_576):
+        end = min(start + 1_048_576, pairs.shape[0])
+        called = valid[start:end]
+        values = pairs[start:end].astype(np.uint64, copy=True)
+        values[~called] = 0
+        weights = np.arange(start + 1, end + 1, dtype=np.uint64)
+        weighted_sum += np.sum(
+            weights * (values[:, 0] * np.uint64(3) + values[:, 1] * np.uint64(5)),
+            dtype=np.uint64,
+        )
+    return f"{valid_count}:{left_sum}:{right_sum}:{int(weighted_sum)}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate")
+    generate_parser.add_argument("prefix", type=Path)
+    generate_parser.add_argument("--variants", type=int, default=DEFAULT_VARIANTS)
+    generate_parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    generate_parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+
+    benchmark_parser = subparsers.add_parser("benchmark")
+    benchmark_parser.add_argument("prefix", type=Path)
+    benchmark_parser.add_argument("--iterations", type=int, default=11)
+
+    arguments = parser.parse_args()
+    if arguments.command == "generate":
+        generate(arguments.prefix, arguments.variants, arguments.samples, arguments.seed)
+    else:
+        benchmark(arguments.prefix, arguments.iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/datafusion/bio-format-pgen/benchmark/requirements-pgen-parity.txt
+++ b/datafusion/bio-format-pgen/benchmark/requirements-pgen-parity.txt
@@ -1,0 +1,3 @@
+numpy==2.4.6
+pgenlib==0.94.1
+snputils @ git+https://github.com/AI-sandbox/snputils.git@482c6d1dfd6c4001935dfaec81ae01a5e0ec3e53

--- a/datafusion/bio-format-pgen/examples/pgen_parity.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_parity.rs
@@ -1,0 +1,186 @@
+//! Reproducible steady-state PGEN `GT` benchmark used by the release gate.
+//!
+//! Usage:
+//! `cargo run --release -p datafusion-bio-format-pgen --example pgen_parity -- <PGEN> [iterations] [partitions]`
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use datafusion::arrow::array::{Array, FixedSizeListArray, ListArray, StructArray, UInt16Array};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_pgen::{PgenReadOptions, PgenTableProvider};
+
+async fn execute(context: &SessionContext) -> (usize, usize) {
+    let batches = context
+        .sql("SELECT genotypes FROM pgen")
+        .await
+        .expect("plan GT scan")
+        .collect()
+        .await
+        .expect("execute GT scan");
+    (
+        batches.iter().map(|batch| batch.num_rows()).sum(),
+        batches
+            .iter()
+            .map(|batch| batch.get_array_memory_size())
+            .sum(),
+    )
+}
+
+async fn oracle_digest(context: &SessionContext) -> GenotypeDigest {
+    let batches = context
+        .sql("SELECT genotypes FROM pgen")
+        .await
+        .expect("plan GT checksum scan")
+        .collect()
+        .await
+        .expect("execute GT checksum scan");
+    let mut digest = GenotypeDigest::default();
+    for batch in &batches {
+        digest.update(batch);
+    }
+    digest
+}
+
+#[derive(Default)]
+struct GenotypeDigest {
+    sample_index: u64,
+    valid_count: u64,
+    left_sum: u64,
+    right_sum: u64,
+    weighted_sum: u64,
+}
+
+impl GenotypeDigest {
+    fn update(&mut self, batch: &RecordBatch) {
+        let genotypes = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("genotypes struct");
+        let gt = genotypes
+            .column_by_name("GT")
+            .expect("GT child")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("GT outer list");
+        let samples = gt
+            .values()
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("GT fixed-size sample pairs");
+        let alleles = samples
+            .values()
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("GT UInt16 alleles");
+        for sample in 0..samples.len() {
+            self.sample_index += 1;
+            if samples.is_null(sample) {
+                continue;
+            }
+            let left = u64::from(alleles.value(sample * 2));
+            let right = u64::from(alleles.value(sample * 2 + 1));
+            self.valid_count += 1;
+            self.left_sum += left;
+            self.right_sum += right;
+            self.weighted_sum = self.weighted_sum.wrapping_add(
+                self.sample_index
+                    .wrapping_mul(left.wrapping_mul(3).wrapping_add(right.wrapping_mul(5))),
+            );
+        }
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "{}:{}:{}:{}",
+            self.valid_count, self.left_sum, self.right_sum, self.weighted_sum
+        )
+    }
+}
+
+async fn open_context(path: &str, partitions: usize) -> SessionContext {
+    let provider = PgenTableProvider::try_new(
+        path,
+        PgenReadOptions {
+            genotype_fields: Some(vec!["GT".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("open PGEN fileset");
+    let context = SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_target_partitions(partitions)
+            .with_batch_size(8192),
+    );
+    context
+        .register_table("pgen", Arc::new(provider))
+        .expect("register PGEN table");
+    context
+}
+
+fn median(values: &mut [Duration]) -> Duration {
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
+async fn run(path: &str, iterations: usize, partitions: usize) {
+    assert!(
+        iterations >= 10,
+        "release parity requires at least 10 iterations"
+    );
+    assert!(partitions > 0, "partitions must be positive");
+
+    let open_started = Instant::now();
+    let context = open_context(path, partitions).await;
+    let provider_open = open_started.elapsed();
+    let expected = execute(&context).await;
+    let digest = oracle_digest(&context).await;
+
+    let mut scan_times = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        assert_eq!(execute(&context).await, expected);
+        scan_times.push(started.elapsed());
+    }
+
+    let mut end_to_end_times = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        let fresh = open_context(path, partitions).await;
+        assert_eq!(execute(&fresh).await, expected);
+        end_to_end_times.push(started.elapsed());
+    }
+
+    println!("rows={}", expected.0);
+    println!("arrow_bytes={}", expected.1);
+    println!("digest={}", digest.display());
+    println!("iterations={iterations}");
+    println!("partitions={partitions}");
+    println!("provider_open_ns={}", provider_open.as_nanos());
+    println!("scan_median_ns={}", median(&mut scan_times).as_nanos());
+    println!(
+        "end_to_end_median_ns={}",
+        median(&mut end_to_end_times).as_nanos()
+    );
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("PGEN path argument");
+    let iterations = std::env::args()
+        .nth(2)
+        .map(|value| value.parse::<usize>().expect("integer iteration count"))
+        .unwrap_or(11);
+    let partitions = std::env::args()
+        .nth(3)
+        .map(|value| value.parse::<usize>().expect("integer partition count"))
+        .unwrap_or(1);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(partitions)
+        .enable_all()
+        .build()
+        .expect("build Tokio runtime")
+        .block_on(run(&path, iterations, partitions));
+}

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -13,6 +13,93 @@ pub(crate) struct DecodedRecord {
     pub(crate) hds: Vec<Option<[f32; 2]>>,
 }
 
+/// Logical genotype children that a scan will retain in its output rows.
+///
+/// Physical tracks are still parsed and validated when their child is absent,
+/// but the decoder does not allocate or retain unprojected logical vectors.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct GenotypeProjection {
+    gt: bool,
+    phased: bool,
+    ds: bool,
+    ds_stored: bool,
+    hds: bool,
+}
+
+impl GenotypeProjection {
+    pub(crate) fn gt_only() -> Self {
+        Self {
+            gt: true,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn from_fields(fields: &[String]) -> Self {
+        let mut projection = Self::default();
+        for field in fields {
+            match field.as_str() {
+                "GT" => projection.gt = true,
+                "PHASED" => projection.phased = true,
+                "DS" => projection.ds = true,
+                "DS_STORED" => projection.ds_stored = true,
+                "HDS" => projection.hds = true,
+                _ => {}
+            }
+        }
+        projection
+    }
+
+    #[cfg(test)]
+    fn all() -> Self {
+        Self {
+            gt: true,
+            phased: true,
+            ds: true,
+            ds_stored: true,
+            hds: true,
+        }
+    }
+}
+
+struct DosageTrack<'a> {
+    encoding: u8,
+    sample_count: usize,
+    sample_ids: Vec<usize>,
+    value_bytes: &'a [u8],
+    values: Option<Vec<Option<f32>>>,
+}
+
+impl DosageTrack<'_> {
+    fn entry_count(&self) -> usize {
+        if self.encoding == 2 {
+            self.sample_count
+        } else {
+            self.sample_ids.len()
+        }
+    }
+
+    fn sample_at(&self, entry: usize) -> usize {
+        if self.encoding == 2 {
+            entry
+        } else {
+            self.sample_ids[entry]
+        }
+    }
+
+    fn stored_at(&self, entry: usize) -> Option<f32> {
+        let offset = entry * 2;
+        let value = u16::from_le_bytes([self.value_bytes[offset], self.value_bytes[offset + 1]]);
+        (value != u16::MAX).then(|| f32::from(value) / DOSAGE_SCALE)
+    }
+
+    fn effective_at(&self, entry: usize, calls: &[Option<[u16; 2]>]) -> Option<f32> {
+        self.stored_at(entry).or_else(|| {
+            calls[self.sample_at(entry)]
+                .map(|call| (u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32)
+        })
+    }
+}
+
 /// Reusable state for the projection-specialized biallelic `GT` decoder.
 ///
 /// The source-to-output map is built once per physical partition. Record
@@ -397,6 +484,7 @@ pub(crate) fn decode_record(
         variant_index,
         sample_count,
         allele_count,
+        GenotypeProjection::all(),
         selected_samples,
         ld_base,
     )
@@ -411,10 +499,18 @@ pub(crate) fn decode_record_and_main(
     variant_index: usize,
     sample_count: usize,
     allele_count: usize,
+    projection: GenotypeProjection,
     selected_samples: &[usize],
     ld_base: Option<&[u8]>,
 ) -> Result<(DecodedRecord, Vec<u8>)> {
     let mut cursor = Cursor::new(bytes, variant_index);
+    for &sample in selected_samples {
+        if sample >= sample_count {
+            return Err(cursor.error(format!(
+                "selected sample index {sample} is out of bounds for {sample_count} samples"
+            )));
+        }
+    }
     let categories = decode_main(&mut cursor, mode, record_type, sample_count, ld_base)?;
     let mut calls = categories
         .iter()
@@ -435,11 +531,16 @@ pub(crate) fn decode_record_and_main(
         )));
     }
 
-    let mut phased = vec![None; sample_count];
+    let mut phased = (projection.phased || projection.hds).then(|| vec![None; sample_count]);
     if record_type != 0xff && record_type & 0x10 != 0 {
-        decode_phase(&mut cursor, &mut calls, &mut phased)?;
-    } else {
-        for (call, output) in calls.iter().zip(&mut phased) {
+        decode_phase(
+            &mut cursor,
+            &mut calls,
+            phased.as_deref_mut(),
+            projection.gt || projection.hds,
+        )?;
+    } else if let Some(phased) = &mut phased {
+        for (call, output) in calls.iter().zip(phased) {
             if call.is_some() {
                 *output = Some(false);
             }
@@ -456,31 +557,60 @@ pub(crate) fn decode_record_and_main(
             "unsupported multiallelic PGEN dosage track; hardcalls remain supported".to_string(),
         ));
     }
-    let (stored_dosages, dosage_sample_ids) =
-        decode_dosage(&mut cursor, dosage_encoding, sample_count)?;
-    if dosage_encoding == 2 {
-        validate_fixed_dosage_missingness(&calls, &stored_dosages, &cursor)?;
-    }
-    validate_dosage_hardcall_consistency(&calls, &stored_dosages, &cursor)?;
-    let mut dosages = stored_dosages.clone();
-    for (dosage, call) in dosages.iter_mut().zip(&calls) {
-        if dosage.is_none()
-            && let Some(call) = call
-        {
-            *dosage = Some((u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32);
+    let has_hds_track = record_type != 0xff && record_type & 0x80 != 0;
+    let materialize_stored = projection.ds || projection.ds_stored || projection.hds;
+    let mut dosage_track = decode_dosage(
+        &mut cursor,
+        dosage_encoding,
+        sample_count,
+        &calls,
+        materialize_stored,
+    )?;
+    let mut dosages = if projection.ds || projection.hds {
+        Some(if projection.ds_stored {
+            dosage_track
+                .values
+                .clone()
+                .unwrap_or_else(|| vec![None; sample_count])
+        } else {
+            dosage_track
+                .values
+                .take()
+                .unwrap_or_else(|| vec![None; sample_count])
+        })
+    } else {
+        None
+    };
+    if let Some(dosages) = &mut dosages {
+        for (dosage, call) in dosages.iter_mut().zip(&calls) {
+            if dosage.is_none()
+                && let Some(call) = call
+            {
+                *dosage = Some((u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32);
+            }
         }
     }
-    let hds = if record_type != 0xff && record_type & 0x80 != 0 {
+    let hds = if has_hds_track {
         decode_phased_dosage(
             &mut cursor,
-            dosage_encoding,
-            &dosage_sample_ids,
-            &dosages,
+            &dosage_track,
+            dosages.as_deref(),
             &calls,
-            &phased,
+            phased.as_deref(),
+            projection.hds,
         )?
+    } else if projection.hds {
+        Some(implicit_haplotype_dosages(
+            dosages.as_deref().ok_or_else(|| {
+                cursor.error("HDS projection has no effective dosage values".to_string())
+            })?,
+            &calls,
+            phased.as_deref().ok_or_else(|| {
+                cursor.error("HDS projection has no hardcall phase values".to_string())
+            })?,
+        ))
     } else {
-        implicit_haplotype_dosages(&dosages, &calls, &phased)
+        None
     };
 
     if !cursor.is_finished() {
@@ -493,23 +623,67 @@ pub(crate) fn decode_record_and_main(
         return Err(cursor.error("decoded hardcall count is inconsistent".to_string()));
     }
 
-    let mut selected_gt = Vec::with_capacity(selected_samples.len());
-    let mut selected_phased = Vec::with_capacity(selected_samples.len());
-    let mut selected_ds = Vec::with_capacity(selected_samples.len());
-    let mut selected_ds_stored = Vec::with_capacity(selected_samples.len());
-    let mut selected_hds = Vec::with_capacity(selected_samples.len());
-    for &sample in selected_samples {
-        if sample >= sample_count {
-            return Err(cursor.error(format!(
-                "selected sample index {sample} is out of bounds for {sample_count} samples"
-            )));
-        }
-        selected_gt.push(calls[sample]);
-        selected_phased.push(phased[sample]);
-        selected_ds.push(dosages[sample]);
-        selected_ds_stored.push(stored_dosages[sample]);
-        selected_hds.push(hds[sample]);
-    }
+    let selected_gt = if projection.gt {
+        selected_samples
+            .iter()
+            .map(|&sample| calls[sample])
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let selected_phased = projection
+        .phased
+        .then(|| {
+            let phased = phased
+                .as_deref()
+                .ok_or_else(|| cursor.error("PHASED projection has no phase values".to_string()))?;
+            Ok::<_, DataFusionError>(
+                selected_samples
+                    .iter()
+                    .map(|&sample| phased[sample])
+                    .collect(),
+            )
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let selected_ds = projection
+        .ds
+        .then(|| {
+            let dosages = dosages.as_deref().ok_or_else(|| {
+                cursor.error("DS projection has no effective dosage values".to_string())
+            })?;
+            Ok::<_, DataFusionError>(
+                selected_samples
+                    .iter()
+                    .map(|&sample| dosages[sample])
+                    .collect(),
+            )
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let selected_ds_stored = if projection.ds_stored {
+        selected_samples
+            .iter()
+            .map(|&sample| {
+                dosage_track
+                    .values
+                    .as_deref()
+                    .and_then(|dosages| dosages[sample])
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let selected_hds = projection
+        .hds
+        .then(|| {
+            let hds = hds.as_deref().ok_or_else(|| {
+                cursor.error("HDS projection has no phased dosage values".to_string())
+            })?;
+            Ok::<_, DataFusionError>(selected_samples.iter().map(|&sample| hds[sample]).collect())
+        })
+        .transpose()?
+        .unwrap_or_default();
     Ok((
         DecodedRecord {
             gt: selected_gt,
@@ -910,7 +1084,8 @@ fn decode_packed_values(
 fn decode_phase(
     cursor: &mut Cursor<'_>,
     calls: &mut [Option<[u16; 2]>],
-    phased: &mut [Option<bool>],
+    mut phased: Option<&mut [Option<bool>]>,
+    orient_calls: bool,
 ) -> Result<()> {
     let heterozygous = calls
         .iter()
@@ -925,17 +1100,18 @@ fn decode_phase(
             cursor.error("hardcall-phase track is present without heterozygous calls".to_string())
         );
     }
+    let phase_bit_count = heterozygous
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| cursor.error("hardcall-phase bit count overflowed".to_string()))?;
     let first = *cursor
         .bytes
         .get(cursor.position)
         .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
     let explicit_present = first & 1 != 0;
     let present = if explicit_present {
-        let bytes = cursor.take(
-            (heterozygous.len() + 1).div_ceil(8),
-            "phase-present bitarray",
-        )?;
-        validate_phase_padding(bytes, heterozygous.len() + 1, cursor)?;
+        let bytes = cursor.take(phase_bit_count.div_ceil(8), "phase-present bitarray")?;
+        validate_phase_padding(bytes, phase_bit_count, cursor)?;
         (0..heterozygous.len())
             .map(|index| bit(bytes, index + 1))
             .collect::<Vec<_>>()
@@ -950,16 +1126,13 @@ fn decode_phase(
             .map(|index| bit(bytes, index))
             .collect::<Vec<_>>()
     } else {
-        let bytes = cursor.take(
-            (heterozygous.len() + 1).div_ceil(8),
-            "implicit phase-info bitarray",
-        )?;
+        let bytes = cursor.take(phase_bit_count.div_ceil(8), "implicit phase-info bitarray")?;
         if bytes.first().is_some_and(|byte| byte & 1 != 0) {
             return Err(
                 cursor.error("implicit phase track has phase-present marker set".to_string())
             );
         }
-        validate_phase_padding(bytes, heterozygous.len() + 1, cursor)?;
+        validate_phase_padding(bytes, phase_bit_count, cursor)?;
         (0..heterozygous.len())
             .map(|index| bit(bytes, index + 1))
             .collect::<Vec<_>>()
@@ -967,7 +1140,7 @@ fn decode_phase(
     let mut info_index = 0;
     for (heterozygous_index, &sample) in heterozygous.iter().enumerate() {
         if present[heterozygous_index] {
-            if info[info_index] {
+            if info[info_index] && orient_calls {
                 let call = calls[sample].as_mut().ok_or_else(|| {
                     cursor.error(format!(
                         "phase information addresses a missing hardcall for sample {sample}"
@@ -975,15 +1148,19 @@ fn decode_phase(
                 })?;
                 call.swap(0, 1);
             }
-            phased[sample] = Some(true);
+            if let Some(output) = phased.as_deref_mut() {
+                output[sample] = Some(true);
+            }
             info_index += 1;
-        } else {
-            phased[sample] = Some(false);
+        } else if let Some(output) = phased.as_deref_mut() {
+            output[sample] = Some(false);
         }
     }
-    for (sample, call) in calls.iter().enumerate() {
-        if call.is_some() && phased[sample].is_none() {
-            phased[sample] = Some(false);
+    if let Some(phased) = phased {
+        for (sample, call) in calls.iter().enumerate() {
+            if call.is_some() && phased[sample].is_none() {
+                phased[sample] = Some(false);
+            }
         }
     }
     Ok(())
@@ -996,6 +1173,9 @@ fn decode_phase_for_selected_gt(
     selected_codes: &mut [u8],
     identity_selection: bool,
 ) -> Result<()> {
+    // With a subset selection, phase orientation belongs only in selected_codes:
+    // categories must remain the raw main track so it can become a later LD base.
+    // For an identity selection, retain_main snapshots categories before this call.
     let heterozygous_count = categories.iter().filter(|&&category| category == 1).count();
     if heterozygous_count == 0 {
         return Err(
@@ -1100,18 +1280,20 @@ fn orient_selected_call(
     Ok(())
 }
 
-fn decode_dosage(
-    cursor: &mut Cursor<'_>,
+fn decode_dosage<'a>(
+    cursor: &mut Cursor<'a>,
     encoding: u8,
     sample_count: usize,
-) -> Result<(Vec<Option<f32>>, Vec<usize>)> {
+    calls: &[Option<[u16; 2]>],
+    materialize: bool,
+) -> Result<DosageTrack<'a>> {
     let sample_ids = match encoding {
         0 => Vec::new(),
         1 => decode_difflist(cursor, sample_count, false)?
             .into_iter()
             .map(|(sample, _)| sample)
             .collect(),
-        2 => (0..sample_count).collect(),
+        2 => Vec::new(),
         3 => {
             let bits = cursor.take(sample_count.div_ceil(8), "dosage-presence bitarray")?;
             validate_packed_padding(bits, sample_count, 1, cursor)?;
@@ -1121,17 +1303,40 @@ fn decode_dosage(
         }
         _ => unreachable!(),
     };
+    if encoding == 0 {
+        return Ok(DosageTrack {
+            encoding,
+            sample_count,
+            sample_ids,
+            value_bytes: &[],
+            values: None,
+        });
+    }
+    let entry_count = if encoding == 2 {
+        sample_count
+    } else {
+        sample_ids.len()
+    };
     let value_bytes = cursor.take(
-        sample_ids
-            .len()
+        entry_count
             .checked_mul(2)
             .ok_or_else(|| cursor.error("dosage byte count overflowed".to_string()))?,
         "dosage values",
     )?;
-    let mut output = vec![None; sample_count];
-    for (index, &sample) in sample_ids.iter().enumerate() {
+    let mut output = materialize.then(|| vec![None; sample_count]);
+    for index in 0..entry_count {
+        let sample = if encoding == 2 {
+            index
+        } else {
+            sample_ids[index]
+        };
         let value = u16::from_le_bytes([value_bytes[index * 2], value_bytes[index * 2 + 1]]);
         if encoding == 2 && value == u16::MAX {
+            if calls[sample].is_some() {
+                return Err(cursor.error(format!(
+                    "fixed-width dosage is missing while the hardcall is present for sample {sample}"
+                )));
+            }
             continue;
         }
         if value > 32_768 {
@@ -1139,83 +1344,80 @@ fn decode_dosage(
                 "dosage integer {value} exceeds 32768 for sample {sample}"
             )));
         }
-        output[sample] = Some(f32::from(value) / DOSAGE_SCALE);
-    }
-    Ok((output, sample_ids))
-}
-
-fn validate_dosage_hardcall_consistency(
-    calls: &[Option<[u16; 2]>],
-    dosages: &[Option<f32>],
-    cursor: &Cursor<'_>,
-) -> Result<()> {
-    for (sample, (call, dosage)) in calls.iter().zip(dosages).enumerate() {
-        let (Some(call), Some(dosage)) = (call, dosage) else {
-            continue;
-        };
-        let hardcall = (u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32;
-        if (hardcall - dosage).abs() > 0.5001 {
-            return Err(cursor.error(format!(
-                "dosage {dosage} is inconsistent with hardcall ALT count {hardcall} for sample {sample}"
-            )));
+        let dosage = f32::from(value) / DOSAGE_SCALE;
+        if let Some(call) = calls[sample] {
+            let hardcall = (u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32;
+            if (hardcall - dosage).abs() > 0.5001 {
+                return Err(cursor.error(format!(
+                    "dosage {dosage} is inconsistent with hardcall ALT count {hardcall} for sample {sample}"
+                )));
+            }
+        }
+        if let Some(output) = &mut output {
+            output[sample] = Some(dosage);
         }
     }
-    Ok(())
-}
-
-fn validate_fixed_dosage_missingness(
-    calls: &[Option<[u16; 2]>],
-    stored_dosages: &[Option<f32>],
-    cursor: &Cursor<'_>,
-) -> Result<()> {
-    for (sample, (call, dosage)) in calls.iter().zip(stored_dosages).enumerate() {
-        if dosage.is_none() && call.is_some() {
-            return Err(cursor.error(format!(
-                "fixed-width dosage is missing while the hardcall is present for sample {sample}"
-            )));
-        }
-    }
-    Ok(())
+    Ok(DosageTrack {
+        encoding,
+        sample_count,
+        sample_ids,
+        value_bytes,
+        values: output,
+    })
 }
 
 fn decode_phased_dosage(
     cursor: &mut Cursor<'_>,
-    dosage_encoding: u8,
-    dosage_sample_ids: &[usize],
-    dosages: &[Option<f32>],
+    dosage: &DosageTrack<'_>,
+    dosages: Option<&[Option<f32>]>,
     calls: &[Option<[u16; 2]>],
-    phased: &[Option<bool>],
-) -> Result<Vec<Option<[f32; 2]>>> {
-    if dosage_encoding == 0 {
+    phased: Option<&[Option<bool>]>,
+    materialize: bool,
+) -> Result<Option<Vec<Option<[f32; 2]>>>> {
+    if dosage.encoding == 0 {
         return Err(
             cursor.error("phased-dosage track is present without a dosage track".to_string())
         );
     }
-    let explicit_samples = if dosage_encoding == 2 {
-        dosage_sample_ids.to_vec()
+    let entry_count = dosage.entry_count();
+    let presence = if dosage.encoding == 2 {
+        None
     } else {
-        let bits = cursor.take(
-            dosage_sample_ids.len().div_ceil(8),
-            "phased-dosage-presence bitarray",
-        )?;
-        validate_packed_padding(bits, dosage_sample_ids.len(), 1, cursor)?;
-        dosage_sample_ids
-            .iter()
-            .enumerate()
-            .filter_map(|(index, &sample)| bit(bits, index).then_some(sample))
-            .collect()
+        let bits = cursor.take(entry_count.div_ceil(8), "phased-dosage-presence bitarray")?;
+        validate_packed_padding(bits, entry_count, 1, cursor)?;
+        Some(bits)
     };
+    let explicit_count = presence.map_or(entry_count, |bits| {
+        (0..entry_count).filter(|&index| bit(bits, index)).count()
+    });
     let values = cursor.take(
-        explicit_samples
-            .len()
+        explicit_count
             .checked_mul(2)
             .ok_or_else(|| cursor.error("phased dosage byte count overflowed".to_string()))?,
         "phased-dosage values",
     )?;
-    let mut output = implicit_haplotype_dosages(dosages, calls, phased);
-    for (index, &sample) in explicit_samples.iter().enumerate() {
-        let value = i16::from_le_bytes([values[index * 2], values[index * 2 + 1]]);
-        if dosage_encoding == 2 && value == i16::MIN {
+    let mut output = if materialize {
+        Some(implicit_haplotype_dosages(
+            dosages.ok_or_else(|| {
+                cursor.error("phased dosage output has no total dosage values".to_string())
+            })?,
+            calls,
+            phased.ok_or_else(|| {
+                cursor.error("phased dosage output has no hardcall phase values".to_string())
+            })?,
+        ))
+    } else {
+        None
+    };
+    let mut value_index = 0;
+    for entry in 0..entry_count {
+        if presence.is_some_and(|bits| !bit(bits, entry)) {
+            continue;
+        }
+        let sample = dosage.sample_at(entry);
+        let value = i16::from_le_bytes([values[value_index * 2], values[value_index * 2 + 1]]);
+        value_index += 1;
+        if dosage.encoding == 2 && value == i16::MIN {
             continue;
         }
         if !(-16_384..=16_384).contains(&value) {
@@ -1223,7 +1425,10 @@ fn decode_phased_dosage(
                 "phased-dosage difference {value} is outside [-16384, 16384] for sample {sample}"
             )));
         }
-        let Some(total) = dosages[sample] else {
+        let Some(total) = dosages
+            .and_then(|values| values[sample])
+            .or_else(|| dosage.effective_at(entry, calls))
+        else {
             return Err(cursor.error(format!(
                 "phased dosage exists without total dosage for sample {sample}"
             )));
@@ -1236,8 +1441,11 @@ fn decode_phased_dosage(
                 "phased dosage [{left}, {right}] is outside haplotype bounds for sample {sample}"
             )));
         }
-        output[sample] = Some([left.clamp(0.0, 1.0), right.clamp(0.0, 1.0)]);
+        if let Some(output) = &mut output {
+            output[sample] = Some([left.clamp(0.0, 1.0), right.clamp(0.0, 1.0)]);
+        }
     }
+    debug_assert_eq!(value_index, explicit_count);
     Ok(output)
 }
 
@@ -1432,6 +1640,58 @@ mod tests {
         )
         .unwrap();
         assert_eq!(record.gt, vec![None, Some([0, 1]), Some([0, 0])]);
+    }
+
+    #[test]
+    fn retains_only_projected_genotype_children() {
+        let fields = vec!["PHASED".to_string()];
+        let (record, _) = decode_record_and_main(
+            &[0b11_10_01_00],
+            PgenMode::Variable,
+            0,
+            0,
+            4,
+            2,
+            GenotypeProjection::from_fields(&fields),
+            &[0, 1, 2, 3],
+            None,
+        )
+        .unwrap();
+        assert!(record.gt.is_empty());
+        assert_eq!(
+            record.phased,
+            vec![Some(false), Some(false), Some(false), None]
+        );
+        assert!(record.ds.is_empty());
+        assert!(record.ds_stored.is_empty());
+        assert!(record.hds.is_empty());
+
+        let mut physical_hds = vec![0b11_10_01_00];
+        for dosage in [0_u16, 16_384, 32_768, u16::MAX] {
+            physical_hds.extend_from_slice(&dosage.to_le_bytes());
+        }
+        for difference in [0_i16, 0, 0, i16::MIN] {
+            physical_hds.extend_from_slice(&difference.to_le_bytes());
+        }
+        let (record, _) = decode_record_and_main(
+            &physical_hds,
+            PgenMode::Variable,
+            0xc0,
+            0,
+            4,
+            2,
+            GenotypeProjection::from_fields(&fields),
+            &[0, 1, 2, 3],
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            record.phased,
+            vec![Some(false), Some(false), Some(false), None]
+        );
+        assert!(record.ds.is_empty());
+        assert!(record.ds_stored.is_empty());
+        assert!(record.hds.is_empty());
     }
 
     #[test]

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -1,0 +1,957 @@
+use datafusion::common::{DataFusionError, Result};
+
+use crate::fileset::{PgenMode, read_varint};
+
+const DOSAGE_SCALE: f32 = 16_384.0;
+
+#[derive(Clone, Debug)]
+pub(crate) struct DecodedRecord {
+    pub(crate) gt: Vec<Option<[u16; 2]>>,
+    pub(crate) phased: Vec<Option<bool>>,
+    pub(crate) ds: Vec<Option<f32>>,
+    pub(crate) hds: Vec<Option<[f32; 2]>>,
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_record(
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+    allele_count: usize,
+    selected_samples: &[usize],
+    ld_base: Option<&[u8]>,
+) -> Result<DecodedRecord> {
+    decode_record_and_main(
+        bytes,
+        mode,
+        record_type,
+        variant_index,
+        sample_count,
+        allele_count,
+        selected_samples,
+        ld_base,
+    )
+    .map(|(decoded, _)| decoded)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_record_and_main(
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+    allele_count: usize,
+    selected_samples: &[usize],
+    ld_base: Option<&[u8]>,
+) -> Result<(DecodedRecord, Vec<u8>)> {
+    let mut cursor = Cursor::new(bytes, variant_index);
+    let categories = decode_main(&mut cursor, mode, record_type, sample_count, ld_base)?;
+    let mut calls = categories
+        .iter()
+        .map(|&category| category_call(category))
+        .collect::<Vec<_>>();
+
+    if record_type != 0xff && record_type & 0x08 != 0 {
+        apply_multiallelic_patches(
+            &mut cursor,
+            &categories,
+            &mut calls,
+            sample_count,
+            allele_count,
+        )?;
+    } else if allele_count > 2 {
+        return Err(cursor.error(format!(
+            "multiallelic PVAR row has {allele_count} alleles but its PGEN record has no hardcall patch track"
+        )));
+    }
+
+    let mut phased = vec![None; sample_count];
+    if record_type != 0xff && record_type & 0x10 != 0 {
+        decode_phase(&mut cursor, &mut calls, &mut phased)?;
+    } else {
+        for (call, output) in calls.iter().zip(&mut phased) {
+            if call.is_some() {
+                *output = Some(false);
+            }
+        }
+    }
+
+    let dosage_encoding = if record_type == 0xff {
+        0
+    } else {
+        (record_type >> 5) & 3
+    };
+    if allele_count > 2 && dosage_encoding != 0 {
+        return Err(cursor.error(
+            "unsupported multiallelic PGEN dosage track; hardcalls remain supported".to_string(),
+        ));
+    }
+    let (mut dosages, dosage_sample_ids) =
+        decode_dosage(&mut cursor, dosage_encoding, sample_count)?;
+    if dosage_encoding != 0 {
+        for (dosage, call) in dosages.iter_mut().zip(&calls) {
+            if dosage.is_none()
+                && let Some(call) = call
+            {
+                *dosage = Some((u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32);
+            }
+        }
+    }
+    validate_dosage_hardcall_consistency(&calls, &dosages, &cursor)?;
+    let hds = if record_type != 0xff && record_type & 0x80 != 0 {
+        decode_phased_dosage(
+            &mut cursor,
+            dosage_encoding,
+            &dosage_sample_ids,
+            &dosages,
+            &calls,
+            &phased,
+        )?
+    } else {
+        implicit_haplotype_dosages(&dosages, &calls, &phased)
+    };
+
+    if !cursor.is_finished() {
+        return Err(cursor.error(format!(
+            "{} trailing bytes remain after decoding the declared record tracks",
+            cursor.remaining()
+        )));
+    }
+    if categories.len() != sample_count {
+        return Err(cursor.error("decoded hardcall count is inconsistent".to_string()));
+    }
+
+    let mut selected_gt = Vec::with_capacity(selected_samples.len());
+    let mut selected_phased = Vec::with_capacity(selected_samples.len());
+    let mut selected_ds = Vec::with_capacity(selected_samples.len());
+    let mut selected_hds = Vec::with_capacity(selected_samples.len());
+    for &sample in selected_samples {
+        if sample >= sample_count {
+            return Err(cursor.error(format!(
+                "selected sample index {sample} is out of bounds for {sample_count} samples"
+            )));
+        }
+        selected_gt.push(calls[sample]);
+        selected_phased.push(phased[sample]);
+        selected_ds.push(dosages[sample]);
+        selected_hds.push(hds[sample]);
+    }
+    dosages.clear();
+    Ok((
+        DecodedRecord {
+            gt: selected_gt,
+            phased: selected_phased,
+            ds: selected_ds,
+            hds: selected_hds,
+        },
+        categories,
+    ))
+}
+
+pub(crate) fn decode_main_track(
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+    ld_base: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    let mut cursor = Cursor::new(bytes, variant_index);
+    decode_main(&mut cursor, mode, record_type, sample_count, ld_base)
+}
+
+fn decode_main(
+    cursor: &mut Cursor<'_>,
+    mode: PgenMode,
+    record_type: u8,
+    sample_count: usize,
+    ld_base: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    if mode == PgenMode::Plink1 {
+        let bytes = cursor.take(sample_count.div_ceil(4), "PLINK 1 hardcalls")?;
+        validate_packed_padding(bytes, sample_count, 2, cursor)?;
+        return Ok((0..sample_count)
+            .map(|sample| match packed_value(bytes, sample, 2) as u8 {
+                0 => 2,
+                1 => 3,
+                2 => 1,
+                3 => 0,
+                _ => unreachable!(),
+            })
+            .collect());
+    }
+
+    match record_type & 7 {
+        0 => {
+            let bytes = cursor.take(sample_count.div_ceil(4), "dense hardcalls")?;
+            validate_packed_padding(bytes, sample_count, 2, cursor)?;
+            Ok((0..sample_count)
+                .map(|sample| packed_value(bytes, sample, 2) as u8)
+                .collect())
+        }
+        1 => decode_onebit(cursor, sample_count),
+        2 | 3 => {
+            let base = ld_base.ok_or_else(|| {
+                cursor.error("LD-compressed record was decoded without its base".to_string())
+            })?;
+            if base.len() != sample_count {
+                return Err(cursor.error(format!(
+                    "LD base has {} calls; expected {sample_count}",
+                    base.len()
+                )));
+            }
+            let mut result = base.to_vec();
+            for (sample, value) in decode_difflist(cursor, sample_count, true)? {
+                result[sample] = value.ok_or_else(|| {
+                    cursor.error("LD difflist omitted a genotype value".to_string())
+                })?;
+            }
+            if record_type & 1 != 0 {
+                for category in &mut result {
+                    *category = match *category {
+                        0 => 2,
+                        2 => 0,
+                        value => value,
+                    };
+                }
+            }
+            Ok(result)
+        }
+        common @ (4 | 6 | 7) => {
+            let common = common & 3;
+            let mut result = vec![common; sample_count];
+            for (sample, value) in decode_difflist(cursor, sample_count, true)? {
+                result[sample] = value.ok_or_else(|| {
+                    cursor.error("hardcall difflist omitted a genotype value".to_string())
+                })?;
+            }
+            Ok(result)
+        }
+        5 => Err(cursor.error("reserved PGEN main-track representation 5".to_string())),
+        _ => unreachable!(),
+    }
+}
+
+fn decode_onebit(cursor: &mut Cursor<'_>, sample_count: usize) -> Result<Vec<u8>> {
+    let code = cursor.byte("one-bit common-category code")?;
+    let lower = code / 4;
+    let delta = code & 3;
+    if delta == 0 || lower.checked_add(delta).is_none_or(|value| value > 3) {
+        return Err(cursor.error(format!("invalid one-bit common-category code 0x{code:02x}")));
+    }
+    let bits = cursor.take(sample_count.div_ceil(8), "one-bit hardcall array")?;
+    validate_packed_padding(bits, sample_count, 1, cursor)?;
+    let mut result = (0..sample_count)
+        .map(|sample| lower + (bit(bits, sample) as u8) * delta)
+        .collect::<Vec<_>>();
+    for (sample, value) in decode_difflist(cursor, sample_count, true)? {
+        result[sample] = value.ok_or_else(|| {
+            cursor.error("one-bit exception omitted a genotype value".to_string())
+        })?;
+    }
+    Ok(result)
+}
+
+fn decode_difflist(
+    cursor: &mut Cursor<'_>,
+    sample_count: usize,
+    has_values: bool,
+) -> Result<Vec<(usize, Option<u8>)>> {
+    let length = usize::try_from(cursor.varint("difflist length")?)
+        .map_err(|_| cursor.error("difflist length does not fit usize".to_string()))?;
+    if length > sample_count {
+        return Err(cursor.error(format!(
+            "difflist length {length} exceeds sample count {sample_count}"
+        )));
+    }
+    if length == 0 {
+        return Ok(Vec::new());
+    }
+    let group_count = length.div_ceil(64);
+    let id_width = bytes_to_represent(sample_count);
+    let group_starts_raw =
+        cursor.take(group_count * id_width, "difflist group-start sample IDs")?;
+    let group_starts = (0..group_count)
+        .map(|group| {
+            read_small_le(&group_starts_raw[group * id_width..(group + 1) * id_width]) as usize
+        })
+        .collect::<Vec<_>>();
+    let group_sizes = cursor
+        .take(group_count.saturating_sub(1), "difflist group byte sizes")?
+        .to_vec();
+    let packed_values = if has_values {
+        Some(cursor.take(length.div_ceil(4), "difflist genotype values")?)
+    } else {
+        None
+    };
+    if let Some(values) = packed_values {
+        validate_packed_padding(values, length, 2, cursor)?;
+    }
+
+    let mut result = Vec::with_capacity(length);
+    let mut previous_global = None;
+    for group in 0..group_count {
+        let group_len = (length - group * 64).min(64);
+        let mut sample = group_starts[group];
+        if sample >= sample_count || previous_global.is_some_and(|previous| sample <= previous) {
+            return Err(cursor.error(format!(
+                "difflist group {group} starts with invalid sample index {sample}"
+            )));
+        }
+        let delta_start = cursor.position;
+        for element in 0..group_len {
+            if element > 0 {
+                let delta =
+                    usize::try_from(cursor.varint("difflist sample delta")?).map_err(|_| {
+                        cursor.error("difflist sample delta does not fit usize".to_string())
+                    })?;
+                if delta == 0 {
+                    return Err(cursor.error("difflist sample delta is zero".to_string()));
+                }
+                sample = sample
+                    .checked_add(delta)
+                    .ok_or_else(|| cursor.error("difflist sample index overflowed".to_string()))?;
+                if sample >= sample_count {
+                    return Err(cursor.error(format!(
+                        "difflist sample index {sample} exceeds sample count {sample_count}"
+                    )));
+                }
+            }
+            let value =
+                packed_values.map(|values| packed_value(values, group * 64 + element, 2) as u8);
+            result.push((sample, value));
+            previous_global = Some(sample);
+        }
+        if group + 1 < group_count {
+            let observed = cursor.position - delta_start;
+            let declared = usize::from(group_sizes[group]) + 63;
+            if observed != declared {
+                return Err(cursor.error(format!(
+                    "difflist group {group} delta bytes {observed} differ from declared {declared}"
+                )));
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn apply_multiallelic_patches(
+    cursor: &mut Cursor<'_>,
+    categories: &[u8],
+    calls: &mut [Option<[u16; 2]>],
+    sample_count: usize,
+    allele_count: usize,
+) -> Result<()> {
+    if !(3..=65_536).contains(&allele_count) {
+        return Err(cursor.error(format!(
+            "PGEN raw-allele output supports 3..=65536 alleles, observed {allele_count}"
+        )));
+    }
+    let control = cursor.byte("multiallelic patch control")?;
+    let category_one = category_samples(categories, 1);
+    let category_two = category_samples(categories, 2);
+    let patch_one = decode_patch_samples(cursor, control & 0x0f, &category_one, sample_count)?;
+    let alt_count = allele_count - 1;
+    let width_one = patch_one_width(alt_count);
+    let values_one = if width_one == 0 {
+        vec![0_u32; patch_one.len()]
+    } else {
+        decode_packed_values(
+            cursor,
+            patch_one.len(),
+            width_one,
+            "category-1 patch alleles",
+        )?
+    };
+    for (sample, value) in patch_one.into_iter().zip(values_one) {
+        let allele = usize::try_from(value)
+            .ok()
+            .and_then(|value| value.checked_add(2))
+            .ok_or_else(|| cursor.error("category-1 patch allele overflowed".to_string()))?;
+        if allele >= allele_count {
+            return Err(cursor.error(format!(
+                "category-1 patch references allele {allele} outside {allele_count} alleles for sample {sample}"
+            )));
+        }
+        calls[sample] = Some([0, allele as u16]);
+    }
+
+    let patch_two = decode_patch_samples(cursor, control >> 4, &category_two, sample_count)?;
+    if alt_count == 2 {
+        let values = decode_packed_values(cursor, patch_two.len(), 1, "category-2 patch alleles")?;
+        for (sample, value) in patch_two.into_iter().zip(values) {
+            calls[sample] = if value == 0 {
+                Some([1, 2])
+            } else {
+                Some([2, 2])
+            };
+        }
+    } else {
+        let width = patch_two_width(alt_count);
+        let values = decode_packed_values(
+            cursor,
+            patch_two.len().checked_mul(2).ok_or_else(|| {
+                cursor.error("category-2 patch value count overflowed".to_string())
+            })?,
+            width,
+            "category-2 patch alleles",
+        )?;
+        for (patch_index, sample) in patch_two.into_iter().enumerate() {
+            let first = values[patch_index * 2] as usize + 1;
+            let second = values[patch_index * 2 + 1] as usize + 1;
+            if first > second || second >= allele_count {
+                return Err(cursor.error(format!(
+                    "category-2 patch has invalid alleles [{first}, {second}] for sample {sample}"
+                )));
+            }
+            calls[sample] = Some([first as u16, second as u16]);
+        }
+    }
+    Ok(())
+}
+
+fn category_samples(categories: &[u8], category: u8) -> Vec<usize> {
+    categories
+        .iter()
+        .enumerate()
+        .filter_map(|(sample, &value)| (value == category).then_some(sample))
+        .collect()
+}
+
+fn decode_patch_samples(
+    cursor: &mut Cursor<'_>,
+    format: u8,
+    category_samples: &[usize],
+    sample_count: usize,
+) -> Result<Vec<usize>> {
+    match format {
+        0 => {
+            let bits = cursor.take(
+                category_samples.len().div_ceil(8),
+                "multiallelic patch bitarray",
+            )?;
+            validate_packed_padding(bits, category_samples.len(), 1, cursor)?;
+            Ok(category_samples
+                .iter()
+                .enumerate()
+                .filter_map(|(index, &sample)| bit(bits, index).then_some(sample))
+                .collect())
+        }
+        1 => {
+            let decoded = decode_difflist(cursor, sample_count, false)?;
+            let membership = category_samples
+                .iter()
+                .copied()
+                .collect::<std::collections::HashSet<_>>();
+            let mut samples = Vec::with_capacity(decoded.len());
+            for (sample, _) in decoded {
+                if !membership.contains(&sample) {
+                    return Err(cursor.error(format!(
+                        "multiallelic patch addresses sample {sample} outside its genotype category"
+                    )));
+                }
+                samples.push(sample);
+            }
+            Ok(samples)
+        }
+        15 => Ok(Vec::new()),
+        _ => Err(cursor.error(format!("reserved multiallelic patch-set format {format}"))),
+    }
+}
+
+fn patch_one_width(alt_count: usize) -> usize {
+    match alt_count {
+        2 => 0,
+        3 => 1,
+        4..=5 => 2,
+        6..=17 => 4,
+        18..=257 => 8,
+        _ => 16,
+    }
+}
+
+fn patch_two_width(alt_count: usize) -> usize {
+    match alt_count {
+        3..=4 => 2,
+        5..=16 => 4,
+        17..=256 => 8,
+        _ => 16,
+    }
+}
+
+fn decode_packed_values(
+    cursor: &mut Cursor<'_>,
+    count: usize,
+    width: usize,
+    context: &str,
+) -> Result<Vec<u32>> {
+    let bit_count = count
+        .checked_mul(width)
+        .ok_or_else(|| cursor.error(format!("{context} bit count overflowed")))?;
+    let bytes = cursor.take(bit_count.div_ceil(8), context)?;
+    validate_packed_padding(bytes, count, width, cursor)?;
+    Ok((0..count)
+        .map(|index| packed_value(bytes, index, width))
+        .collect())
+}
+
+fn decode_phase(
+    cursor: &mut Cursor<'_>,
+    calls: &mut [Option<[u16; 2]>],
+    phased: &mut [Option<bool>],
+) -> Result<()> {
+    let heterozygous = calls
+        .iter()
+        .enumerate()
+        .filter_map(|(sample, call)| {
+            call.filter(|alleles| alleles[0] != alleles[1])
+                .map(|_| sample)
+        })
+        .collect::<Vec<_>>();
+    if heterozygous.is_empty() {
+        return Err(
+            cursor.error("hardcall-phase track is present without heterozygous calls".to_string())
+        );
+    }
+    let first = *cursor
+        .bytes
+        .get(cursor.position)
+        .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
+    let explicit_present = first & 1 != 0;
+    let present = if explicit_present {
+        let bytes = cursor.take(
+            (heterozygous.len() + 1).div_ceil(8),
+            "phase-present bitarray",
+        )?;
+        validate_phase_padding(bytes, heterozygous.len() + 1, cursor)?;
+        (0..heterozygous.len())
+            .map(|index| bit(bytes, index + 1))
+            .collect::<Vec<_>>()
+    } else {
+        vec![true; heterozygous.len()]
+    };
+    let phased_count = present.iter().filter(|&&value| value).count();
+    let info = if explicit_present {
+        let bytes = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
+        validate_packed_padding(bytes, phased_count, 1, cursor)?;
+        (0..phased_count)
+            .map(|index| bit(bytes, index))
+            .collect::<Vec<_>>()
+    } else {
+        let bytes = cursor.take(
+            (heterozygous.len() + 1).div_ceil(8),
+            "implicit phase-info bitarray",
+        )?;
+        if bytes.first().is_some_and(|byte| byte & 1 != 0) {
+            return Err(
+                cursor.error("implicit phase track has phase-present marker set".to_string())
+            );
+        }
+        validate_phase_padding(bytes, heterozygous.len() + 1, cursor)?;
+        (0..heterozygous.len())
+            .map(|index| bit(bytes, index + 1))
+            .collect::<Vec<_>>()
+    };
+    let mut info_index = 0;
+    for (heterozygous_index, &sample) in heterozygous.iter().enumerate() {
+        if present[heterozygous_index] {
+            if info[info_index] {
+                calls[sample].as_mut().unwrap().swap(0, 1);
+            }
+            phased[sample] = Some(true);
+            info_index += 1;
+        } else {
+            phased[sample] = Some(false);
+        }
+    }
+    for (sample, call) in calls.iter().enumerate() {
+        if call.is_some() && phased[sample].is_none() {
+            phased[sample] = Some(false);
+        }
+    }
+    Ok(())
+}
+
+fn decode_dosage(
+    cursor: &mut Cursor<'_>,
+    encoding: u8,
+    sample_count: usize,
+) -> Result<(Vec<Option<f32>>, Vec<usize>)> {
+    let sample_ids = match encoding {
+        0 => Vec::new(),
+        1 => decode_difflist(cursor, sample_count, false)?
+            .into_iter()
+            .map(|(sample, _)| sample)
+            .collect(),
+        2 => (0..sample_count).collect(),
+        3 => {
+            let bits = cursor.take(sample_count.div_ceil(8), "dosage-presence bitarray")?;
+            validate_packed_padding(bits, sample_count, 1, cursor)?;
+            (0..sample_count)
+                .filter(|&sample| bit(bits, sample))
+                .collect()
+        }
+        _ => unreachable!(),
+    };
+    let value_bytes = cursor.take(
+        sample_ids
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| cursor.error("dosage byte count overflowed".to_string()))?,
+        "dosage values",
+    )?;
+    let mut output = vec![None; sample_count];
+    for (index, &sample) in sample_ids.iter().enumerate() {
+        let value = u16::from_le_bytes([value_bytes[index * 2], value_bytes[index * 2 + 1]]);
+        if encoding == 2 && value == u16::MAX {
+            continue;
+        }
+        if value > 32_768 {
+            return Err(cursor.error(format!(
+                "dosage integer {value} exceeds 32768 for sample {sample}"
+            )));
+        }
+        output[sample] = Some(f32::from(value) / DOSAGE_SCALE);
+    }
+    Ok((output, sample_ids))
+}
+
+fn validate_dosage_hardcall_consistency(
+    calls: &[Option<[u16; 2]>],
+    dosages: &[Option<f32>],
+    cursor: &Cursor<'_>,
+) -> Result<()> {
+    for (sample, (call, dosage)) in calls.iter().zip(dosages).enumerate() {
+        let (Some(call), Some(dosage)) = (call, dosage) else {
+            continue;
+        };
+        let hardcall = (u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32;
+        if (hardcall - dosage).abs() > 0.5001 {
+            return Err(cursor.error(format!(
+                "dosage {dosage} is inconsistent with hardcall ALT count {hardcall} for sample {sample}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn decode_phased_dosage(
+    cursor: &mut Cursor<'_>,
+    dosage_encoding: u8,
+    dosage_sample_ids: &[usize],
+    dosages: &[Option<f32>],
+    calls: &[Option<[u16; 2]>],
+    phased: &[Option<bool>],
+) -> Result<Vec<Option<[f32; 2]>>> {
+    if dosage_encoding == 0 {
+        return Err(
+            cursor.error("phased-dosage track is present without a dosage track".to_string())
+        );
+    }
+    let explicit_samples = if dosage_encoding == 2 {
+        dosage_sample_ids.to_vec()
+    } else {
+        let bits = cursor.take(
+            dosage_sample_ids.len().div_ceil(8),
+            "phased-dosage-presence bitarray",
+        )?;
+        validate_packed_padding(bits, dosage_sample_ids.len(), 1, cursor)?;
+        dosage_sample_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &sample)| bit(bits, index).then_some(sample))
+            .collect()
+    };
+    let values = cursor.take(
+        explicit_samples
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| cursor.error("phased dosage byte count overflowed".to_string()))?,
+        "phased-dosage values",
+    )?;
+    let mut output = implicit_haplotype_dosages(dosages, calls, phased);
+    for (index, &sample) in explicit_samples.iter().enumerate() {
+        let value = i16::from_le_bytes([values[index * 2], values[index * 2 + 1]]);
+        if dosage_encoding == 2 && value == i16::MIN {
+            continue;
+        }
+        if !(-16_384..=16_384).contains(&value) {
+            return Err(cursor.error(format!(
+                "phased-dosage difference {value} is outside [-16384, 16384] for sample {sample}"
+            )));
+        }
+        let Some(total) = dosages[sample] else {
+            return Err(cursor.error(format!(
+                "phased dosage exists without total dosage for sample {sample}"
+            )));
+        };
+        let difference = f32::from(value) / DOSAGE_SCALE;
+        let left = (total + difference) * 0.5;
+        let right = (total - difference) * 0.5;
+        if !(-0.0001..=1.0001).contains(&left) || !(-0.0001..=1.0001).contains(&right) {
+            return Err(cursor.error(format!(
+                "phased dosage [{left}, {right}] is outside haplotype bounds for sample {sample}"
+            )));
+        }
+        output[sample] = Some([left.clamp(0.0, 1.0), right.clamp(0.0, 1.0)]);
+    }
+    Ok(output)
+}
+
+fn implicit_haplotype_dosages(
+    dosages: &[Option<f32>],
+    calls: &[Option<[u16; 2]>],
+    phased: &[Option<bool>],
+) -> Vec<Option<[f32; 2]>> {
+    dosages
+        .iter()
+        .zip(calls)
+        .zip(phased)
+        .map(|((dosage, call), phased)| {
+            let (Some(total), Some(call), Some(true)) = (dosage, call, phased) else {
+                return None;
+            };
+            if call == &[0, 1] {
+                Some(if *total <= 1.0 {
+                    [0.0, *total]
+                } else {
+                    [*total - 1.0, 1.0]
+                })
+            } else if call == &[1, 0] {
+                Some(if *total <= 1.0 {
+                    [*total, 0.0]
+                } else {
+                    [1.0, *total - 1.0]
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn category_call(category: u8) -> Option<[u16; 2]> {
+    match category {
+        0 => Some([0, 0]),
+        1 => Some([0, 1]),
+        2 => Some([1, 1]),
+        3 => None,
+        _ => None,
+    }
+}
+
+fn validate_phase_padding(bytes: &[u8], bit_count: usize, cursor: &Cursor<'_>) -> Result<()> {
+    validate_packed_padding(bytes, bit_count, 1, cursor)
+}
+
+fn validate_packed_padding(
+    bytes: &[u8],
+    value_count: usize,
+    width: usize,
+    cursor: &Cursor<'_>,
+) -> Result<()> {
+    let bits = value_count
+        .checked_mul(width)
+        .ok_or_else(|| cursor.error("packed-array bit count overflowed".to_string()))?;
+    let remainder = bits % 8;
+    if remainder > 0 && bytes.last().is_some_and(|byte| byte >> remainder != 0) {
+        return Err(cursor.error("packed array has nonzero padding bits".to_string()));
+    }
+    Ok(())
+}
+
+fn packed_value(bytes: &[u8], index: usize, width: usize) -> u32 {
+    let bit_offset = index * width;
+    let byte_offset = bit_offset / 8;
+    let shift = bit_offset % 8;
+    let mut word = 0_u64;
+    for (index, byte) in bytes
+        .get(byte_offset..)
+        .unwrap_or_default()
+        .iter()
+        .take(5)
+        .enumerate()
+    {
+        word |= u64::from(*byte) << (index * 8);
+    }
+    ((word >> shift) & ((1_u64 << width) - 1)) as u32
+}
+
+fn bit(bytes: &[u8], index: usize) -> bool {
+    bytes[index / 8] & (1 << (index % 8)) != 0
+}
+
+fn bytes_to_represent(value_count: usize) -> usize {
+    if value_count <= 1 << 8 {
+        1
+    } else if value_count <= 1 << 16 {
+        2
+    } else if value_count <= 1 << 24 {
+        3
+    } else {
+        4
+    }
+}
+
+fn read_small_le(bytes: &[u8]) -> u32 {
+    bytes
+        .iter()
+        .enumerate()
+        .fold(0_u32, |value, (shift, byte)| {
+            value | (u32::from(*byte) << (shift * 8))
+        })
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+    variant_index: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8], variant_index: usize) -> Self {
+        Self {
+            bytes,
+            position: 0,
+            variant_index,
+        }
+    }
+
+    fn take(&mut self, length: usize, context: &str) -> Result<&'a [u8]> {
+        let start = self.position;
+        let end = start
+            .checked_add(length)
+            .ok_or_else(|| self.error(format!("{context} length overflowed")))?;
+        let result = self.bytes.get(start..end).ok_or_else(|| {
+            self.error(format!(
+                "truncated {context} at record byte {start}; need {length} bytes"
+            ))
+        })?;
+        self.position = end;
+        Ok(result)
+    }
+
+    fn byte(&mut self, context: &str) -> Result<u8> {
+        Ok(self.take(1, context)?[0])
+    }
+
+    fn varint(&mut self, context: &str) -> Result<u64> {
+        read_varint(self.bytes, &mut self.position)
+            .map_err(|error| self.error(format!("{context}: {error}")))
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.position
+    }
+
+    fn is_finished(&self) -> bool {
+        self.position == self.bytes.len()
+    }
+
+    fn error(&self, detail: String) -> DataFusionError {
+        DataFusionError::Execution(format!(
+            "PGEN variant {} at record byte {}: {detail}",
+            self.variant_index, self.position
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_varint(mut value: usize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            bytes.push(byte);
+            if value == 0 {
+                return bytes;
+            }
+        }
+    }
+
+    #[test]
+    fn decodes_dense_hardcalls() {
+        let record = decode_record(
+            &[0b11_10_01_00],
+            PgenMode::Variable,
+            0,
+            0,
+            4,
+            2,
+            &[3, 1, 0],
+            None,
+        )
+        .unwrap();
+        assert_eq!(record.gt, vec![None, Some([0, 1]), Some([0, 0])]);
+    }
+
+    #[test]
+    fn decodes_onebit_and_exception_difflist() {
+        let mut bytes = vec![2, 0b0000_1010];
+        bytes.extend(encode_varint(1));
+        bytes.push(2);
+        bytes.push(1);
+        let record =
+            decode_record(&bytes, PgenMode::Variable, 1, 0, 4, 2, &[0, 1, 2, 3], None).unwrap();
+        assert_eq!(
+            record.gt,
+            vec![Some([0, 0]), Some([1, 1]), Some([0, 1]), Some([1, 1])]
+        );
+    }
+
+    #[test]
+    fn rejects_zero_difflist_delta() {
+        let mut cursor = Cursor::new(&[2, 0, 0, 0], 7);
+        let error = decode_difflist(&mut cursor, 8, false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("delta is zero"), "{error}");
+    }
+
+    #[test]
+    fn decodes_difflist_group_boundary() {
+        let mut bytes = encode_varint(65);
+        bytes.extend([0, 64]);
+        bytes.push(0);
+        bytes.extend(pack_two_bit_values(&[2; 65]));
+        bytes.extend(vec![1; 63]);
+        let mut cursor = Cursor::new(&bytes, 0);
+        let decoded = decode_difflist(&mut cursor, 130, true).unwrap();
+        assert_eq!(decoded.len(), 65);
+        assert_eq!(decoded.first(), Some(&(0, Some(2))));
+        assert_eq!(decoded.last(), Some(&(64, Some(2))));
+        assert!(cursor.is_finished());
+    }
+
+    #[test]
+    fn rejects_overlapping_difflist_groups() {
+        let mut bytes = encode_varint(65);
+        bytes.extend([0, 63]);
+        bytes.push(0);
+        bytes.extend(pack_two_bit_values(&[0; 65]));
+        bytes.extend(vec![1; 63]);
+        let mut cursor = Cursor::new(&bytes, 3);
+        let error = decode_difflist(&mut cursor, 130, true)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("invalid sample index 63"), "{error}");
+    }
+
+    fn pack_two_bit_values(values: &[u8]) -> Vec<u8> {
+        let mut bytes = vec![0; values.len().div_ceil(4)];
+        for (index, value) in values.iter().copied().enumerate() {
+            bytes[index / 4] |= value << ((index % 4) * 2);
+        }
+        bytes
+    }
+}

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -523,10 +523,6 @@ pub(crate) fn decode_record_and_main(
             sample_count,
             allele_count,
         )?;
-    } else if allele_count > 2 {
-        return Err(cursor.error(format!(
-            "multiallelic PVAR row has {allele_count} alleles but its PGEN record has no hardcall patch track"
-        )));
     }
 
     let mut phased = (projection.phased || projection.hds).then(|| vec![None; sample_count]);

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -93,10 +93,8 @@ impl DosageTrack<'_> {
     }
 
     fn effective_at(&self, entry: usize, calls: &[Option<[u16; 2]>]) -> Option<f32> {
-        self.stored_at(entry).or_else(|| {
-            calls[self.sample_at(entry)]
-                .map(|call| (u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32)
-        })
+        self.stored_at(entry)
+            .or_else(|| calls[self.sample_at(entry)].map(|call| alt1_hardcall_dosage(&call)))
     }
 }
 
@@ -586,7 +584,7 @@ pub(crate) fn decode_record_and_main(
             if dosage.is_none()
                 && let Some(call) = call
             {
-                *dosage = Some((u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32);
+                *dosage = Some(alt1_hardcall_dosage(call));
             }
         }
     }
@@ -1346,7 +1344,7 @@ fn decode_dosage<'a>(
         }
         let dosage = f32::from(value) / DOSAGE_SCALE;
         if let Some(call) = calls[sample] {
-            let hardcall = (u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32;
+            let hardcall = alt1_hardcall_dosage(&call);
             if (hardcall - dosage).abs() > 0.5001 {
                 return Err(cursor.error(format!(
                     "dosage {dosage} is inconsistent with hardcall ALT count {hardcall} for sample {sample}"
@@ -1479,6 +1477,10 @@ fn implicit_haplotype_dosages(
             }
         })
         .collect()
+}
+
+fn alt1_hardcall_dosage(call: &[u16; 2]) -> f32 {
+    call.iter().filter(|&&allele| allele == 1).count() as f32
 }
 
 fn category_call(category: u8) -> Option<[u16; 2]> {

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -782,6 +782,8 @@ fn decode_main_into(
                 })?;
             }
             if record_type & 1 != 0 {
+                // Inverted-LD difflist values are stored pre-inversion. PLINK
+                // applies this final inversion after patching the base.
                 for category in output {
                     *category = match *category {
                         0 => 2,
@@ -813,6 +815,8 @@ fn decode_onebit_into(
     output: &mut Vec<u8>,
 ) -> Result<()> {
     let code = cursor.byte("one-bit common-category code")?;
+    // PLINK packs the lower common category in bits 2+ and the positive
+    // distance to the higher category in bits 0-1 (valid codes: 1,2,3,5,6,9).
     let lower = code / 4;
     let delta = code & 3;
     if delta == 0 || lower.checked_add(delta).is_none_or(|value| value > 3) {
@@ -1714,6 +1718,43 @@ mod tests {
         assert_eq!(
             record.gt,
             vec![Some([0, 0]), Some([1, 1]), Some([0, 1]), Some([1, 1])]
+        );
+    }
+
+    #[test]
+    fn decodes_only_the_specified_onebit_common_category_codes() {
+        for (code, expected) in [
+            (1, vec![0, 1]),
+            (2, vec![0, 2]),
+            (3, vec![0, 3]),
+            (5, vec![1, 2]),
+            (6, vec![1, 3]),
+            (9, vec![2, 3]),
+        ] {
+            let bytes = [code, 0b0000_0010, 0];
+            let mut cursor = Cursor::new(&bytes, 0);
+            assert_eq!(
+                decode_main(&mut cursor, PgenMode::Variable, 1, 2, None).unwrap(),
+                expected
+            );
+        }
+
+        let mut cursor = Cursor::new(&[0x08], 0);
+        let error = decode_main(&mut cursor, PgenMode::Variable, 1, 2, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("invalid one-bit common-category code"));
+    }
+
+    #[test]
+    fn inverts_ld_difflist_values_after_patching() {
+        // Patch sample 0 from base category 0 to stored category 2, then apply
+        // the final inverted-LD 0 <-> 2 swap to the entire reconstructed row.
+        let bytes = [1, 0, 2];
+        let mut cursor = Cursor::new(&bytes, 1);
+        assert_eq!(
+            decode_main(&mut cursor, PgenMode::Variable, 3, 4, Some(&[0, 1, 2, 3]),).unwrap(),
+            vec![0, 1, 0, 3]
         );
     }
 

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -9,7 +9,373 @@ pub(crate) struct DecodedRecord {
     pub(crate) gt: Vec<Option<[u16; 2]>>,
     pub(crate) phased: Vec<Option<bool>>,
     pub(crate) ds: Vec<Option<f32>>,
+    pub(crate) ds_stored: Vec<Option<f32>>,
     pub(crate) hds: Vec<Option<[f32; 2]>>,
+}
+
+/// Reusable state for the projection-specialized biallelic `GT` decoder.
+///
+/// The source-to-output map is built once per physical partition. Record
+/// decoding then reuses both vectors instead of allocating full-cohort phase,
+/// dosage, and phased-dosage intermediates for every variant.
+pub(crate) struct GtDecodeWorkspace {
+    categories: Vec<u8>,
+    selected_codes: Vec<u8>,
+    source_to_output: Vec<usize>,
+    identity_selection: bool,
+    retained_main: Vec<u8>,
+    retained_main_valid: bool,
+}
+
+impl GtDecodeWorkspace {
+    pub(crate) fn new(sample_count: usize, selected_samples: &[usize]) -> Result<Self> {
+        let mut source_to_output = vec![usize::MAX; sample_count];
+        for (output, &source) in selected_samples.iter().enumerate() {
+            let slot = source_to_output.get_mut(source).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "selected sample index {source} is out of bounds for {sample_count} samples"
+                ))
+            })?;
+            if *slot != usize::MAX {
+                return Err(DataFusionError::Execution(format!(
+                    "selected sample index {source} appears more than once"
+                )));
+            }
+            *slot = output;
+        }
+        Ok(Self {
+            categories: Vec::with_capacity(sample_count),
+            selected_codes: Vec::with_capacity(selected_samples.len()),
+            source_to_output,
+            identity_selection: selected_samples.len() == sample_count
+                && selected_samples
+                    .iter()
+                    .enumerate()
+                    .all(|(index, &sample)| index == sample),
+            retained_main: Vec::with_capacity(sample_count),
+            retained_main_valid: false,
+        })
+    }
+
+    pub(crate) fn selected_codes(&self) -> &[u8] {
+        if self.identity_selection {
+            &self.categories
+        } else {
+            &self.selected_codes
+        }
+    }
+
+    pub(crate) fn has_identity_selection(&self) -> bool {
+        self.identity_selection
+    }
+
+    pub(crate) fn swap_main_track(&mut self, track: &mut Vec<u8>) {
+        if self.retained_main_valid {
+            std::mem::swap(&mut self.retained_main, track);
+            self.retained_main_valid = false;
+        } else {
+            std::mem::swap(&mut self.categories, track);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_dense_biallelic_gt<F>(
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+    mut emit: F,
+) -> Result<()>
+where
+    F: FnMut(&[u16], u8, usize),
+{
+    if !supports_biallelic_gt_fast_path(record_type, 2)
+        || mode != PgenMode::Plink1 && record_type & 7 != 0
+    {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN variant {variant_index} is not eligible for direct dense GT decoding"
+        )));
+    }
+
+    let mut cursor = Cursor::new(bytes, variant_index);
+    let packed = cursor.take(sample_count.div_ceil(4), "dense hardcalls")?;
+    validate_packed_padding(packed, sample_count, 2, &cursor)?;
+    if mode == PgenMode::Plink1 {
+        for sample in 0..sample_count {
+            let code = match packed_two_bit(packed, sample) {
+                0 => 2,
+                1 => 3,
+                2 => 1,
+                3 => 0,
+                _ => unreachable!(),
+            };
+            emit_gt(code, &mut emit);
+        }
+    } else if record_type == 0xff || record_type & 0x10 == 0 {
+        emit_dense_quads(packed, sample_count, |_| 0, &mut emit);
+    } else {
+        let heterozygous_count = packed
+            .iter()
+            .map(|&byte| usize::from(HETEROZYGOUS_PER_BYTE[usize::from(byte)]))
+            .sum::<usize>();
+        if heterozygous_count == 0 {
+            return Err(cursor
+                .error("hardcall-phase track is present without heterozygous calls".to_string()));
+        }
+        let first = *cursor
+            .bytes
+            .get(cursor.position)
+            .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
+        let explicit_present = first & 1 != 0;
+        if explicit_present {
+            let present = cursor.take(
+                (heterozygous_count + 1).div_ceil(8),
+                "phase-present bitarray",
+            )?;
+            validate_phase_padding(present, heterozygous_count + 1, &cursor)?;
+            let phased_count = (0..heterozygous_count)
+                .filter(|&index| bit(present, index + 1))
+                .count();
+            let info = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
+            validate_packed_padding(info, phased_count, 1, &cursor)?;
+            let mut heterozygous_index = 0;
+            let mut info_index = 0;
+            for sample in 0..sample_count {
+                let mut code = packed_two_bit(packed, sample);
+                if code == 1 {
+                    if bit(present, heterozygous_index + 1) {
+                        if bit(info, info_index) {
+                            code = 4;
+                        }
+                        info_index += 1;
+                    }
+                    heterozygous_index += 1;
+                }
+                emit_gt(code, &mut emit);
+            }
+        } else {
+            let info = cursor.take(
+                (heterozygous_count + 1).div_ceil(8),
+                "implicit phase-info bitarray",
+            )?;
+            if info.first().is_some_and(|byte| byte & 1 != 0) {
+                return Err(
+                    cursor.error("implicit phase track has phase-present marker set".to_string())
+                );
+            }
+            validate_phase_padding(info, heterozygous_count + 1, &cursor)?;
+            let mut phase_offset = 1;
+            emit_dense_quads(
+                packed,
+                sample_count,
+                |byte| {
+                    let count = usize::from(HETEROZYGOUS_PER_BYTE[usize::from(byte)]);
+                    let pattern = read_packed_bits(info, phase_offset, count);
+                    phase_offset += count;
+                    pattern
+                },
+                &mut emit,
+            );
+        }
+    }
+
+    if !cursor.is_finished() {
+        return Err(cursor.error(format!(
+            "{} trailing bytes remain after direct dense GT decoding",
+            cursor.remaining()
+        )));
+    }
+    Ok(())
+}
+
+fn emit_dense_quads<F, P>(packed: &[u8], sample_count: usize, mut phase_pattern: P, emit: &mut F)
+where
+    F: FnMut(&[u16], u8, usize),
+    P: FnMut(u8) -> u8,
+{
+    let full_bytes = sample_count / 4;
+    for &byte in &packed[..full_bytes] {
+        let decoded = &DENSE_QUADS[usize::from(byte)][usize::from(phase_pattern(byte))];
+        emit(&decoded.alleles, decoded.validity, 4);
+    }
+    if !sample_count.is_multiple_of(4) {
+        let byte = packed[full_bytes];
+        let decoded = &DENSE_QUADS[usize::from(byte)][usize::from(phase_pattern(byte))];
+        for sample in 0..sample_count % 4 {
+            emit(
+                &decoded.alleles[sample * 2..sample * 2 + 2],
+                (decoded.validity >> sample) & 1,
+                1,
+            );
+        }
+    }
+}
+
+#[inline]
+fn read_packed_bits(bytes: &[u8], offset: usize, count: usize) -> u8 {
+    if count == 0 {
+        return 0;
+    }
+    let byte = offset / 8;
+    let shift = offset % 8;
+    let mut value = bytes[byte] >> shift;
+    if shift + count > 8 {
+        value |= bytes[byte + 1] << (8 - shift);
+    }
+    value & ((1 << count) - 1)
+}
+
+#[derive(Clone, Copy)]
+struct DecodedQuad {
+    alleles: [u16; 8],
+    validity: u8,
+}
+
+static DENSE_QUADS: [[DecodedQuad; 16]; 256] = build_dense_quads();
+
+const fn build_dense_quads() -> [[DecodedQuad; 16]; 256] {
+    const EMPTY: DecodedQuad = DecodedQuad {
+        alleles: [0; 8],
+        validity: 0,
+    };
+    let mut output = [[EMPTY; 16]; 256];
+    let mut byte = 0;
+    while byte < 256 {
+        let mut pattern = 0;
+        while pattern < 16 {
+            let mut heterozygous_index = 0;
+            let mut sample = 0;
+            while sample < 4 {
+                let code = (byte >> (sample * 2)) & 3;
+                let allele_offset = sample * 2;
+                if code == 0 {
+                    output[byte][pattern].validity |= 1 << sample;
+                } else if code == 1 {
+                    output[byte][pattern].validity |= 1 << sample;
+                    if pattern & (1 << heterozygous_index) == 0 {
+                        output[byte][pattern].alleles[allele_offset + 1] = 1;
+                    } else {
+                        output[byte][pattern].alleles[allele_offset] = 1;
+                    }
+                    heterozygous_index += 1;
+                } else if code == 2 {
+                    output[byte][pattern].validity |= 1 << sample;
+                    output[byte][pattern].alleles[allele_offset] = 1;
+                    output[byte][pattern].alleles[allele_offset + 1] = 1;
+                }
+                sample += 1;
+            }
+            pattern += 1;
+        }
+        byte += 1;
+    }
+    output
+}
+
+#[inline]
+fn emit_gt<F: FnMut(&[u16], u8, usize)>(code: u8, emit: &mut F) {
+    const ALLELES: [[u16; 2]; 5] = [[0, 0], [0, 1], [1, 1], [0, 0], [1, 0]];
+    let alleles = ALLELES[usize::from(code)];
+    emit(&alleles, u8::from(code != 3), 1);
+}
+
+const HETEROZYGOUS_PER_BYTE: [u8; 256] = build_heterozygous_per_byte();
+
+const fn build_heterozygous_per_byte() -> [u8; 256] {
+    let mut output = [0_u8; 256];
+    let mut byte = 0;
+    while byte < 256 {
+        let mut count = 0;
+        let mut shift = 0;
+        while shift < 8 {
+            if (byte >> shift) & 3 == 1 {
+                count += 1;
+            }
+            shift += 2;
+        }
+        output[byte] = count;
+        byte += 1;
+    }
+    output
+}
+
+#[inline]
+fn packed_two_bit(bytes: &[u8], sample: usize) -> u8 {
+    (bytes[sample / 4] >> ((sample % 4) * 2)) & 3
+}
+
+pub(crate) fn supports_biallelic_gt_fast_path(record_type: u8, allele_count: usize) -> bool {
+    allele_count == 2
+        && (record_type == 0xff
+            || record_type & 0x08 == 0 && (record_type >> 5) & 3 == 0 && record_type & 0x80 == 0)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_biallelic_gt_into(
+    workspace: &mut GtDecodeWorkspace,
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+    selected_samples: &[usize],
+    ld_base: Option<&[u8]>,
+    retain_main: bool,
+) -> Result<()> {
+    if !supports_biallelic_gt_fast_path(record_type, 2) {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN variant {variant_index} is not eligible for the biallelic GT fast path"
+        )));
+    }
+    let mut cursor = Cursor::new(bytes, variant_index);
+    decode_main_into(
+        &mut cursor,
+        mode,
+        record_type,
+        sample_count,
+        ld_base,
+        &mut workspace.categories,
+    )?;
+
+    workspace.retained_main_valid = false;
+    if !workspace.identity_selection {
+        workspace.selected_codes.clear();
+        for &sample in selected_samples {
+            let category = *workspace.categories.get(sample).ok_or_else(|| {
+                cursor.error(format!(
+                    "selected sample index {sample} is out of bounds for {sample_count} samples"
+                ))
+            })?;
+            workspace.selected_codes.push(category);
+        }
+    }
+
+    if record_type != 0xff && record_type & 0x10 != 0 {
+        if retain_main && workspace.identity_selection {
+            workspace.retained_main.clear();
+            workspace
+                .retained_main
+                .extend_from_slice(&workspace.categories);
+            workspace.retained_main_valid = true;
+        }
+        decode_phase_for_selected_gt(
+            &mut cursor,
+            &mut workspace.categories,
+            &workspace.source_to_output,
+            &mut workspace.selected_codes,
+            workspace.identity_selection,
+        )?;
+    }
+
+    if !cursor.is_finished() {
+        return Err(cursor.error(format!(
+            "{} trailing bytes remain after decoding the declared GT tracks",
+            cursor.remaining()
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -90,18 +456,20 @@ pub(crate) fn decode_record_and_main(
             "unsupported multiallelic PGEN dosage track; hardcalls remain supported".to_string(),
         ));
     }
-    let (mut dosages, dosage_sample_ids) =
+    let (stored_dosages, dosage_sample_ids) =
         decode_dosage(&mut cursor, dosage_encoding, sample_count)?;
-    if dosage_encoding != 0 {
-        for (dosage, call) in dosages.iter_mut().zip(&calls) {
-            if dosage.is_none()
-                && let Some(call) = call
-            {
-                *dosage = Some((u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32);
-            }
+    if dosage_encoding == 2 {
+        validate_fixed_dosage_missingness(&calls, &stored_dosages, &cursor)?;
+    }
+    validate_dosage_hardcall_consistency(&calls, &stored_dosages, &cursor)?;
+    let mut dosages = stored_dosages.clone();
+    for (dosage, call) in dosages.iter_mut().zip(&calls) {
+        if dosage.is_none()
+            && let Some(call) = call
+        {
+            *dosage = Some((u16::from(call[0] > 0) + u16::from(call[1] > 0)) as f32);
         }
     }
-    validate_dosage_hardcall_consistency(&calls, &dosages, &cursor)?;
     let hds = if record_type != 0xff && record_type & 0x80 != 0 {
         decode_phased_dosage(
             &mut cursor,
@@ -128,6 +496,7 @@ pub(crate) fn decode_record_and_main(
     let mut selected_gt = Vec::with_capacity(selected_samples.len());
     let mut selected_phased = Vec::with_capacity(selected_samples.len());
     let mut selected_ds = Vec::with_capacity(selected_samples.len());
+    let mut selected_ds_stored = Vec::with_capacity(selected_samples.len());
     let mut selected_hds = Vec::with_capacity(selected_samples.len());
     for &sample in selected_samples {
         if sample >= sample_count {
@@ -138,14 +507,15 @@ pub(crate) fn decode_record_and_main(
         selected_gt.push(calls[sample]);
         selected_phased.push(phased[sample]);
         selected_ds.push(dosages[sample]);
+        selected_ds_stored.push(stored_dosages[sample]);
         selected_hds.push(hds[sample]);
     }
-    dosages.clear();
     Ok((
         DecodedRecord {
             gt: selected_gt,
             phased: selected_phased,
             ds: selected_ds,
+            ds_stored: selected_ds_stored,
             hds: selected_hds,
         },
         categories,
@@ -171,29 +541,51 @@ fn decode_main(
     sample_count: usize,
     ld_base: Option<&[u8]>,
 ) -> Result<Vec<u8>> {
+    let mut output = Vec::with_capacity(sample_count);
+    decode_main_into(
+        cursor,
+        mode,
+        record_type,
+        sample_count,
+        ld_base,
+        &mut output,
+    )?;
+    Ok(output)
+}
+
+fn decode_main_into(
+    cursor: &mut Cursor<'_>,
+    mode: PgenMode,
+    record_type: u8,
+    sample_count: usize,
+    ld_base: Option<&[u8]>,
+    output: &mut Vec<u8>,
+) -> Result<()> {
+    output.clear();
     if mode == PgenMode::Plink1 {
         let bytes = cursor.take(sample_count.div_ceil(4), "PLINK 1 hardcalls")?;
         validate_packed_padding(bytes, sample_count, 2, cursor)?;
-        return Ok((0..sample_count)
-            .map(|sample| match packed_value(bytes, sample, 2) as u8 {
+        unpack_two_bit(bytes, sample_count, output);
+        for category in output {
+            *category = match *category {
                 0 => 2,
                 1 => 3,
                 2 => 1,
                 3 => 0,
                 _ => unreachable!(),
-            })
-            .collect());
+            };
+        }
+        return Ok(());
     }
 
     match record_type & 7 {
         0 => {
             let bytes = cursor.take(sample_count.div_ceil(4), "dense hardcalls")?;
             validate_packed_padding(bytes, sample_count, 2, cursor)?;
-            Ok((0..sample_count)
-                .map(|sample| packed_value(bytes, sample, 2) as u8)
-                .collect())
+            unpack_two_bit(bytes, sample_count, output);
+            Ok(())
         }
-        1 => decode_onebit(cursor, sample_count),
+        1 => decode_onebit_into(cursor, sample_count, output),
         2 | 3 => {
             let base = ld_base.ok_or_else(|| {
                 cursor.error("LD-compressed record was decoded without its base".to_string())
@@ -204,14 +596,14 @@ fn decode_main(
                     base.len()
                 )));
             }
-            let mut result = base.to_vec();
+            output.extend_from_slice(base);
             for (sample, value) in decode_difflist(cursor, sample_count, true)? {
-                result[sample] = value.ok_or_else(|| {
+                output[sample] = value.ok_or_else(|| {
                     cursor.error("LD difflist omitted a genotype value".to_string())
                 })?;
             }
             if record_type & 1 != 0 {
-                for category in &mut result {
+                for category in output {
                     *category = match *category {
                         0 => 2,
                         2 => 0,
@@ -219,24 +611,28 @@ fn decode_main(
                     };
                 }
             }
-            Ok(result)
+            Ok(())
         }
         common @ (4 | 6 | 7) => {
             let common = common & 3;
-            let mut result = vec![common; sample_count];
+            output.resize(sample_count, common);
             for (sample, value) in decode_difflist(cursor, sample_count, true)? {
-                result[sample] = value.ok_or_else(|| {
+                output[sample] = value.ok_or_else(|| {
                     cursor.error("hardcall difflist omitted a genotype value".to_string())
                 })?;
             }
-            Ok(result)
+            Ok(())
         }
         5 => Err(cursor.error("reserved PGEN main-track representation 5".to_string())),
         _ => unreachable!(),
     }
 }
 
-fn decode_onebit(cursor: &mut Cursor<'_>, sample_count: usize) -> Result<Vec<u8>> {
+fn decode_onebit_into(
+    cursor: &mut Cursor<'_>,
+    sample_count: usize,
+    output: &mut Vec<u8>,
+) -> Result<()> {
     let code = cursor.byte("one-bit common-category code")?;
     let lower = code / 4;
     let delta = code & 3;
@@ -245,15 +641,27 @@ fn decode_onebit(cursor: &mut Cursor<'_>, sample_count: usize) -> Result<Vec<u8>
     }
     let bits = cursor.take(sample_count.div_ceil(8), "one-bit hardcall array")?;
     validate_packed_padding(bits, sample_count, 1, cursor)?;
-    let mut result = (0..sample_count)
-        .map(|sample| lower + (bit(bits, sample) as u8) * delta)
-        .collect::<Vec<_>>();
+    output.clear();
+    output.reserve(sample_count);
+    for sample in 0..sample_count {
+        output.push(lower + (bit(bits, sample) as u8) * delta);
+    }
     for (sample, value) in decode_difflist(cursor, sample_count, true)? {
-        result[sample] = value.ok_or_else(|| {
+        output[sample] = value.ok_or_else(|| {
             cursor.error("one-bit exception omitted a genotype value".to_string())
         })?;
     }
-    Ok(result)
+    Ok(())
+}
+
+#[inline]
+fn unpack_two_bit(bytes: &[u8], sample_count: usize, output: &mut Vec<u8>) {
+    output.clear();
+    output.reserve(sample_count);
+    for &byte in bytes {
+        output.extend_from_slice(&[byte & 3, (byte >> 2) & 3, (byte >> 4) & 3, (byte >> 6) & 3]);
+    }
+    output.truncate(sample_count);
 }
 
 fn decode_difflist(
@@ -560,7 +968,12 @@ fn decode_phase(
     for (heterozygous_index, &sample) in heterozygous.iter().enumerate() {
         if present[heterozygous_index] {
             if info[info_index] {
-                calls[sample].as_mut().unwrap().swap(0, 1);
+                let call = calls[sample].as_mut().ok_or_else(|| {
+                    cursor.error(format!(
+                        "phase information addresses a missing hardcall for sample {sample}"
+                    ))
+                })?;
+                call.swap(0, 1);
             }
             phased[sample] = Some(true);
             info_index += 1;
@@ -573,6 +986,117 @@ fn decode_phase(
             phased[sample] = Some(false);
         }
     }
+    Ok(())
+}
+
+fn decode_phase_for_selected_gt(
+    cursor: &mut Cursor<'_>,
+    categories: &mut [u8],
+    source_to_output: &[usize],
+    selected_codes: &mut [u8],
+    identity_selection: bool,
+) -> Result<()> {
+    let heterozygous_count = categories.iter().filter(|&&category| category == 1).count();
+    if heterozygous_count == 0 {
+        return Err(
+            cursor.error("hardcall-phase track is present without heterozygous calls".to_string())
+        );
+    }
+
+    let first = *cursor
+        .bytes
+        .get(cursor.position)
+        .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
+    let explicit_present = first & 1 != 0;
+    if explicit_present {
+        let present = cursor.take(
+            (heterozygous_count + 1).div_ceil(8),
+            "phase-present bitarray",
+        )?;
+        validate_phase_padding(present, heterozygous_count + 1, cursor)?;
+        let phased_count = (0..heterozygous_count)
+            .filter(|&index| bit(present, index + 1))
+            .count();
+        let info = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
+        validate_packed_padding(info, phased_count, 1, cursor)?;
+
+        let mut heterozygous_index = 0;
+        let mut info_index = 0;
+        for source in 0..categories.len() {
+            let category = categories[source];
+            if category != 1 {
+                continue;
+            }
+            if bit(present, heterozygous_index + 1) {
+                if bit(info, info_index) {
+                    orient_selected_call(
+                        source,
+                        categories,
+                        source_to_output,
+                        selected_codes,
+                        identity_selection,
+                        cursor,
+                    )?;
+                }
+                info_index += 1;
+            }
+            heterozygous_index += 1;
+        }
+    } else {
+        let info = cursor.take(
+            (heterozygous_count + 1).div_ceil(8),
+            "implicit phase-info bitarray",
+        )?;
+        if info.first().is_some_and(|byte| byte & 1 != 0) {
+            return Err(
+                cursor.error("implicit phase track has phase-present marker set".to_string())
+            );
+        }
+        validate_phase_padding(info, heterozygous_count + 1, cursor)?;
+        let mut heterozygous_index = 0;
+        for source in 0..categories.len() {
+            let category = categories[source];
+            if category != 1 {
+                continue;
+            }
+            if bit(info, heterozygous_index + 1) {
+                orient_selected_call(
+                    source,
+                    categories,
+                    source_to_output,
+                    selected_codes,
+                    identity_selection,
+                    cursor,
+                )?;
+            }
+            heterozygous_index += 1;
+        }
+    }
+    Ok(())
+}
+
+fn orient_selected_call(
+    source: usize,
+    categories: &mut [u8],
+    source_to_output: &[usize],
+    selected_codes: &mut [u8],
+    identity_selection: bool,
+    cursor: &Cursor<'_>,
+) -> Result<()> {
+    if identity_selection {
+        categories[source] = 4;
+        return Ok(());
+    }
+    let output = source_to_output[source];
+    if output == usize::MAX {
+        return Ok(());
+    }
+    let code = selected_codes.get_mut(output).ok_or_else(|| {
+        cursor.error(format!(
+            "phase information addresses an invalid selected call for sample {source}"
+        ))
+    })?;
+    *code = 4;
     Ok(())
 }
 
@@ -633,6 +1157,21 @@ fn validate_dosage_hardcall_consistency(
         if (hardcall - dosage).abs() > 0.5001 {
             return Err(cursor.error(format!(
                 "dosage {dosage} is inconsistent with hardcall ALT count {hardcall} for sample {sample}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_fixed_dosage_missingness(
+    calls: &[Option<[u16; 2]>],
+    stored_dosages: &[Option<f32>],
+    cursor: &Cursor<'_>,
+) -> Result<()> {
+    for (sample, (call, dosage)) in calls.iter().zip(stored_dosages).enumerate() {
+        if dosage.is_none() && call.is_some() {
+            return Err(cursor.error(format!(
+                "fixed-width dosage is missing while the hardcall is present for sample {sample}"
             )));
         }
     }
@@ -953,5 +1492,55 @@ mod tests {
             bytes[index / 4] |= value << ((index % 4) * 2);
         }
         bytes
+    }
+
+    fn decode_direct_dense(
+        bytes: &[u8],
+        mode: PgenMode,
+        record_type: u8,
+        sample_count: usize,
+    ) -> Vec<Option<[u16; 2]>> {
+        let mut output = Vec::new();
+        decode_dense_biallelic_gt(
+            bytes,
+            mode,
+            record_type,
+            0,
+            sample_count,
+            |alleles, validity, samples| {
+                for sample in 0..samples {
+                    output.push(
+                        (validity & (1 << sample) != 0)
+                            .then(|| [alleles[sample * 2], alleles[sample * 2 + 1]]),
+                    );
+                }
+            },
+        )
+        .unwrap();
+        output
+    }
+
+    #[test]
+    fn direct_dense_decodes_implicit_phase_in_quad_chunks() {
+        assert_eq!(
+            decode_direct_dense(&[0b11_00_01_01, 0b0000_0100], PgenMode::Variable, 0x10, 4,),
+            vec![Some([0, 1]), Some([1, 0]), Some([0, 0]), None]
+        );
+    }
+
+    #[test]
+    fn direct_dense_handles_partial_final_byte() {
+        assert_eq!(
+            decode_direct_dense(&[0b00_11_01_00, 0b0000_0010], PgenMode::Variable, 0x10, 3,),
+            vec![Some([0, 0]), Some([1, 0]), None]
+        );
+    }
+
+    #[test]
+    fn direct_dense_preserves_unphased_and_missing_calls() {
+        assert_eq!(
+            decode_direct_dense(&[0b11_10_01_00], PgenMode::Variable, 0, 4,),
+            vec![Some([0, 0]), Some([0, 1]), Some([1, 1]), None]
+        );
     }
 }

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -690,16 +690,27 @@ pub(crate) fn decode_record_and_main(
     ))
 }
 
-pub(crate) fn decode_main_track(
+pub(crate) fn decode_main_track_and_validate(
     bytes: &[u8],
     mode: PgenMode,
     record_type: u8,
     variant_index: usize,
     sample_count: usize,
+    allele_count: usize,
     ld_base: Option<&[u8]>,
 ) -> Result<Vec<u8>> {
-    let mut cursor = Cursor::new(bytes, variant_index);
-    decode_main(&mut cursor, mode, record_type, sample_count, ld_base)
+    decode_record_and_main(
+        bytes,
+        mode,
+        record_type,
+        variant_index,
+        sample_count,
+        allele_count,
+        GenotypeProjection::default(),
+        &[],
+        ld_base,
+    )
+    .map(|(_, main)| main)
 }
 
 fn decode_main(

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -170,10 +170,15 @@ impl PgenFileset {
             )));
         }
 
-        let psam_bytes = ObjectAccess::open(&psam_path, &storage_options)
+        let psam_raw = ObjectAccess::open(&psam_path, &storage_options)
             .await?
             .read_all_bounded(&psam_path, options.max_companion_bytes)
             .await?;
+        let psam_bytes = decode_text_companion(
+            &psam_path,
+            &psam_raw,
+            options.max_decompressed_companion_bytes,
+        )?;
         let identities = parse_psam(&psam_path, &psam_bytes, options.max_samples)?;
         let source_names = sample_names(&identities, options.psam_id_mode);
         let selected_samples = resolve_samples(
@@ -363,7 +368,7 @@ fn decode_text_companion(path: &str, bytes: &[u8], max_decoded: usize) -> Result
     if bytes.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
         let decoder = zstd::stream::read::Decoder::new(bytes).map_err(|error| {
             DataFusionError::Plan(format!(
-                "failed to decompress PVAR {} as zstd: {error}",
+                "failed to decompress text companion {} as zstd: {error}",
                 sanitize_location(path)
             ))
         })?;
@@ -372,7 +377,7 @@ fn decode_text_companion(path: &str, bytes: &[u8], max_decoded: usize) -> Result
             .read_to_end(&mut decoded)
             .map_err(|error| {
                 DataFusionError::Plan(format!(
-                    "failed to decompress PVAR {} as zstd: {error}",
+                    "failed to decompress text companion {} as zstd: {error}",
                     sanitize_location(path)
                 ))
             })?;
@@ -382,7 +387,7 @@ fn decode_text_companion(path: &str, bytes: &[u8], max_decoded: usize) -> Result
             .read_to_end(&mut decoded)
             .map_err(|error| {
                 DataFusionError::Plan(format!(
-                    "failed to decompress PVAR {} as gzip: {error}",
+                    "failed to decompress text companion {} as gzip: {error}",
                     sanitize_location(path)
                 ))
             })?;
@@ -391,7 +396,7 @@ fn decode_text_companion(path: &str, bytes: &[u8], max_decoded: usize) -> Result
     }
     if decoded.len() > max_decoded {
         return Err(DataFusionError::Plan(format!(
-            "decompressed PVAR {} exceeds configured limit {max_decoded}",
+            "decompressed text companion {} exceeds configured limit {max_decoded}",
             sanitize_location(path)
         )));
     }
@@ -525,6 +530,12 @@ fn parse_pvar(
                 "has malformed ALT allele list".to_string(),
             ));
         }
+        if variants.len() >= max_variants {
+            return Err(DataFusionError::Plan(format!(
+                "PVAR {} exceeds configured max_variants {max_variants}",
+                sanitize_location(path)
+            )));
+        }
         variants.push(PvarVariant {
             chrom: fields[chrom_col].to_string(),
             start: site.start,
@@ -533,12 +544,6 @@ fn parse_pvar(
             reference: reference.to_string(),
             alternate,
         });
-        if variants.len() > max_variants {
-            return Err(DataFusionError::Plan(format!(
-                "PVAR {} exceeds configured max_variants {max_variants}",
-                sanitize_location(path)
-            )));
-        }
     }
     Ok(variants)
 }

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -567,27 +567,32 @@ fn parse_pvar(
             sanitize_location(path)
         ))
     })?;
-    let lines: Vec<_> = text.lines().collect();
-    let body_start = lines
-        .iter()
-        .position(|line| !line.starts_with('#'))
-        .unwrap_or(lines.len());
-    let header_index = lines[..body_start]
-        .iter()
-        .rposition(|line| line.starts_with("#CHROM"));
-    let (start_line, columns) = if let Some(index) = header_index {
-        if index + 1 != body_start {
+    let mut lines = text.lines().enumerate();
+    let mut header = None;
+    let mut body_start = 0;
+    let first_body = loop {
+        match lines.next() {
+            Some((line_index, line)) if line.starts_with('#') => {
+                body_start = line_index + 1;
+                if line.starts_with("#CHROM") {
+                    header = Some((line_index, line));
+                }
+            }
+            body => break body,
+        }
+    };
+    let columns = if let Some((header_index, header)) = header {
+        if header_index + 1 != body_start {
             return Err(DataFusionError::Plan(format!(
                 "PVAR {} #CHROM line must be the final header line",
                 sanitize_location(path)
             )));
         }
-        let columns = lines[index]
+        header
             .trim_start_matches('#')
             .split_whitespace()
             .map(str::to_string)
-            .collect::<Vec<_>>();
-        (body_start, columns)
+            .collect::<Vec<_>>()
     } else {
         if body_start > 0 {
             return Err(DataFusionError::Plan(format!(
@@ -595,14 +600,16 @@ fn parse_pvar(
                 sanitize_location(path)
             )));
         }
-        let first_width = lines
+        let first_width = first_body
             .iter()
-            .find(|line| !line.is_empty())
-            .map(|line| line.split_whitespace().count())
+            .copied()
+            .chain(lines.clone())
+            .find(|(_, line)| !line.is_empty())
+            .map(|(_, line)| line.split_whitespace().count())
             .unwrap_or(0);
         // PLINK 2 specifies BIM order for a headerless PVAR. The five-column
         // form omits CM: CHROM, ID, POS, ALT, REF.
-        let columns = match first_width {
+        match first_width {
             5 => vec!["CHROM", "ID", "POS", "ALT", "REF"],
             6.. => vec!["CHROM", "ID", "CM", "POS", "ALT", "REF"],
             _ => {
@@ -614,8 +621,7 @@ fn parse_pvar(
         }
         .into_iter()
         .map(str::to_string)
-        .collect();
-        (0, columns)
+        .collect()
     };
     let column = |name: &str| {
         columns
@@ -640,9 +646,15 @@ fn parse_pvar(
         + 1;
 
     let mut variants = Vec::new();
-    for (line_index, line) in lines.iter().enumerate().skip(start_line) {
+    for (line_index, line) in first_body.into_iter().chain(lines) {
         if line.is_empty() || line.starts_with('#') {
             continue;
+        }
+        if variants.len() >= max_variants {
+            return Err(DataFusionError::Plan(format!(
+                "PVAR {} exceeds configured max_variants {max_variants}",
+                sanitize_location(path)
+            )));
         }
         let fields: Vec<_> = line.split_whitespace().collect();
         if fields.len() < required_width {
@@ -684,12 +696,6 @@ fn parse_pvar(
                 "has malformed ALT allele list".to_string(),
             ));
         }
-        if variants.len() >= max_variants {
-            return Err(DataFusionError::Plan(format!(
-                "PVAR {} exceeds configured max_variants {max_variants}",
-                sanitize_location(path)
-            )));
-        }
         variants.push(PvarVariant {
             chrom: fields[chrom_col].to_string(),
             start: site.start,
@@ -717,25 +723,26 @@ fn parse_psam(path: &str, bytes: &[u8], max_samples: usize) -> Result<Vec<PsamId
             sanitize_location(path)
         ))
     })?;
-    let lines: Vec<_> = text.lines().collect();
-    let body_start = lines
-        .iter()
-        .position(|line| !line.starts_with('#'))
-        .unwrap_or(lines.len());
-    let header = lines[..body_start]
-        .iter()
-        .rfind(|line| line.starts_with("#FID") || line.starts_with("#IID"));
-    let (columns, start) = if let Some(header) = header {
-        (
-            header
-                .trim_start_matches('#')
-                .split_whitespace()
-                .collect::<Vec<_>>(),
-            body_start,
-        )
+    let mut lines = text.lines().enumerate();
+    let mut header = None;
+    let first_body = loop {
+        match lines.next() {
+            Some((_, line)) if line.starts_with('#') => {
+                if line.starts_with("#FID") || line.starts_with("#IID") {
+                    header = Some(line);
+                }
+            }
+            body => break body,
+        }
+    };
+    let columns = if let Some(header) = header {
+        header
+            .trim_start_matches('#')
+            .split_whitespace()
+            .collect::<Vec<_>>()
     } else {
-        let first_width = lines
-            .iter()
+        let first_width = text
+            .lines()
             .find(|line| !line.is_empty())
             .map(|line| line.split_whitespace().count())
             .unwrap_or(0);
@@ -745,7 +752,7 @@ fn parse_psam(path: &str, bytes: &[u8], max_samples: usize) -> Result<Vec<PsamId
                 sanitize_location(path)
             )));
         }
-        (vec!["FID", "IID", "PAT", "MAT", "SEX"], 0)
+        vec!["FID", "IID", "PAT", "MAT", "SEX"]
     };
     let iid_col = columns
         .iter()
@@ -760,9 +767,15 @@ fn parse_psam(path: &str, bytes: &[u8], max_samples: usize) -> Result<Vec<PsamId
     let sid_col = columns.iter().position(|value| *value == "SID");
     let mut identities = Vec::new();
     let mut full_ids = HashSet::new();
-    for (line_index, line) in lines.iter().enumerate().skip(start) {
+    for (line_index, line) in first_body.into_iter().chain(lines) {
         if line.is_empty() || line.starts_with('#') {
             continue;
+        }
+        if identities.len() >= max_samples {
+            return Err(DataFusionError::Plan(format!(
+                "PSAM {} exceeds configured max_samples {max_samples}",
+                sanitize_location(path)
+            )));
         }
         let fields: Vec<_> = line.split_whitespace().collect();
         if fields.len() < columns.len() {
@@ -805,12 +818,6 @@ fn parse_psam(path: &str, bytes: &[u8], max_samples: usize) -> Result<Vec<PsamId
             )));
         }
         identities.push(identity);
-        if identities.len() > max_samples {
-            return Err(DataFusionError::Plan(format!(
-                "PSAM {} exceeds configured max_samples {max_samples}",
-                sanitize_location(path)
-            )));
-        }
     }
     Ok(identities)
 }
@@ -1690,9 +1697,21 @@ mod tests {
         assert_eq!(variants[0].id.as_deref(), Some("v1"));
         assert_eq!(variants[0].reference, "A");
         assert_eq!(variants[0].alternate, vec!["C"]);
-        let error = parse_pvar("cohort.pvar", bytes, CoordinateSystem::ZeroBasedHalfOpen, 1)
-            .unwrap_err()
-            .to_string();
+        let error = parse_pvar(
+            "cohort.pvar",
+            b"1 v1 10 C A\nmalformed\n",
+            CoordinateSystem::ZeroBasedHalfOpen,
+            1,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(error.contains("max_variants 1"), "{error}");
+    }
+
+    #[test]
+    fn streams_psam_rows_and_enforces_limit_before_parsing_excess_rows() {
+        let bytes = b"#FID IID PAT MAT SEX\nf1 i1 0 0 0\nmalformed\n";
+        let error = parse_psam("cohort.psam", bytes, 1).unwrap_err().to_string();
+        assert!(error.contains("max_samples 1"), "{error}");
     }
 }

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -1066,10 +1066,18 @@ async fn parse_index(
     let block_offsets = (0..block_count)
         .map(|index| read_le(&body, 12 + index * 8, 8))
         .collect::<Result<Vec<_>>>()?;
-    if variant_count > 0 && block_offsets.first().copied().unwrap_or(0) < 3 {
-        return Err(DataFusionError::Plan(
-            "PGEN first variant block starts inside the file magic".to_string(),
-        ));
+    if variant_count > 0 {
+        let first_offset = block_offsets.first().copied().unwrap_or(0);
+        if external.is_some() && first_offset != 3 {
+            return Err(DataFusionError::Plan(format!(
+                "external-index PGEN variant data must start at byte 3, observed {first_offset}"
+            )));
+        }
+        if first_offset < 3 {
+            return Err(DataFusionError::Plan(
+                "PGEN first variant block starts inside the file magic".to_string(),
+            ));
+        }
     }
 
     let mut cursor = 12 + offsets_bytes;

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -66,6 +66,13 @@ impl PgenMode {
             Self::VariableExtensions | Self::ExternalIndexExtensions
         )
     }
+
+    fn is_biallelic_only(self) -> bool {
+        matches!(
+            self,
+            Self::Plink1 | Self::FixedHardcall | Self::FixedDosage | Self::FixedPhasedDosage
+        )
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -448,6 +455,8 @@ fn parse_pvar(
             .find(|line| !line.is_empty())
             .map(|line| line.split_whitespace().count())
             .unwrap_or(0);
+        // PLINK 2 specifies BIM order for a headerless PVAR. The five-column
+        // form omits CM: CHROM, ID, POS, ALT, REF.
         let columns = match first_width {
             5 => vec!["CHROM", "ID", "POS", "ALT", "REF"],
             6.. => vec!["CHROM", "ID", "CM", "POS", "ALT", "REF"],
@@ -695,6 +704,18 @@ async fn parse_index(
     pvar: &[PvarVariant],
     psam_sample_count: usize,
 ) -> Result<(Vec<RecordInfo>, u64, usize, usize)> {
+    if mode.is_biallelic_only()
+        && let Some((index, count)) = pvar
+            .iter()
+            .map(PvarVariant::allele_count)
+            .enumerate()
+            .find(|(_, count)| *count != 2)
+    {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN storage mode 0x{:02x} is biallelic-only, but PVAR variant {index} has {count} alleles",
+            mode.byte()
+        )));
+    }
     if mode == PgenMode::Plink1 {
         let bytes_per_variant = psam_sample_count.checked_add(3).ok_or_else(|| {
             DataFusionError::Plan("PGEN sample count arithmetic overflowed".to_string())
@@ -981,6 +1002,8 @@ async fn parse_index(
                 block_offsets[block + 1]
             )));
         }
+        // In variable-width modes, zero means counts are supplied by the
+        // accompanying PVAR; it does not imply that every row is biallelic.
         if allele_width > 0 {
             let raw = take(&body, &mut cursor, count * allele_width, "allele counts")?;
             for index in 0..count {
@@ -1253,11 +1276,12 @@ mod tests {
     }
 
     #[test]
-    fn parses_five_column_headerless_pvar_and_enforces_row_limit() {
+    fn parses_bim_order_headerless_pvar_and_enforces_row_limit() {
         let bytes = b"1 v1 10 C A\n2 v2 20 G T\n";
         let variants =
             parse_pvar("cohort.pvar", bytes, CoordinateSystem::ZeroBasedHalfOpen, 2).unwrap();
         assert_eq!(variants[0].start, 9);
+        assert_eq!(variants[0].id.as_deref(), Some("v1"));
         assert_eq!(variants[0].reference, "A");
         assert_eq!(variants[0].alternate, vec!["C"]);
         let error = parse_pvar("cohort.pvar", bytes, CoordinateSystem::ZeroBasedHalfOpen, 1)

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -1046,7 +1046,8 @@ async fn parse_index(
         }
     }
 
-    let mut header_bytes = body_len as u64;
+    let mut header_end = body_len as u64;
+    let mut extension_bytes_read = 0_u64;
     let mut footer_offset = None;
     if mode.has_extensions() {
         let known_extension_end = if external.is_some() {
@@ -1054,37 +1055,44 @@ async fn parse_index(
         } else {
             block_offsets.first().copied()
         };
-        let extension_end = known_extension_end
-            .unwrap_or_else(|| pgen_size.min(u64::try_from(max_header_bytes).unwrap_or(u64::MAX)));
-        if extension_end < body_len as u64 {
-            return Err(DataFusionError::Plan(
-                "PGEN header extensions overlap the fixed header body".to_string(),
-            ));
-        }
-        let extension_len = usize::try_from(extension_end - body_len as u64).map_err(|_| {
-            DataFusionError::Plan("PGEN extension region does not fit usize".to_string())
-        })?;
-        if body_len.saturating_add(extension_len) > max_header_bytes {
-            return Err(DataFusionError::Plan(format!(
-                "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
-            )));
-        }
-        let extensions = header_object
-            .read_range(header_path, body_len as u64..extension_end)
-            .await?;
-        if known_extension_end.is_some() {
+        if let Some(extension_end) = known_extension_end {
+            if extension_end < body_len as u64 {
+                return Err(DataFusionError::Plan(
+                    "PGEN header extensions overlap the fixed header body".to_string(),
+                ));
+            }
+            let extension_len = usize::try_from(extension_end - body_len as u64).map_err(|_| {
+                DataFusionError::Plan("PGEN extension region does not fit usize".to_string())
+            })?;
+            if body_len.saturating_add(extension_len) > max_header_bytes {
+                return Err(DataFusionError::Plan(format!(
+                    "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
+                )));
+            }
+            let extensions = header_object
+                .read_range(header_path, body_len as u64..extension_end)
+                .await?;
             footer_offset = validate_extensions(&extensions, pgen_size)?;
-            header_bytes = extension_end;
+            header_end = extension_end;
+            extension_bytes_read = extension_end - body_len as u64;
         } else {
-            let (parsed_footer_offset, parsed_len) = parse_extensions(&extensions, pgen_size)?;
+            let (parsed_footer_offset, parsed_len, bytes_read) = read_empty_embedded_extensions(
+                header_object,
+                header_path,
+                body_len,
+                pgen_size,
+                max_header_bytes,
+            )
+            .await?;
             footer_offset = parsed_footer_offset;
-            header_bytes = (body_len as u64)
+            header_end = (body_len as u64)
                 .checked_add(u64::try_from(parsed_len).map_err(|_| {
                     DataFusionError::Plan("PGEN extension length does not fit u64".to_string())
                 })?)
                 .ok_or_else(|| {
                     DataFusionError::Plan("PGEN extension end overflowed".to_string())
                 })?;
+            extension_bytes_read = bytes_read;
         }
     } else if external.is_some() {
         let observed = header_object.size(header_path).await?;
@@ -1108,7 +1116,7 @@ async fn parse_index(
     let data_end = records
         .last()
         .map(RecordInfo::end)
-        .unwrap_or_else(|| if external.is_some() { 3 } else { header_bytes });
+        .unwrap_or_else(|| if external.is_some() { 3 } else { header_end });
     let expected_data_end = footer_offset.unwrap_or(pgen_size);
     if data_end != expected_data_end {
         return Err(DataFusionError::Plan(format!(
@@ -1120,7 +1128,90 @@ async fn parse_index(
             }
         )));
     }
-    Ok((records, 12 + header_bytes, sample_count, variant_count))
+    Ok((
+        records,
+        12 + body_len as u64 + extension_bytes_read,
+        sample_count,
+        variant_count,
+    ))
+}
+
+async fn read_empty_embedded_extensions(
+    header_object: &ObjectAccess,
+    header_path: &str,
+    body_len: usize,
+    pgen_size: u64,
+    max_header_bytes: usize,
+) -> Result<(Option<u64>, usize, u64)> {
+    // A zero-variant embedded index has no first block offset to delimit its
+    // extension region. Grow the probe only to the next parser requirement so
+    // a declared footer is never downloaded as if it were header metadata.
+    let body_start = body_len as u64;
+    let available = pgen_size.checked_sub(body_start).ok_or_else(|| {
+        DataFusionError::Plan("PGEN header extensions overlap the fixed header body".to_string())
+    })?;
+    let max_extension_bytes = max_header_bytes.checked_sub(body_len).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
+        ))
+    })?;
+    let mut bytes = Vec::new();
+    let initial_len = available.min(2) as usize;
+    if initial_len > max_extension_bytes {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
+        )));
+    }
+    if initial_len > 0 {
+        bytes.extend_from_slice(
+            &header_object
+                .read_range(header_path, body_start..body_start + initial_len as u64)
+                .await?,
+        );
+    }
+
+    loop {
+        match parse_extension_layout(&bytes, pgen_size)? {
+            ExtensionLayoutStatus::NeedMore(required) => {
+                if required > max_extension_bytes {
+                    return Err(DataFusionError::Plan(format!(
+                        "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
+                    )));
+                }
+                if required as u64 > available {
+                    return Err(DataFusionError::Plan(
+                        "truncated PGEN header extension metadata".to_string(),
+                    ));
+                }
+                let start = body_start + bytes.len() as u64;
+                let end = body_start + required as u64;
+                bytes.extend_from_slice(&header_object.read_range(header_path, start..end).await?);
+            }
+            ExtensionLayoutStatus::Complete {
+                footer_offset,
+                total_len,
+            } => {
+                if total_len > max_extension_bytes {
+                    return Err(DataFusionError::Plan(format!(
+                        "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
+                    )));
+                }
+                if total_len as u64 > available {
+                    return Err(DataFusionError::Plan(
+                        "truncated PGEN header extension body".to_string(),
+                    ));
+                }
+                if total_len > bytes.len() {
+                    let start = body_start + bytes.len() as u64;
+                    let end = body_start + total_len as u64;
+                    bytes.extend_from_slice(
+                        &header_object.read_range(header_path, start..end).await?,
+                    );
+                }
+                return Ok((footer_offset, total_len, bytes.len() as u64));
+            }
+        }
+    }
 }
 
 fn validate_extensions(bytes: &[u8], pgen_size: u64) -> Result<Option<u64>> {
@@ -1135,10 +1226,50 @@ fn validate_extensions(bytes: &[u8], pgen_size: u64) -> Result<Option<u64>> {
 }
 
 fn parse_extensions(bytes: &[u8], pgen_size: u64) -> Result<(Option<u64>, usize)> {
+    let (footer_offset, cursor) = match parse_extension_layout(bytes, pgen_size)? {
+        ExtensionLayoutStatus::Complete {
+            footer_offset,
+            total_len,
+        } => (footer_offset, total_len),
+        ExtensionLayoutStatus::NeedMore(_) => {
+            return Err(DataFusionError::Plan(
+                "truncated PGEN header extension metadata".to_string(),
+            ));
+        }
+    };
+    if cursor > bytes.len() {
+        return Err(DataFusionError::Plan(
+            "truncated PGEN header extension body".to_string(),
+        ));
+    }
+    Ok((footer_offset, cursor))
+}
+
+enum ExtensionLayoutStatus {
+    NeedMore(usize),
+    Complete {
+        footer_offset: Option<u64>,
+        total_len: usize,
+    },
+}
+
+fn parse_extension_layout(bytes: &[u8], pgen_size: u64) -> Result<ExtensionLayoutStatus> {
     let mut cursor = 0;
-    let header_flags = read_flag_varint(bytes, &mut cursor)?;
-    let footer_flags = read_flag_varint(bytes, &mut cursor)?;
+    let header_flags = match read_flag_varint_prefix(bytes, &mut cursor)? {
+        Some(value) => value,
+        None => return Ok(ExtensionLayoutStatus::NeedMore(cursor + 1)),
+    };
+    let footer_flags = match read_flag_varint_prefix(bytes, &mut cursor)? {
+        Some(value) => value,
+        None => return Ok(ExtensionLayoutStatus::NeedMore(cursor + 1)),
+    };
     let footer_offset = if footer_flags > 0 {
+        let required = cursor
+            .checked_add(8)
+            .ok_or_else(|| DataFusionError::Plan("PGEN extension cursor overflowed".to_string()))?;
+        if required > bytes.len() {
+            return Ok(ExtensionLayoutStatus::NeedMore(required));
+        }
         let footer_offset = read_le(bytes, cursor, 8)?;
         cursor += 8;
         if footer_offset > pgen_size {
@@ -1152,30 +1283,31 @@ fn parse_extensions(bytes: &[u8], pgen_size: u64) -> Result<(Option<u64>, usize)
     };
     let mut body_bytes = 0_usize;
     for _ in 0..header_flags {
-        let length = read_varint(bytes, &mut cursor)?;
+        let length = match read_varint_prefix(bytes, &mut cursor)? {
+            Some(value) => value,
+            None => return Ok(ExtensionLayoutStatus::NeedMore(cursor + 1)),
+        };
         body_bytes = body_bytes
             .checked_add(usize::try_from(length).map_err(|_| {
                 DataFusionError::Plan("PGEN header extension length does not fit usize".to_string())
             })?)
             .ok_or_else(|| DataFusionError::Plan("PGEN extension length overflowed".to_string()))?;
     }
-    cursor = cursor
+    let total_len = cursor
         .checked_add(body_bytes)
         .ok_or_else(|| DataFusionError::Plan("PGEN extension cursor overflowed".to_string()))?;
-    if cursor > bytes.len() {
-        return Err(DataFusionError::Plan(
-            "truncated PGEN header extension body".to_string(),
-        ));
-    }
-    Ok((footer_offset, cursor))
+    Ok(ExtensionLayoutStatus::Complete {
+        footer_offset,
+        total_len,
+    })
 }
 
-fn read_flag_varint(bytes: &[u8], cursor: &mut usize) -> Result<usize> {
+fn read_flag_varint_prefix(bytes: &[u8], cursor: &mut usize) -> Result<Option<usize>> {
     let mut set_bits = 0_usize;
     for index in 0..37 {
-        let byte = *bytes.get(*cursor).ok_or_else(|| {
-            DataFusionError::Plan("truncated PGEN extension flag varint".to_string())
-        })?;
+        let Some(&byte) = bytes.get(*cursor) else {
+            return Ok(None);
+        };
         *cursor += 1;
         set_bits = set_bits
             .checked_add((byte & 0x7f).count_ones() as usize)
@@ -1186,7 +1318,7 @@ fn read_flag_varint(bytes: &[u8], cursor: &mut usize) -> Result<usize> {
                     "PGEN extension flags exceed 256 bits".to_string(),
                 ));
             }
-            return Ok(set_bits);
+            return Ok(Some(set_bits));
         }
     }
     Err(DataFusionError::Plan(
@@ -1194,12 +1326,12 @@ fn read_flag_varint(bytes: &[u8], cursor: &mut usize) -> Result<usize> {
     ))
 }
 
-pub(crate) fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64> {
+fn read_varint_prefix(bytes: &[u8], cursor: &mut usize) -> Result<Option<u64>> {
     let mut value = 0_u64;
     for shift in (0..=63).step_by(7) {
-        let byte = *bytes.get(*cursor).ok_or_else(|| {
-            DataFusionError::Execution("truncated PGEN base-128 varint".to_string())
-        })?;
+        let Some(&byte) = bytes.get(*cursor) else {
+            return Ok(None);
+        };
         *cursor += 1;
         if shift == 63 && byte > 1 {
             return Err(DataFusionError::Execution(
@@ -1208,11 +1340,20 @@ pub(crate) fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64> {
         }
         value |= u64::from(byte & 0x7f) << shift;
         if byte & 0x80 == 0 {
-            return Ok(value);
+            return Ok(Some(value));
         }
     }
     Err(DataFusionError::Execution(
         "PGEN base-128 varint exceeds ten bytes".to_string(),
+    ))
+}
+
+pub(crate) fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64> {
+    if let Some(value) = read_varint_prefix(bytes, cursor)? {
+        return Ok(value);
+    }
+    Err(DataFusionError::Execution(
+        "truncated PGEN base-128 varint".to_string(),
     ))
 }
 

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -1007,6 +1007,9 @@ async fn parse_index(
         if allele_width > 0 {
             let raw = take(&body, &mut cursor, count * allele_width, "allele counts")?;
             for index in 0..count {
+                // The PGEN header stores total allele count verbatim. The
+                // pinned pgenlib reader compares this raw value directly with
+                // the accompanying PVAR allele-index offset delta.
                 allele_counts.push(read_le(raw, index * allele_width, allele_width)? as usize);
             }
         }

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -1117,6 +1117,11 @@ async fn parse_index(
                     "PGEN variant {absolute_index} uses reserved main-track representation 5 under {PGEN_SPEC_BASELINE}"
                 )));
             }
+            if record_type & 0x80 != 0 && (record_type >> 5) & 3 == 0 {
+                return Err(DataFusionError::Plan(format!(
+                    "PGEN variant {absolute_index} has a phased-dosage track without a dosage track"
+                )));
+            }
             if length == 0 {
                 return Err(DataFusionError::Plan(format!(
                     "PGEN variant {absolute_index} has an empty record"

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -1,0 +1,1263 @@
+use std::collections::HashSet;
+use std::io::Read;
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion_bio_format_core::companion::{CompanionRule, resolve_companion, sanitize_location};
+use datafusion_bio_format_core::genotype::{CoordinateSystem, SampleSelection, resolve_samples};
+use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
+use flate2::read::MultiGzDecoder;
+
+use crate::source::ObjectAccess;
+use crate::table_provider::{PgenReadOptions, PsamIdMode};
+
+pub(crate) const PGEN_SPEC_BASELINE: &str = "plink-ng 9ee41ce (2026-07-27)";
+const PGEN_BLOCK_VARIANTS: usize = 1 << 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PgenMode {
+    Plink1,
+    FixedHardcall,
+    FixedDosage,
+    FixedPhasedDosage,
+    Variable,
+    VariableExtensions,
+    ExternalIndex,
+    ExternalIndexExtensions,
+}
+
+impl PgenMode {
+    fn from_byte(value: u8) -> Result<Self> {
+        match value {
+            0x01 => Ok(Self::Plink1),
+            0x02 => Ok(Self::FixedHardcall),
+            0x03 => Ok(Self::FixedDosage),
+            0x04 => Ok(Self::FixedPhasedDosage),
+            0x10 => Ok(Self::Variable),
+            0x11 => Ok(Self::VariableExtensions),
+            0x20 => Ok(Self::ExternalIndex),
+            0x21 => Ok(Self::ExternalIndexExtensions),
+            _ => Err(DataFusionError::Plan(format!(
+                "unsupported PGEN storage mode 0x{value:02x}; specification baseline {PGEN_SPEC_BASELINE}"
+            ))),
+        }
+    }
+
+    pub(crate) fn byte(self) -> u8 {
+        match self {
+            Self::Plink1 => 0x01,
+            Self::FixedHardcall => 0x02,
+            Self::FixedDosage => 0x03,
+            Self::FixedPhasedDosage => 0x04,
+            Self::Variable => 0x10,
+            Self::VariableExtensions => 0x11,
+            Self::ExternalIndex => 0x20,
+            Self::ExternalIndexExtensions => 0x21,
+        }
+    }
+
+    fn has_external_index(self) -> bool {
+        matches!(self, Self::ExternalIndex | Self::ExternalIndexExtensions)
+    }
+
+    fn has_extensions(self) -> bool {
+        matches!(
+            self,
+            Self::VariableExtensions | Self::ExternalIndexExtensions
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PvarVariant {
+    pub(crate) chrom: String,
+    pub(crate) start: u64,
+    pub(crate) end: u64,
+    pub(crate) id: Option<String>,
+    pub(crate) reference: String,
+    pub(crate) alternate: Vec<String>,
+}
+
+impl PvarVariant {
+    pub(crate) fn allele_count(&self) -> usize {
+        1 + self.alternate.len()
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub(crate) struct PsamIdentity {
+    pub(crate) fid: String,
+    pub(crate) iid: String,
+    pub(crate) sid: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RecordInfo {
+    pub(crate) offset: u64,
+    pub(crate) length: u32,
+    pub(crate) record_type: u8,
+    pub(crate) ld_base: Option<usize>,
+}
+
+impl RecordInfo {
+    pub(crate) fn end(&self) -> u64 {
+        self.offset + u64::from(self.length)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PgenFileset {
+    pub(crate) pgen_path: String,
+    pub(crate) pvar_path: String,
+    pub(crate) psam_path: String,
+    pub(crate) pgi_path: Option<String>,
+    pub(crate) source: ObjectAccess,
+    pub(crate) variants: Arc<Vec<PvarVariant>>,
+    pub(crate) selected_samples: SampleSelection,
+    pub(crate) selected_identities: Arc<Vec<PsamIdentity>>,
+    pub(crate) sample_count: usize,
+    pub(crate) records: Arc<Vec<RecordInfo>>,
+    pub(crate) mode: PgenMode,
+    pub(crate) companion_bytes: u64,
+    pub(crate) header_bytes: u64,
+}
+
+impl PgenFileset {
+    pub(crate) async fn open(pgen_path: String, options: &PgenReadOptions) -> Result<Self> {
+        let storage_options = options.object_storage_options.clone().unwrap_or_default();
+        let source = ObjectAccess::open(&pgen_path, &storage_options).await?;
+        let pgen_size = source.size(&pgen_path).await?;
+        if pgen_size < 3 {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN {} is shorter than its 3-byte magic",
+                sanitize_location(&pgen_path)
+            )));
+        }
+
+        reject_hybrid_companions(&pgen_path, options, &storage_options).await?;
+        let pvar_path = resolve_pvar(&pgen_path, options, &storage_options).await?;
+        let psam_path = resolve_member(
+            &pgen_path,
+            "PSAM",
+            options.psam_path.as_deref(),
+            &[CompanionRule::ReplaceExtension("psam".to_string())],
+            &storage_options,
+        )
+        .await?;
+        let pvar_raw = ObjectAccess::open(&pvar_path, &storage_options)
+            .await?
+            .read_all_bounded(&pvar_path, options.max_companion_bytes)
+            .await?;
+        let pvar_bytes = decode_text_companion(
+            &pvar_path,
+            &pvar_raw,
+            options.max_decompressed_companion_bytes,
+        )?;
+        let variants = parse_pvar(
+            &pvar_path,
+            &pvar_bytes,
+            options.coordinate_system,
+            options.max_variants,
+        )?;
+        if let Some((index, count)) = variants
+            .iter()
+            .map(PvarVariant::allele_count)
+            .enumerate()
+            .find(|(_, count)| *count > 65_536)
+        {
+            return Err(DataFusionError::Plan(format!(
+                "PVAR variant {index} has {count} alleles; raw UInt16 allele output supports at most 65536"
+            )));
+        }
+
+        let psam_bytes = ObjectAccess::open(&psam_path, &storage_options)
+            .await?
+            .read_all_bounded(&psam_path, options.max_companion_bytes)
+            .await?;
+        let identities = parse_psam(&psam_path, &psam_bytes, options.max_samples)?;
+        let source_names = sample_names(&identities, options.psam_id_mode);
+        let selected_samples = resolve_samples(
+            &source_names,
+            options.samples.as_deref(),
+            options.missing_sample_policy,
+        )?;
+        let selected_identities = selected_samples
+            .source_indices()
+            .iter()
+            .map(|&index| identities[index].clone())
+            .collect();
+
+        let prefix = source.read_range(&pgen_path, 0..3).await?;
+        if prefix[0..2] != [0x6c, 0x1b] {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN {} has invalid magic; expected 6c 1b",
+                sanitize_location(&pgen_path)
+            )));
+        }
+        let mode = PgenMode::from_byte(prefix[2])?;
+        let (
+            pgi_path,
+            records,
+            header_bytes,
+            index_companion_bytes,
+            header_sample_count,
+            header_variant_count,
+        ) = if mode.has_external_index() {
+            let pgi_path = resolve_member(
+                &pgen_path,
+                "PGEN index",
+                options.pgi_path.as_deref(),
+                &[CompanionRule::AppendSuffix(".pgi".to_string())],
+                &storage_options,
+            )
+            .await?;
+            let pgi = ObjectAccess::open(&pgi_path, &storage_options).await?;
+            let (records, index_bytes_read, samples, variants) = parse_index(
+                &pgen_path,
+                &source,
+                pgen_size,
+                mode,
+                Some((&pgi_path, &pgi)),
+                options.max_header_bytes,
+                options.max_record_bytes,
+                &variants,
+                identities.len(),
+            )
+            .await?;
+            (
+                Some(pgi_path),
+                records,
+                3,
+                index_bytes_read,
+                samples,
+                variants,
+            )
+        } else {
+            let (records, index_bytes_read, samples, variants) = parse_index(
+                &pgen_path,
+                &source,
+                pgen_size,
+                mode,
+                None,
+                options.max_header_bytes,
+                options.max_record_bytes,
+                &variants,
+                identities.len(),
+            )
+            .await?;
+            (None, records, 3 + index_bytes_read, 0, samples, variants)
+        };
+
+        if header_sample_count != identities.len() {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN sample count {header_sample_count} differs from PSAM row count {}",
+                identities.len()
+            )));
+        }
+        if header_variant_count != variants.len() {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN variant count {header_variant_count} differs from PVAR row count {}",
+                variants.len()
+            )));
+        }
+
+        Ok(Self {
+            pgen_path,
+            pvar_path,
+            psam_path,
+            pgi_path,
+            source,
+            variants: Arc::new(variants),
+            selected_samples,
+            selected_identities: Arc::new(selected_identities),
+            sample_count: identities.len(),
+            records: Arc::new(records),
+            mode,
+            companion_bytes: (pvar_raw.len() + psam_bytes.len()) as u64 + index_companion_bytes,
+            header_bytes,
+        })
+    }
+}
+
+async fn resolve_pvar(
+    pgen_path: &str,
+    options: &PgenReadOptions,
+    storage_options: &ObjectStorageOptions,
+) -> Result<String> {
+    resolve_member(
+        pgen_path,
+        "PVAR",
+        options.pvar_path.as_deref(),
+        &[
+            CompanionRule::ReplaceExtension("pvar".to_string()),
+            CompanionRule::ReplaceExtension("pvar.zst".to_string()),
+        ],
+        storage_options,
+    )
+    .await
+}
+
+async fn resolve_member(
+    pgen_path: &str,
+    role: &str,
+    explicit: Option<&str>,
+    rules: &[CompanionRule],
+    options: &ObjectStorageOptions,
+) -> Result<String> {
+    resolve_companion(pgen_path, role, explicit, rules, true, |candidate| {
+        let options = options.clone();
+        async move { ObjectAccess::exists(&candidate, &options).await }
+    })
+    .await?
+    .ok_or_else(|| DataFusionError::Plan(format!("required {role} companion was not found")))
+}
+
+async fn reject_hybrid_companions(
+    pgen_path: &str,
+    options: &PgenReadOptions,
+    storage_options: &ObjectStorageOptions,
+) -> Result<()> {
+    if options.pvar_path.is_some() || options.psam_path.is_some() {
+        return Ok(());
+    }
+    let pvar = datafusion_bio_format_core::companion::companion_candidates(
+        pgen_path,
+        &[
+            CompanionRule::ReplaceExtension("pvar".to_string()),
+            CompanionRule::ReplaceExtension("pvar.zst".to_string()),
+        ],
+    )?;
+    let psam = datafusion_bio_format_core::companion::companion_candidates(
+        pgen_path,
+        &[CompanionRule::ReplaceExtension("psam".to_string())],
+    )?;
+    let has_pvar = if ObjectAccess::exists(&pvar[0], storage_options).await? {
+        true
+    } else {
+        ObjectAccess::exists(&pvar[1], storage_options).await?
+    };
+    if has_pvar || ObjectAccess::exists(&psam[0], storage_options).await? {
+        return Ok(());
+    }
+    let bim = datafusion_bio_format_core::companion::companion_candidates(
+        pgen_path,
+        &[CompanionRule::ReplaceExtension("bim".to_string())],
+    )?;
+    let fam = datafusion_bio_format_core::companion::companion_candidates(
+        pgen_path,
+        &[CompanionRule::ReplaceExtension("fam".to_string())],
+    )?;
+    if ObjectAccess::exists(&bim[0], storage_options).await?
+        && ObjectAccess::exists(&fam[0], storage_options).await?
+    {
+        return Err(DataFusionError::Plan(
+            "unsupported hybrid PGEN/BIM/FAM fileset; provide standard PVAR/PSAM companions"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn decode_text_companion(path: &str, bytes: &[u8], max_decoded: usize) -> Result<Vec<u8>> {
+    let mut decoded = Vec::new();
+    if bytes.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
+        let decoder = zstd::stream::read::Decoder::new(bytes).map_err(|error| {
+            DataFusionError::Plan(format!(
+                "failed to decompress PVAR {} as zstd: {error}",
+                sanitize_location(path)
+            ))
+        })?;
+        decoder
+            .take((max_decoded as u64).saturating_add(1))
+            .read_to_end(&mut decoded)
+            .map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "failed to decompress PVAR {} as zstd: {error}",
+                    sanitize_location(path)
+                ))
+            })?;
+    } else if bytes.starts_with(&[0x1f, 0x8b]) {
+        MultiGzDecoder::new(bytes)
+            .take((max_decoded as u64).saturating_add(1))
+            .read_to_end(&mut decoded)
+            .map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "failed to decompress PVAR {} as gzip: {error}",
+                    sanitize_location(path)
+                ))
+            })?;
+    } else {
+        decoded.extend_from_slice(bytes);
+    }
+    if decoded.len() > max_decoded {
+        return Err(DataFusionError::Plan(format!(
+            "decompressed PVAR {} exceeds configured limit {max_decoded}",
+            sanitize_location(path)
+        )));
+    }
+    Ok(decoded)
+}
+
+fn parse_pvar(
+    path: &str,
+    bytes: &[u8],
+    coordinates: CoordinateSystem,
+    max_variants: usize,
+) -> Result<Vec<PvarVariant>> {
+    let text = std::str::from_utf8(bytes).map_err(|error| {
+        DataFusionError::Plan(format!(
+            "PVAR {} is not valid UTF-8: {error}",
+            sanitize_location(path)
+        ))
+    })?;
+    let lines: Vec<_> = text.lines().collect();
+    let body_start = lines
+        .iter()
+        .position(|line| !line.starts_with('#'))
+        .unwrap_or(lines.len());
+    let header_index = lines[..body_start]
+        .iter()
+        .rposition(|line| line.starts_with("#CHROM"));
+    let (start_line, columns) = if let Some(index) = header_index {
+        if index + 1 != body_start {
+            return Err(DataFusionError::Plan(format!(
+                "PVAR {} #CHROM line must be the final header line",
+                sanitize_location(path)
+            )));
+        }
+        let columns = lines[index]
+            .trim_start_matches('#')
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        (body_start, columns)
+    } else {
+        if body_start > 0 {
+            return Err(DataFusionError::Plan(format!(
+                "PVAR {} header does not end with #CHROM",
+                sanitize_location(path)
+            )));
+        }
+        let first_width = lines
+            .iter()
+            .find(|line| !line.is_empty())
+            .map(|line| line.split_whitespace().count())
+            .unwrap_or(0);
+        let columns = match first_width {
+            5 => vec!["CHROM", "ID", "POS", "ALT", "REF"],
+            6.. => vec!["CHROM", "ID", "CM", "POS", "ALT", "REF"],
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "headerless PVAR {} must have at least five columns",
+                    sanitize_location(path)
+                )));
+            }
+        }
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        (0, columns)
+    };
+    let column = |name: &str| {
+        columns
+            .iter()
+            .position(|value| value == name)
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "PVAR {} is missing required {name} column",
+                    sanitize_location(path)
+                ))
+            })
+    };
+    let chrom_col = column("CHROM")?;
+    let pos_col = column("POS")?;
+    let id_col = column("ID")?;
+    let ref_col = column("REF")?;
+    let alt_col = column("ALT")?;
+    let required_width = [chrom_col, pos_col, id_col, ref_col, alt_col]
+        .into_iter()
+        .max()
+        .unwrap_or(0)
+        + 1;
+
+    let mut variants = Vec::new();
+    for (line_index, line) in lines.iter().enumerate().skip(start_line) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let fields: Vec<_> = line.split_whitespace().collect();
+        if fields.len() < required_width {
+            return Err(pvar_line_error(
+                path,
+                line_index,
+                format!(
+                    "has {} columns; at least {required_width} required",
+                    fields.len()
+                ),
+            ));
+        }
+        let position = fields[pos_col].parse::<u64>().map_err(|error| {
+            pvar_line_error(path, line_index, format!("has invalid POS: {error}"))
+        })?;
+        let site = coordinates
+            .site(position)
+            .map_err(|error| pvar_line_error(path, line_index, error.to_string()))?;
+        let reference = fields[ref_col];
+        if reference.is_empty() || reference == "." || reference.contains(',') {
+            return Err(pvar_line_error(
+                path,
+                line_index,
+                "has malformed REF allele".to_string(),
+            ));
+        }
+        let alternate = fields[alt_col]
+            .split(',')
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if alternate.is_empty()
+            || alternate
+                .iter()
+                .any(|allele| allele.is_empty() || allele == ".")
+        {
+            return Err(pvar_line_error(
+                path,
+                line_index,
+                "has malformed ALT allele list".to_string(),
+            ));
+        }
+        variants.push(PvarVariant {
+            chrom: fields[chrom_col].to_string(),
+            start: site.start,
+            end: site.end,
+            id: (fields[id_col] != ".").then(|| fields[id_col].to_string()),
+            reference: reference.to_string(),
+            alternate,
+        });
+        if variants.len() > max_variants {
+            return Err(DataFusionError::Plan(format!(
+                "PVAR {} exceeds configured max_variants {max_variants}",
+                sanitize_location(path)
+            )));
+        }
+    }
+    Ok(variants)
+}
+
+fn pvar_line_error(path: &str, line_index: usize, detail: String) -> DataFusionError {
+    DataFusionError::Plan(format!(
+        "PVAR {} line {} {detail}",
+        sanitize_location(path),
+        line_index + 1
+    ))
+}
+
+fn parse_psam(path: &str, bytes: &[u8], max_samples: usize) -> Result<Vec<PsamIdentity>> {
+    let text = std::str::from_utf8(bytes).map_err(|error| {
+        DataFusionError::Plan(format!(
+            "PSAM {} is not valid UTF-8: {error}",
+            sanitize_location(path)
+        ))
+    })?;
+    let lines: Vec<_> = text.lines().collect();
+    let body_start = lines
+        .iter()
+        .position(|line| !line.starts_with('#'))
+        .unwrap_or(lines.len());
+    let header = lines[..body_start]
+        .iter()
+        .rfind(|line| line.starts_with("#FID") || line.starts_with("#IID"));
+    let (columns, start) = if let Some(header) = header {
+        (
+            header
+                .trim_start_matches('#')
+                .split_whitespace()
+                .collect::<Vec<_>>(),
+            body_start,
+        )
+    } else {
+        let first_width = lines
+            .iter()
+            .find(|line| !line.is_empty())
+            .map(|line| line.split_whitespace().count())
+            .unwrap_or(0);
+        if first_width < 5 {
+            return Err(DataFusionError::Plan(format!(
+                "headerless PSAM {} must have at least five columns",
+                sanitize_location(path)
+            )));
+        }
+        (vec!["FID", "IID", "PAT", "MAT", "SEX"], 0)
+    };
+    let iid_col = columns
+        .iter()
+        .position(|value| *value == "IID")
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "PSAM {} is missing required IID column",
+                sanitize_location(path)
+            ))
+        })?;
+    let fid_col = columns.iter().position(|value| *value == "FID");
+    let sid_col = columns.iter().position(|value| *value == "SID");
+    let mut identities = Vec::new();
+    let mut full_ids = HashSet::new();
+    for (line_index, line) in lines.iter().enumerate().skip(start) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let fields: Vec<_> = line.split_whitespace().collect();
+        if fields.len() < columns.len() {
+            return Err(DataFusionError::Plan(format!(
+                "PSAM {} line {} has {} fields; expected at least {}",
+                sanitize_location(path),
+                line_index + 1,
+                fields.len(),
+                columns.len()
+            )));
+        }
+        let iid = fields[iid_col];
+        if iid == "0" || iid.is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "PSAM {} line {} has invalid IID",
+                sanitize_location(path),
+                line_index + 1
+            )));
+        }
+        let identity = PsamIdentity {
+            fid: fid_col
+                .map(|index| fields[index])
+                .unwrap_or("0")
+                .to_string(),
+            iid: iid.to_string(),
+            sid: sid_col
+                .map(|index| fields[index])
+                .unwrap_or("0")
+                .to_string(),
+        };
+        if !full_ids.insert((
+            identity.fid.clone(),
+            identity.iid.clone(),
+            identity.sid.clone(),
+        )) {
+            return Err(DataFusionError::Plan(format!(
+                "PSAM {} line {} repeats a full FID/IID/SID identity",
+                sanitize_location(path),
+                line_index + 1
+            )));
+        }
+        identities.push(identity);
+        if identities.len() > max_samples {
+            return Err(DataFusionError::Plan(format!(
+                "PSAM {} exceeds configured max_samples {max_samples}",
+                sanitize_location(path)
+            )));
+        }
+    }
+    Ok(identities)
+}
+
+fn sample_names(identities: &[PsamIdentity], mode: PsamIdMode) -> Vec<String> {
+    identities
+        .iter()
+        .map(|identity| match mode {
+            PsamIdMode::Iid => identity.iid.clone(),
+            PsamIdMode::FidIid => {
+                format!("{}:{}", escape_id(&identity.fid), escape_id(&identity.iid))
+            }
+            PsamIdMode::FidIidSid => format!(
+                "{}:{}:{}",
+                escape_id(&identity.fid),
+                escape_id(&identity.iid),
+                escape_id(&identity.sid)
+            ),
+        })
+        .collect()
+}
+
+fn escape_id(value: &str) -> String {
+    value.replace('\\', "\\\\").replace(':', "\\:")
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn parse_index(
+    pgen_path: &str,
+    pgen: &ObjectAccess,
+    pgen_size: u64,
+    mode: PgenMode,
+    external: Option<(&str, &ObjectAccess)>,
+    max_header_bytes: usize,
+    max_record_bytes: u64,
+    pvar: &[PvarVariant],
+    psam_sample_count: usize,
+) -> Result<(Vec<RecordInfo>, u64, usize, usize)> {
+    if mode == PgenMode::Plink1 {
+        let bytes_per_variant = psam_sample_count.checked_add(3).ok_or_else(|| {
+            DataFusionError::Plan("PGEN sample count arithmetic overflowed".to_string())
+        })? / 4;
+        let expected = 3_u64
+            .checked_add(
+                u64::try_from(bytes_per_variant)
+                    .ok()
+                    .and_then(|width| width.checked_mul(pvar.len() as u64))
+                    .ok_or_else(|| {
+                        DataFusionError::Plan("PGEN fixed-width length overflowed".to_string())
+                    })?,
+            )
+            .ok_or_else(|| DataFusionError::Plan("PGEN length overflowed".to_string()))?;
+        if bytes_per_variant as u64 > max_record_bytes {
+            return Err(DataFusionError::Plan(format!(
+                "PLINK 1-mode PGEN record width {bytes_per_variant} exceeds configured max_record_bytes {max_record_bytes}"
+            )));
+        }
+        if expected != pgen_size {
+            return Err(DataFusionError::Plan(format!(
+                "PLINK 1-mode PGEN length mismatch: expected {expected}, observed {pgen_size}"
+            )));
+        }
+        let records = (0..pvar.len())
+            .map(|index| RecordInfo {
+                offset: 3 + (index * bytes_per_variant) as u64,
+                length: bytes_per_variant as u32,
+                record_type: 0xff,
+                ld_base: None,
+            })
+            .collect();
+        return Ok((records, 0, psam_sample_count, pvar.len()));
+    }
+
+    let (header_path, header_object, expected_magic) = if let Some((path, object)) = external {
+        let magic = if mode == PgenMode::ExternalIndex {
+            0x30
+        } else {
+            0x31
+        };
+        (path, object, magic)
+    } else {
+        (pgen_path, pgen, mode.byte())
+    };
+    let prefix = header_object.read_range(header_path, 0..12).await?;
+    if prefix[0..2] != [0x6c, 0x1b] || prefix[2] != expected_magic {
+        return Err(DataFusionError::Plan(format!(
+            "{} has invalid PGEN index magic; expected 6c 1b {expected_magic:02x}",
+            sanitize_location(header_path)
+        )));
+    }
+    let variant_count = read_le(&prefix, 3, 4)? as usize;
+    let sample_count = read_le(&prefix, 7, 4)? as usize;
+    if variant_count != pvar.len() {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header variant count {variant_count} differs from PVAR row count {}",
+            pvar.len()
+        )));
+    }
+    if sample_count != psam_sample_count {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header sample count {sample_count} differs from PSAM row count {psam_sample_count}"
+        )));
+    }
+    let control = prefix[11];
+    let type_storage = control & 0x0f;
+    if type_storage > 7 {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header control uses reserved record-index encoding {type_storage} under {PGEN_SPEC_BASELINE}"
+        )));
+    }
+    let allele_width = usize::from((control >> 4) & 0x03);
+    let nonref_mode = control >> 6;
+
+    if matches!(
+        mode,
+        PgenMode::FixedHardcall | PgenMode::FixedDosage | PgenMode::FixedPhasedDosage
+    ) {
+        if control & 0x3f != 0 {
+            return Err(DataFusionError::Plan(format!(
+                "fixed-width PGEN mode 0x{:02x} has invalid header control 0x{control:02x}",
+                mode.byte()
+            )));
+        }
+        let nonref_bytes = if nonref_mode == 3 {
+            variant_count.div_ceil(8)
+        } else {
+            0
+        };
+        let header_len = 12_usize
+            .checked_add(nonref_bytes)
+            .ok_or_else(|| DataFusionError::Plan("PGEN header length overflowed".to_string()))?;
+        if header_len > max_header_bytes {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN header exceeds configured max_header_bytes {max_header_bytes}"
+            )));
+        }
+        let header = header_object
+            .read_range(header_path, 0..header_len as u64)
+            .await?;
+        if nonref_bytes > 0 {
+            validate_padding(&header[12..], variant_count, "provisional-reference flags")?;
+        }
+        let hardcall_bytes = sample_count.div_ceil(4);
+        let record_width = match mode {
+            PgenMode::FixedHardcall => hardcall_bytes,
+            PgenMode::FixedDosage => hardcall_bytes
+                .checked_add(sample_count.checked_mul(2).ok_or_else(|| {
+                    DataFusionError::Plan("PGEN dosage width overflowed".to_string())
+                })?)
+                .ok_or_else(|| DataFusionError::Plan("PGEN record width overflowed".to_string()))?,
+            PgenMode::FixedPhasedDosage => hardcall_bytes
+                .checked_add(sample_count.checked_mul(4).ok_or_else(|| {
+                    DataFusionError::Plan("PGEN phased-dosage width overflowed".to_string())
+                })?)
+                .ok_or_else(|| DataFusionError::Plan("PGEN record width overflowed".to_string()))?,
+            _ => unreachable!(),
+        };
+        let expected_size = (header_len as u64)
+            .checked_add(
+                (record_width as u64)
+                    .checked_mul(variant_count as u64)
+                    .ok_or_else(|| {
+                        DataFusionError::Plan("PGEN expected size overflowed".to_string())
+                    })?,
+            )
+            .ok_or_else(|| DataFusionError::Plan("PGEN expected size overflowed".to_string()))?;
+        if record_width as u64 > max_record_bytes {
+            return Err(DataFusionError::Plan(format!(
+                "fixed-width PGEN record width {record_width} exceeds configured max_record_bytes {max_record_bytes}"
+            )));
+        }
+        if expected_size != pgen_size {
+            return Err(DataFusionError::Plan(format!(
+                "fixed-width PGEN length mismatch: expected {expected_size}, observed {pgen_size}"
+            )));
+        }
+        let record_type = match mode {
+            PgenMode::FixedHardcall => 0x00,
+            PgenMode::FixedDosage => 0x40,
+            PgenMode::FixedPhasedDosage => 0xc0,
+            _ => unreachable!(),
+        };
+        let records = (0..variant_count)
+            .map(|index| RecordInfo {
+                offset: header_len as u64 + (index * record_width) as u64,
+                length: record_width as u32,
+                record_type,
+                ld_base: None,
+            })
+            .collect();
+        return Ok((records, 12 + header_len as u64, sample_count, variant_count));
+    }
+
+    let block_count = variant_count.div_ceil(PGEN_BLOCK_VARIANTS);
+    let offsets_bytes = block_count
+        .checked_mul(8)
+        .ok_or_else(|| DataFusionError::Plan("PGEN block index size overflowed".to_string()))?;
+    let length_width = 1 + usize::from(type_storage & 3);
+    let type_width_is_nibble = type_storage < 4;
+    let mut body_len = 12_usize
+        .checked_add(offsets_bytes)
+        .ok_or_else(|| DataFusionError::Plan("PGEN header size overflowed".to_string()))?;
+    for block in 0..block_count {
+        let count = (variant_count - block * PGEN_BLOCK_VARIANTS).min(PGEN_BLOCK_VARIANTS);
+        let type_bytes = if type_width_is_nibble {
+            count.div_ceil(2)
+        } else {
+            count
+        };
+        body_len = body_len
+            .checked_add(type_bytes)
+            .and_then(|value| value.checked_add(count.checked_mul(length_width)?))
+            .and_then(|value| value.checked_add(count.checked_mul(allele_width)?))
+            .and_then(|value| {
+                value.checked_add(if nonref_mode == 3 {
+                    count.div_ceil(8)
+                } else {
+                    0
+                })
+            })
+            .ok_or_else(|| DataFusionError::Plan("PGEN header size overflowed".to_string()))?;
+    }
+    if body_len > max_header_bytes {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header body {body_len} exceeds configured max_header_bytes {max_header_bytes}"
+        )));
+    }
+    let body = header_object
+        .read_range(header_path, 0..body_len as u64)
+        .await?;
+    let block_offsets = (0..block_count)
+        .map(|index| read_le(&body, 12 + index * 8, 8))
+        .collect::<Result<Vec<_>>>()?;
+    if variant_count > 0 && block_offsets.first().copied().unwrap_or(0) < 3 {
+        return Err(DataFusionError::Plan(
+            "PGEN first variant block starts inside the file magic".to_string(),
+        ));
+    }
+
+    let mut cursor = 12 + offsets_bytes;
+    let mut records = Vec::with_capacity(variant_count);
+    let mut allele_counts = Vec::with_capacity(variant_count);
+    for block in 0..block_count {
+        let block_start_index = block * PGEN_BLOCK_VARIANTS;
+        let count = (variant_count - block_start_index).min(PGEN_BLOCK_VARIANTS);
+        let type_bytes = if type_width_is_nibble {
+            count.div_ceil(2)
+        } else {
+            count
+        };
+        let type_slice = take(&body, &mut cursor, type_bytes, "variant record types")?;
+        if type_width_is_nibble && count % 2 == 1 && type_slice.last().unwrap() & 0xf0 != 0 {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN variant block {block} has nonzero record-type padding"
+            )));
+        }
+        let record_types = (0..count)
+            .map(|index| {
+                if type_width_is_nibble {
+                    (type_slice[index / 2] >> ((index % 2) * 4)) & 0x0f
+                } else {
+                    type_slice[index]
+                }
+            })
+            .collect::<Vec<_>>();
+        let lengths = take(
+            &body,
+            &mut cursor,
+            count * length_width,
+            "variant record lengths",
+        )?;
+        let mut offset = block_offsets[block];
+        for (index, &record_type) in record_types.iter().enumerate() {
+            let length = read_le(lengths, index * length_width, length_width)?;
+            let length = u32::try_from(length)
+                .map_err(|_| DataFusionError::Plan("PGEN record length exceeds u32".to_string()))?;
+            let absolute_index = block_start_index + index;
+            if record_type & 7 == 5 {
+                return Err(DataFusionError::Plan(format!(
+                    "PGEN variant {absolute_index} uses reserved main-track representation 5 under {PGEN_SPEC_BASELINE}"
+                )));
+            }
+            if length == 0 {
+                return Err(DataFusionError::Plan(format!(
+                    "PGEN variant {absolute_index} has an empty record"
+                )));
+            }
+            if u64::from(length) > max_record_bytes {
+                return Err(DataFusionError::Plan(format!(
+                    "PGEN variant {absolute_index} record length {length} exceeds configured max_record_bytes {max_record_bytes}"
+                )));
+            }
+            let ld_base = if record_type & 6 == 2 {
+                records[block_start_index..]
+                    .iter()
+                    .rposition(|record: &RecordInfo| record.record_type & 6 != 2)
+                    .map(|relative| block_start_index + relative)
+                    .ok_or_else(|| {
+                        DataFusionError::Plan(format!(
+                            "PGEN LD-compressed variant {absolute_index} has no base in its variant block"
+                        ))
+                    })?
+                    .into()
+            } else {
+                None
+            };
+            records.push(RecordInfo {
+                offset,
+                length,
+                record_type,
+                ld_base,
+            });
+            offset = offset.checked_add(u64::from(length)).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "PGEN record offset overflow at variant {absolute_index}"
+                ))
+            })?;
+        }
+        if block + 1 < block_count && offset != block_offsets[block + 1] {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN variant block {block} lengths end at {offset}, but next block starts at {}",
+                block_offsets[block + 1]
+            )));
+        }
+        if allele_width > 0 {
+            let raw = take(&body, &mut cursor, count * allele_width, "allele counts")?;
+            for index in 0..count {
+                allele_counts.push(read_le(raw, index * allele_width, allele_width)? as usize);
+            }
+        }
+        if nonref_mode == 3 {
+            let flags = take(
+                &body,
+                &mut cursor,
+                count.div_ceil(8),
+                "provisional-reference flags",
+            )?;
+            validate_padding(flags, count, "provisional-reference flags")?;
+        }
+    }
+    if cursor != body.len() {
+        return Err(DataFusionError::Plan(
+            "PGEN header body parser did not consume its declared extent".to_string(),
+        ));
+    }
+    for (index, count) in allele_counts.iter().copied().enumerate() {
+        if count != pvar.get(index).map(PvarVariant::allele_count).unwrap_or(0) {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN allele count {count} at variant {index} differs from PVAR allele count {}",
+                pvar.get(index).map(PvarVariant::allele_count).unwrap_or(0)
+            )));
+        }
+    }
+    for (index, record) in records.iter().enumerate() {
+        if record.end() > pgen_size {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN record {index} range {}..{} exceeds object length {pgen_size}",
+                record.offset,
+                record.end()
+            )));
+        }
+    }
+
+    let mut header_bytes = body_len as u64;
+    let mut footer_offset = None;
+    if mode.has_extensions() {
+        let extension_end = if external.is_some() {
+            header_object.size(header_path).await?
+        } else {
+            block_offsets.first().copied().unwrap_or(body_len as u64)
+        };
+        if extension_end < body_len as u64 {
+            return Err(DataFusionError::Plan(
+                "PGEN header extensions overlap the fixed header body".to_string(),
+            ));
+        }
+        let extension_len = usize::try_from(extension_end - body_len as u64).map_err(|_| {
+            DataFusionError::Plan("PGEN extension region does not fit usize".to_string())
+        })?;
+        if body_len.saturating_add(extension_len) > max_header_bytes {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN header with extensions exceeds configured max_header_bytes {max_header_bytes}"
+            )));
+        }
+        let extensions = header_object
+            .read_range(header_path, body_len as u64..extension_end)
+            .await?;
+        footer_offset = validate_extensions(&extensions, pgen_size)?;
+        header_bytes = extension_end;
+    } else if external.is_some() {
+        let observed = header_object.size(header_path).await?;
+        if observed != body_len as u64 {
+            return Err(DataFusionError::Plan(format!(
+                "PGI length {observed} does not equal expected header length {body_len}"
+            )));
+        }
+    } else if variant_count > 0 {
+        if block_offsets[0] != body_len as u64 {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN first block offset {} does not equal header end {body_len}",
+                block_offsets[0]
+            )));
+        }
+    } else if pgen_size != body_len as u64 {
+        return Err(DataFusionError::Plan(format!(
+            "empty PGEN length {pgen_size} does not equal header length {body_len}"
+        )));
+    }
+    let data_end = records
+        .last()
+        .map(RecordInfo::end)
+        .unwrap_or_else(|| if external.is_some() { 3 } else { header_bytes });
+    let expected_data_end = footer_offset.unwrap_or(pgen_size);
+    if data_end != expected_data_end {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN variant data ends at {data_end}, but {} begins at {expected_data_end}",
+            if footer_offset.is_some() {
+                "the declared footer"
+            } else {
+                "the object ends"
+            }
+        )));
+    }
+    Ok((records, 12 + header_bytes, sample_count, variant_count))
+}
+
+fn validate_extensions(bytes: &[u8], pgen_size: u64) -> Result<Option<u64>> {
+    let mut cursor = 0;
+    let header_flags = read_flag_varint(bytes, &mut cursor)?;
+    let footer_flags = read_flag_varint(bytes, &mut cursor)?;
+    let footer_offset = if footer_flags > 0 {
+        let footer_offset = read_le(bytes, cursor, 8)?;
+        cursor += 8;
+        if footer_offset > pgen_size {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN footer extension offset {footer_offset} exceeds object length {pgen_size}"
+            )));
+        }
+        Some(footer_offset)
+    } else {
+        None
+    };
+    let mut body_bytes = 0_usize;
+    for _ in 0..header_flags {
+        let length = read_varint(bytes, &mut cursor)?;
+        body_bytes = body_bytes
+            .checked_add(usize::try_from(length).map_err(|_| {
+                DataFusionError::Plan("PGEN header extension length does not fit usize".to_string())
+            })?)
+            .ok_or_else(|| DataFusionError::Plan("PGEN extension length overflowed".to_string()))?;
+    }
+    cursor = cursor
+        .checked_add(body_bytes)
+        .ok_or_else(|| DataFusionError::Plan("PGEN extension cursor overflowed".to_string()))?;
+    if cursor != bytes.len() {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header extension region has {} unaccounted bytes",
+            bytes.len().saturating_sub(cursor)
+        )));
+    }
+    Ok(footer_offset)
+}
+
+fn read_flag_varint(bytes: &[u8], cursor: &mut usize) -> Result<usize> {
+    let mut set_bits = 0_usize;
+    for index in 0..37 {
+        let byte = *bytes.get(*cursor).ok_or_else(|| {
+            DataFusionError::Plan("truncated PGEN extension flag varint".to_string())
+        })?;
+        *cursor += 1;
+        set_bits = set_bits
+            .checked_add((byte & 0x7f).count_ones() as usize)
+            .ok_or_else(|| DataFusionError::Plan("PGEN flag count overflowed".to_string()))?;
+        if byte & 0x80 == 0 {
+            if index == 36 && byte > 0x0f {
+                return Err(DataFusionError::Plan(
+                    "PGEN extension flags exceed 256 bits".to_string(),
+                ));
+            }
+            return Ok(set_bits);
+        }
+    }
+    Err(DataFusionError::Plan(
+        "PGEN extension flags exceed 256 bits".to_string(),
+    ))
+}
+
+pub(crate) fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64> {
+    let mut value = 0_u64;
+    for shift in (0..=63).step_by(7) {
+        let byte = *bytes.get(*cursor).ok_or_else(|| {
+            DataFusionError::Execution("truncated PGEN base-128 varint".to_string())
+        })?;
+        *cursor += 1;
+        if shift == 63 && byte > 1 {
+            return Err(DataFusionError::Execution(
+                "PGEN base-128 varint overflows u64".to_string(),
+            ));
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(DataFusionError::Execution(
+        "PGEN base-128 varint exceeds ten bytes".to_string(),
+    ))
+}
+
+pub(crate) fn read_le(bytes: &[u8], offset: usize, width: usize) -> Result<u64> {
+    if width == 0 || width > 8 || offset.saturating_add(width) > bytes.len() {
+        return Err(DataFusionError::Plan(format!(
+            "truncated PGEN little-endian integer at byte {offset} with width {width}"
+        )));
+    }
+    let mut value = 0_u64;
+    for (shift, byte) in bytes[offset..offset + width].iter().enumerate() {
+        value |= u64::from(*byte) << (shift * 8);
+    }
+    Ok(value)
+}
+
+fn take<'a>(bytes: &'a [u8], cursor: &mut usize, length: usize, context: &str) -> Result<&'a [u8]> {
+    let end = cursor
+        .checked_add(length)
+        .ok_or_else(|| DataFusionError::Plan(format!("{context} length overflowed")))?;
+    let result = bytes.get(*cursor..end).ok_or_else(|| {
+        DataFusionError::Plan(format!("truncated PGEN {context} at byte {cursor}"))
+    })?;
+    *cursor = end;
+    Ok(result)
+}
+
+pub(crate) fn validate_padding(bytes: &[u8], value_count: usize, context: &str) -> Result<()> {
+    let remainder = value_count % 8;
+    if remainder > 0 && bytes.last().is_some_and(|byte| byte >> remainder != 0) {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN {context} has nonzero padding bits"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_varint(mut value: u64) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            bytes.push(byte);
+            if value == 0 {
+                return bytes;
+            }
+        }
+    }
+
+    #[test]
+    fn decodes_varint_boundaries() {
+        for expected in [0, 1, 0x7f, 0x80, 0x3fff, 0x4000, u32::MAX as u64, u64::MAX] {
+            let encoded = encode_varint(expected);
+            let mut cursor = 0;
+            assert_eq!(read_varint(&encoded, &mut cursor).unwrap(), expected);
+            assert_eq!(cursor, encoded.len());
+        }
+    }
+
+    #[test]
+    fn rejects_overlong_and_truncated_varints() {
+        let mut cursor = 0;
+        assert!(read_varint(&[0x80; 10], &mut cursor).is_err());
+        let mut cursor = 0;
+        assert!(read_varint(&[0x80], &mut cursor).is_err());
+        let mut cursor = 0;
+        assert!(read_varint(&[0xff; 10], &mut cursor).is_err());
+    }
+
+    #[test]
+    fn escapes_composite_sample_ids_without_collisions() {
+        let identities = vec![PsamIdentity {
+            fid: "a:b".to_string(),
+            iid: r"c\d".to_string(),
+            sid: "0".to_string(),
+        }];
+        assert_eq!(
+            sample_names(&identities, PsamIdMode::FidIid),
+            vec![r"a\:b:c\\d"]
+        );
+    }
+
+    #[test]
+    fn parses_five_column_headerless_pvar_and_enforces_row_limit() {
+        let bytes = b"1 v1 10 C A\n2 v2 20 G T\n";
+        let variants =
+            parse_pvar("cohort.pvar", bytes, CoordinateSystem::ZeroBasedHalfOpen, 2).unwrap();
+        assert_eq!(variants[0].start, 9);
+        assert_eq!(variants[0].reference, "A");
+        assert_eq!(variants[0].alternate, vec!["C"]);
+        let error = parse_pvar("cohort.pvar", bytes, CoordinateSystem::ZeroBasedHalfOpen, 1)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("max_variants 1"), "{error}");
+    }
+}

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::io::Read;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use datafusion::common::{DataFusionError, Result};
 use datafusion_bio_format_core::companion::{CompanionRule, resolve_companion, sanitize_location};
 use datafusion_bio_format_core::genotype::{CoordinateSystem, SampleSelection, resolve_samples};
@@ -98,12 +99,156 @@ pub(crate) struct PsamIdentity {
     pub(crate) sid: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct RecordInfo {
     pub(crate) offset: u64,
     pub(crate) length: u32,
     pub(crate) record_type: u8,
     pub(crate) ld_base: Option<usize>,
+}
+
+#[derive(Debug)]
+pub(crate) enum RecordIndex {
+    Fixed {
+        count: usize,
+        first_offset: u64,
+        record_width: u32,
+        record_type: u8,
+    },
+    Variable(VariableRecordIndex),
+    #[cfg(test)]
+    Explicit(Box<[RecordInfo]>),
+}
+
+#[derive(Debug)]
+pub(crate) struct VariableRecordIndex {
+    header: Bytes,
+    blocks: Box<[VariableRecordBlock]>,
+    relative_offsets: Box<[u8]>,
+    ld_base_deltas: Box<[u16]>,
+    variant_count: usize,
+    length_width: usize,
+    type_width_is_nibble: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct VariableRecordBlock {
+    first_offset: u64,
+    type_offset: usize,
+    length_offset: usize,
+    relative_offset_start: usize,
+    relative_offset_width: usize,
+    count: usize,
+}
+
+impl RecordIndex {
+    pub(crate) fn record(&self, index: usize) -> Result<RecordInfo> {
+        match self {
+            Self::Fixed {
+                count,
+                first_offset,
+                record_width,
+                record_type,
+            } => {
+                if index >= *count {
+                    return Err(DataFusionError::Plan(format!(
+                        "PGEN record index {index} is out of bounds for {count} variants"
+                    )));
+                }
+                let offset = first_offset
+                    .checked_add(
+                        (index as u64)
+                            .checked_mul(u64::from(*record_width))
+                            .ok_or_else(|| {
+                                DataFusionError::Plan("PGEN record offset overflowed".to_string())
+                            })?,
+                    )
+                    .ok_or_else(|| {
+                        DataFusionError::Plan("PGEN record offset overflowed".to_string())
+                    })?;
+                Ok(RecordInfo {
+                    offset,
+                    length: *record_width,
+                    record_type: *record_type,
+                    ld_base: None,
+                })
+            }
+            Self::Variable(index_data) => index_data.record(index),
+            #[cfg(test)]
+            Self::Explicit(records) => records.get(index).copied().ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "PGEN record index {index} is out of bounds for {} variants",
+                    records.len()
+                ))
+            }),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn explicit(records: Vec<RecordInfo>) -> Self {
+        Self::Explicit(records.into_boxed_slice())
+    }
+}
+
+impl VariableRecordIndex {
+    fn record(&self, index: usize) -> Result<RecordInfo> {
+        if index >= self.variant_count {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN record index {index} is out of bounds for {} variants",
+                self.variant_count
+            )));
+        }
+        let block_index = index / PGEN_BLOCK_VARIANTS;
+        let block = self.blocks.get(block_index).ok_or_else(|| {
+            DataFusionError::Plan(format!("PGEN record {index} has no index block"))
+        })?;
+        let within_block = index % PGEN_BLOCK_VARIANTS;
+        if within_block >= block.count {
+            return Err(DataFusionError::Plan(format!(
+                "PGEN record {index} exceeds index block {block_index}"
+            )));
+        }
+        let type_byte = *self
+            .header
+            .get(block.type_offset + within_block / if self.type_width_is_nibble { 2 } else { 1 })
+            .ok_or_else(|| DataFusionError::Plan("truncated PGEN record type index".to_string()))?;
+        let record_type = if self.type_width_is_nibble {
+            (type_byte >> ((within_block % 2) * 4)) & 0x0f
+        } else {
+            type_byte
+        };
+        let length = u32::try_from(read_le(
+            &self.header,
+            block.length_offset + within_block * self.length_width,
+            self.length_width,
+        )?)
+        .map_err(|_| DataFusionError::Plan("PGEN record length exceeds u32".to_string()))?;
+        let relative_offset = read_le(
+            &self.relative_offsets,
+            block.relative_offset_start + within_block * block.relative_offset_width,
+            block.relative_offset_width,
+        )?;
+        let offset = block
+            .first_offset
+            .checked_add(relative_offset)
+            .ok_or_else(|| DataFusionError::Plan("PGEN record offset overflowed".to_string()))?;
+        let ld_delta = usize::from(*self.ld_base_deltas.get(index).ok_or_else(|| {
+            DataFusionError::Plan(format!("PGEN record {index} has no LD-base entry"))
+        })?);
+        let ld_base = if ld_delta == 0 {
+            None
+        } else {
+            Some(index.checked_sub(ld_delta).ok_or_else(|| {
+                DataFusionError::Plan(format!("PGEN record {index} has an invalid LD-base delta"))
+            })?)
+        };
+        Ok(RecordInfo {
+            offset,
+            length,
+            record_type,
+            ld_base,
+        })
+    }
 }
 
 impl RecordInfo {
@@ -123,7 +268,7 @@ pub(crate) struct PgenFileset {
     pub(crate) selected_samples: SampleSelection,
     pub(crate) selected_identities: Arc<Vec<PsamIdentity>>,
     pub(crate) sample_count: usize,
-    pub(crate) records: Arc<Vec<RecordInfo>>,
+    pub(crate) records: Arc<RecordIndex>,
     pub(crate) mode: PgenMode,
     pub(crate) companion_bytes: u64,
     pub(crate) header_bytes: u64,
@@ -703,7 +848,7 @@ async fn parse_index(
     max_record_bytes: u64,
     pvar: &[PvarVariant],
     psam_sample_count: usize,
-) -> Result<(Vec<RecordInfo>, u64, usize, usize)> {
+) -> Result<(RecordIndex, u64, usize, usize)> {
     if mode.is_biallelic_only()
         && let Some((index, count)) = pvar
             .iter()
@@ -740,15 +885,20 @@ async fn parse_index(
                 "PLINK 1-mode PGEN length mismatch: expected {expected}, observed {pgen_size}"
             )));
         }
-        let records = (0..pvar.len())
-            .map(|index| RecordInfo {
-                offset: 3 + (index * bytes_per_variant) as u64,
-                length: bytes_per_variant as u32,
+        let record_width = u32::try_from(bytes_per_variant).map_err(|_| {
+            DataFusionError::Plan("PLINK 1-mode PGEN record width exceeds u32".to_string())
+        })?;
+        return Ok((
+            RecordIndex::Fixed {
+                count: pvar.len(),
+                first_offset: 3,
+                record_width,
                 record_type: 0xff,
-                ld_base: None,
-            })
-            .collect();
-        return Ok((records, 0, psam_sample_count, pvar.len()));
+            },
+            0,
+            psam_sample_count,
+            pvar.len(),
+        ));
     }
 
     let (header_path, header_object, expected_magic) = if let Some((path, object)) = external {
@@ -860,15 +1010,20 @@ async fn parse_index(
             PgenMode::FixedPhasedDosage => 0xc0,
             _ => unreachable!(),
         };
-        let records = (0..variant_count)
-            .map(|index| RecordInfo {
-                offset: header_len as u64 + (index * record_width) as u64,
-                length: record_width as u32,
+        let record_width = u32::try_from(record_width).map_err(|_| {
+            DataFusionError::Plan("fixed-width PGEN record width exceeds u32".to_string())
+        })?;
+        return Ok((
+            RecordIndex::Fixed {
+                count: variant_count,
+                first_offset: header_len as u64,
+                record_width,
                 record_type,
-                ld_base: None,
-            })
-            .collect();
-        return Ok((records, 12 + header_len as u64, sample_count, variant_count));
+            },
+            12 + header_len as u64,
+            sample_count,
+            variant_count,
+        ));
     }
 
     let block_count = variant_count.div_ceil(PGEN_BLOCK_VARIANTS);
@@ -918,8 +1073,10 @@ async fn parse_index(
     }
 
     let mut cursor = 12 + offsets_bytes;
-    let mut records = Vec::with_capacity(variant_count);
-    let mut allele_counts = Vec::with_capacity(variant_count);
+    let mut blocks = Vec::with_capacity(block_count);
+    let mut relative_offsets = Vec::new();
+    let mut ld_base_deltas = Vec::with_capacity(variant_count);
+    let mut record_data_end = None;
     for block in 0..block_count {
         let block_start_index = block * PGEN_BLOCK_VARIANTS;
         let count = (variant_count - block_start_index).min(PGEN_BLOCK_VARIANTS);
@@ -928,21 +1085,14 @@ async fn parse_index(
         } else {
             count
         };
+        let type_offset = cursor;
         let type_slice = take(&body, &mut cursor, type_bytes, "variant record types")?;
         if type_width_is_nibble && count % 2 == 1 && type_slice.last().unwrap() & 0xf0 != 0 {
             return Err(DataFusionError::Plan(format!(
                 "PGEN variant block {block} has nonzero record-type padding"
             )));
         }
-        let record_types = (0..count)
-            .map(|index| {
-                if type_width_is_nibble {
-                    (type_slice[index / 2] >> ((index % 2) * 4)) & 0x0f
-                } else {
-                    type_slice[index]
-                }
-            })
-            .collect::<Vec<_>>();
+        let length_offset = cursor;
         let lengths = take(
             &body,
             &mut cursor,
@@ -950,7 +1100,14 @@ async fn parse_index(
             "variant record lengths",
         )?;
         let mut offset = block_offsets[block];
-        for (index, &record_type) in record_types.iter().enumerate() {
+        let mut last_non_ld = None;
+        let mut block_relative_offsets = Vec::with_capacity(count);
+        for index in 0..count {
+            let record_type = if type_width_is_nibble {
+                (type_slice[index / 2] >> ((index % 2) * 4)) & 0x0f
+            } else {
+                type_slice[index]
+            };
             let length = read_le(lengths, index * length_width, length_width)?;
             let length = u32::try_from(length)
                 .map_err(|_| DataFusionError::Plan("PGEN record length exceeds u32".to_string()))?;
@@ -970,31 +1127,35 @@ async fn parse_index(
                     "PGEN variant {absolute_index} record length {length} exceeds configured max_record_bytes {max_record_bytes}"
                 )));
             }
-            let ld_base = if record_type & 6 == 2 {
-                records[block_start_index..]
-                    .iter()
-                    .rposition(|record: &RecordInfo| record.record_type & 6 != 2)
-                    .map(|relative| block_start_index + relative)
-                    .ok_or_else(|| {
-                        DataFusionError::Plan(format!(
-                            "PGEN LD-compressed variant {absolute_index} has no base in its variant block"
-                        ))
-                    })?
-                    .into()
+            block_relative_offsets.push(offset.checked_sub(block_offsets[block]).ok_or_else(
+                || DataFusionError::Plan("PGEN block-relative offset underflowed".to_string()),
+            )?);
+            let ld_delta = if record_type & 6 == 2 {
+                let base = last_non_ld.ok_or_else(|| {
+                    DataFusionError::Plan(format!(
+                        "PGEN LD-compressed variant {absolute_index} has no base in its variant block"
+                    ))
+                })?;
+                u16::try_from(index - base).map_err(|_| {
+                    DataFusionError::Plan(format!(
+                        "PGEN LD-base distance overflow at variant {absolute_index}"
+                    ))
+                })?
             } else {
-                None
+                last_non_ld = Some(index);
+                0
             };
-            records.push(RecordInfo {
-                offset,
-                length,
-                record_type,
-                ld_base,
-            });
+            ld_base_deltas.push(ld_delta);
             offset = offset.checked_add(u64::from(length)).ok_or_else(|| {
                 DataFusionError::Plan(format!(
                     "PGEN record offset overflow at variant {absolute_index}"
                 ))
             })?;
+            if offset > pgen_size {
+                return Err(DataFusionError::Plan(format!(
+                    "PGEN record {absolute_index} ends at {offset}, exceeding object length {pgen_size}"
+                )));
+            }
         }
         if block + 1 < block_count && offset != block_offsets[block + 1] {
             return Err(DataFusionError::Plan(format!(
@@ -1002,6 +1163,24 @@ async fn parse_index(
                 block_offsets[block + 1]
             )));
         }
+        let max_relative_offset = block_relative_offsets.last().copied().unwrap_or(0);
+        let relative_offset_width = ((u64::BITS - max_relative_offset.leading_zeros()) as usize)
+            .div_ceil(8)
+            .max(1);
+        let relative_offset_start = relative_offsets.len();
+        for relative_offset in block_relative_offsets {
+            relative_offsets
+                .extend_from_slice(&relative_offset.to_le_bytes()[..relative_offset_width]);
+        }
+        blocks.push(VariableRecordBlock {
+            first_offset: block_offsets[block],
+            type_offset,
+            length_offset,
+            relative_offset_start,
+            relative_offset_width,
+            count,
+        });
+        record_data_end = Some(offset);
         // In variable-width modes, zero means counts are supplied by the
         // accompanying PVAR; it does not imply that every row is biallelic.
         if allele_width > 0 {
@@ -1010,7 +1189,17 @@ async fn parse_index(
                 // The PGEN header stores total allele count verbatim. The
                 // pinned pgenlib reader compares this raw value directly with
                 // the accompanying PVAR allele-index offset delta.
-                allele_counts.push(read_le(raw, index * allele_width, allele_width)? as usize);
+                let allele_count = read_le(raw, index * allele_width, allele_width)? as usize;
+                let absolute_index = block_start_index + index;
+                let pvar_allele_count = pvar
+                    .get(absolute_index)
+                    .map(PvarVariant::allele_count)
+                    .unwrap_or(0);
+                if allele_count != pvar_allele_count {
+                    return Err(DataFusionError::Plan(format!(
+                        "PGEN allele count {allele_count} at variant {absolute_index} differs from PVAR allele count {pvar_allele_count}"
+                    )));
+                }
             }
         }
         if nonref_mode == 3 {
@@ -1028,24 +1217,6 @@ async fn parse_index(
             "PGEN header body parser did not consume its declared extent".to_string(),
         ));
     }
-    for (index, count) in allele_counts.iter().copied().enumerate() {
-        if count != pvar.get(index).map(PvarVariant::allele_count).unwrap_or(0) {
-            return Err(DataFusionError::Plan(format!(
-                "PGEN allele count {count} at variant {index} differs from PVAR allele count {}",
-                pvar.get(index).map(PvarVariant::allele_count).unwrap_or(0)
-            )));
-        }
-    }
-    for (index, record) in records.iter().enumerate() {
-        if record.end() > pgen_size {
-            return Err(DataFusionError::Plan(format!(
-                "PGEN record {index} range {}..{} exceeds object length {pgen_size}",
-                record.offset,
-                record.end()
-            )));
-        }
-    }
-
     let mut header_end = body_len as u64;
     let mut extension_bytes_read = 0_u64;
     let mut footer_offset = None;
@@ -1113,10 +1284,8 @@ async fn parse_index(
             "empty PGEN length {pgen_size} does not equal header length {body_len}"
         )));
     }
-    let data_end = records
-        .last()
-        .map(RecordInfo::end)
-        .unwrap_or_else(|| if external.is_some() { 3 } else { header_end });
+    let data_end =
+        record_data_end.unwrap_or_else(|| if external.is_some() { 3 } else { header_end });
     let expected_data_end = footer_offset.unwrap_or(pgen_size);
     if data_end != expected_data_end {
         return Err(DataFusionError::Plan(format!(
@@ -1129,7 +1298,15 @@ async fn parse_index(
         )));
     }
     Ok((
-        records,
+        RecordIndex::Variable(VariableRecordIndex {
+            header: body,
+            blocks: blocks.into_boxed_slice(),
+            relative_offsets: relative_offsets.into_boxed_slice(),
+            ld_base_deltas: ld_base_deltas.into_boxed_slice(),
+            variant_count,
+            length_width,
+            type_width_is_nibble,
+        }),
         12 + body_len as u64 + extension_bytes_read,
         sample_count,
         variant_count,
@@ -1428,6 +1605,54 @@ mod tests {
         assert!(read_varint(&[0x80], &mut cursor).is_err());
         let mut cursor = 0;
         assert!(read_varint(&[0xff; 10], &mut cursor).is_err());
+    }
+
+    #[test]
+    fn decodes_record_descriptors_from_compact_indexes() {
+        let mut header = vec![0x20, 0x00];
+        for length in [300_u16, 400, 500] {
+            header.extend(length.to_le_bytes());
+        }
+        let mut packed_offsets = Vec::new();
+        for offset in [0_u16, 300, 700] {
+            packed_offsets.extend(offset.to_le_bytes());
+        }
+        let index = RecordIndex::Variable(VariableRecordIndex {
+            header: Bytes::from(header),
+            blocks: vec![VariableRecordBlock {
+                first_offset: 1_000,
+                type_offset: 0,
+                length_offset: 2,
+                relative_offset_start: 0,
+                relative_offset_width: 2,
+                count: 3,
+            }]
+            .into_boxed_slice(),
+            relative_offsets: packed_offsets.into_boxed_slice(),
+            ld_base_deltas: vec![0, 1, 0].into_boxed_slice(),
+            variant_count: 3,
+            length_width: 2,
+            type_width_is_nibble: true,
+        });
+        assert_eq!(index.record(0).unwrap().offset, 1_000);
+        let ld = index.record(1).unwrap();
+        assert_eq!(
+            (ld.offset, ld.length, ld.record_type, ld.ld_base),
+            (1_300, 400, 2, Some(0))
+        );
+        assert_eq!(index.record(2).unwrap().offset, 1_700);
+
+        let fixed = RecordIndex::Fixed {
+            count: 3,
+            first_offset: 12,
+            record_width: 5,
+            record_type: 0x40,
+        };
+        let second = fixed.record(1).unwrap();
+        assert_eq!(
+            (second.offset, second.length, second.record_type),
+            (17, 5, 0x40)
+        );
     }
 
     #[test]

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -285,7 +285,7 @@ impl PgenFileset {
             sample_count: identities.len(),
             records: Arc::new(records),
             mode,
-            companion_bytes: (pvar_raw.len() + psam_bytes.len()) as u64 + index_companion_bytes,
+            companion_bytes: (pvar_raw.len() + psam_raw.len()) as u64 + index_companion_bytes,
             header_bytes,
         })
     }
@@ -1049,11 +1049,13 @@ async fn parse_index(
     let mut header_bytes = body_len as u64;
     let mut footer_offset = None;
     if mode.has_extensions() {
-        let extension_end = if external.is_some() {
-            header_object.size(header_path).await?
+        let known_extension_end = if external.is_some() {
+            Some(header_object.size(header_path).await?)
         } else {
-            block_offsets.first().copied().unwrap_or(body_len as u64)
+            block_offsets.first().copied()
         };
+        let extension_end = known_extension_end
+            .unwrap_or_else(|| pgen_size.min(u64::try_from(max_header_bytes).unwrap_or(u64::MAX)));
         if extension_end < body_len as u64 {
             return Err(DataFusionError::Plan(
                 "PGEN header extensions overlap the fixed header body".to_string(),
@@ -1070,8 +1072,20 @@ async fn parse_index(
         let extensions = header_object
             .read_range(header_path, body_len as u64..extension_end)
             .await?;
-        footer_offset = validate_extensions(&extensions, pgen_size)?;
-        header_bytes = extension_end;
+        if known_extension_end.is_some() {
+            footer_offset = validate_extensions(&extensions, pgen_size)?;
+            header_bytes = extension_end;
+        } else {
+            let (parsed_footer_offset, parsed_len) = parse_extensions(&extensions, pgen_size)?;
+            footer_offset = parsed_footer_offset;
+            header_bytes = (body_len as u64)
+                .checked_add(u64::try_from(parsed_len).map_err(|_| {
+                    DataFusionError::Plan("PGEN extension length does not fit u64".to_string())
+                })?)
+                .ok_or_else(|| {
+                    DataFusionError::Plan("PGEN extension end overflowed".to_string())
+                })?;
+        }
     } else if external.is_some() {
         let observed = header_object.size(header_path).await?;
         if observed != body_len as u64 {
@@ -1110,6 +1124,17 @@ async fn parse_index(
 }
 
 fn validate_extensions(bytes: &[u8], pgen_size: u64) -> Result<Option<u64>> {
+    let (footer_offset, consumed) = parse_extensions(bytes, pgen_size)?;
+    if consumed != bytes.len() {
+        return Err(DataFusionError::Plan(format!(
+            "PGEN header extension region has {} unaccounted bytes",
+            bytes.len() - consumed
+        )));
+    }
+    Ok(footer_offset)
+}
+
+fn parse_extensions(bytes: &[u8], pgen_size: u64) -> Result<(Option<u64>, usize)> {
     let mut cursor = 0;
     let header_flags = read_flag_varint(bytes, &mut cursor)?;
     let footer_flags = read_flag_varint(bytes, &mut cursor)?;
@@ -1137,13 +1162,12 @@ fn validate_extensions(bytes: &[u8], pgen_size: u64) -> Result<Option<u64>> {
     cursor = cursor
         .checked_add(body_bytes)
         .ok_or_else(|| DataFusionError::Plan("PGEN extension cursor overflowed".to_string()))?;
-    if cursor != bytes.len() {
-        return Err(DataFusionError::Plan(format!(
-            "PGEN header extension region has {} unaccounted bytes",
-            bytes.len().saturating_sub(cursor)
-        )));
+    if cursor > bytes.len() {
+        return Err(DataFusionError::Plan(
+            "truncated PGEN header extension body".to_string(),
+        ));
     }
-    Ok(footer_offset)
+    Ok((footer_offset, cursor))
 }
 
 fn read_flag_varint(bytes: &[u8], cursor: &mut usize) -> Result<usize> {

--- a/datafusion/bio-format-pgen/src/filter.rs
+++ b/datafusion/bio-format-pgen/src/filter.rs
@@ -24,6 +24,7 @@ pub(crate) fn supports_exact_filter(expr: &Expr) -> bool {
 }
 
 pub(crate) fn evaluate_exact_filter(variant: &PvarVariant, expr: &Expr) -> bool {
+    debug_assert!(supports_exact_filter(expr));
     match expr {
         Expr::BinaryExpr(binary) if binary.op == Operator::And => {
             evaluate_exact_filter(variant, &binary.left)

--- a/datafusion/bio-format-pgen/src/filter.rs
+++ b/datafusion/bio-format-pgen/src/filter.rs
@@ -1,0 +1,249 @@
+use datafusion::common::ScalarValue;
+use datafusion::logical_expr::{Between, Expr, Operator, expr::InList};
+
+use crate::fileset::PvarVariant;
+
+pub(crate) fn supports_exact_filter(expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            supports_exact_filter(&binary.left) && supports_exact_filter(&binary.right)
+        }
+        Expr::BinaryExpr(binary) => {
+            let Expr::Column(column) = &*binary.left else {
+                return false;
+            };
+            let Expr::Literal(literal, _) = &*binary.right else {
+                return false;
+            };
+            supports_comparison(&column.name, literal, &binary.op)
+        }
+        Expr::Between(between) => supports_between(between),
+        Expr::InList(in_list) => supports_in_list(in_list),
+        _ => false,
+    }
+}
+
+pub(crate) fn evaluate_exact_filter(variant: &PvarVariant, expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            evaluate_exact_filter(variant, &binary.left)
+                && evaluate_exact_filter(variant, &binary.right)
+        }
+        Expr::BinaryExpr(binary) => {
+            let (Expr::Column(column), Expr::Literal(literal, _)) = (&*binary.left, &*binary.right)
+            else {
+                return true;
+            };
+            evaluate_comparison(variant, &column.name, literal, &binary.op)
+        }
+        Expr::Between(between) => evaluate_between(variant, between),
+        Expr::InList(in_list) => evaluate_in_list(variant, in_list),
+        _ => true,
+    }
+}
+
+fn supports_comparison(name: &str, literal: &ScalarValue, operator: &Operator) -> bool {
+    match name {
+        "chrom" | "id" => is_string(literal) && matches!(operator, Operator::Eq | Operator::NotEq),
+        "start" | "end" => {
+            is_integer(literal)
+                && matches!(
+                    operator,
+                    Operator::Eq
+                        | Operator::NotEq
+                        | Operator::Lt
+                        | Operator::LtEq
+                        | Operator::Gt
+                        | Operator::GtEq
+                )
+        }
+        _ => false,
+    }
+}
+
+fn supports_between(between: &Between) -> bool {
+    let Expr::Column(column) = &*between.expr else {
+        return false;
+    };
+    matches!(column.name.as_str(), "start" | "end")
+        && matches!(&*between.low, Expr::Literal(value, _) if is_integer(value))
+        && matches!(&*between.high, Expr::Literal(value, _) if is_integer(value))
+}
+
+fn supports_in_list(in_list: &InList) -> bool {
+    let Expr::Column(column) = &*in_list.expr else {
+        return false;
+    };
+    match column.name.as_str() {
+        "chrom" | "id" => in_list
+            .list
+            .iter()
+            .all(|expr| matches!(expr, Expr::Literal(value, _) if is_string(value))),
+        "start" | "end" => in_list
+            .list
+            .iter()
+            .all(|expr| matches!(expr, Expr::Literal(value, _) if is_integer(value))),
+        _ => false,
+    }
+}
+
+fn evaluate_comparison(
+    variant: &PvarVariant,
+    name: &str,
+    literal: &ScalarValue,
+    operator: &Operator,
+) -> bool {
+    match name {
+        "chrom" => compare_string(Some(variant.chrom.as_str()), literal, operator),
+        "id" => compare_string(variant.id.as_deref(), literal, operator),
+        "start" => compare_integer(variant.start, literal, operator),
+        "end" => compare_integer(variant.end, literal, operator),
+        _ => true,
+    }
+}
+
+fn evaluate_between(variant: &PvarVariant, between: &Between) -> bool {
+    let (Expr::Column(column), Expr::Literal(low, _), Expr::Literal(high, _)) =
+        (&*between.expr, &*between.low, &*between.high)
+    else {
+        return true;
+    };
+    let value = match column.name.as_str() {
+        "start" => variant.start,
+        "end" => variant.end,
+        _ => return true,
+    };
+    let Some(low) = integer(low) else {
+        return true;
+    };
+    let Some(high) = integer(high) else {
+        return true;
+    };
+    let matches = value >= low && value <= high;
+    if between.negated { !matches } else { matches }
+}
+
+fn evaluate_in_list(variant: &PvarVariant, in_list: &InList) -> bool {
+    let Expr::Column(column) = &*in_list.expr else {
+        return true;
+    };
+    let matches = match column.name.as_str() {
+        "chrom" => in_list.list.iter().any(|expr| {
+            matches!(expr, Expr::Literal(value, _) if string(value) == Some(variant.chrom.as_str()))
+        }),
+        "id" => {
+            let Some(id) = variant.id.as_deref() else {
+                return false;
+            };
+            in_list.list.iter().any(
+                |expr| matches!(expr, Expr::Literal(value, _) if string(value) == Some(id)),
+            )
+        }
+        "start" => in_list.list.iter().any(
+            |expr| matches!(expr, Expr::Literal(value, _) if integer(value) == Some(variant.start)),
+        ),
+        "end" => in_list.list.iter().any(
+            |expr| matches!(expr, Expr::Literal(value, _) if integer(value) == Some(variant.end)),
+        ),
+        _ => return true,
+    };
+    if in_list.negated { !matches } else { matches }
+}
+
+fn compare_string(value: Option<&str>, literal: &ScalarValue, operator: &Operator) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    let Some(literal) = string(literal) else {
+        return true;
+    };
+    match operator {
+        Operator::Eq => value == literal,
+        Operator::NotEq => value != literal,
+        _ => true,
+    }
+}
+
+fn compare_integer(value: u64, literal: &ScalarValue, operator: &Operator) -> bool {
+    let Some(literal) = integer(literal) else {
+        return true;
+    };
+    match operator {
+        Operator::Eq => value == literal,
+        Operator::NotEq => value != literal,
+        Operator::Lt => value < literal,
+        Operator::LtEq => value <= literal,
+        Operator::Gt => value > literal,
+        Operator::GtEq => value >= literal,
+        _ => true,
+    }
+}
+
+fn is_string(value: &ScalarValue) -> bool {
+    string(value).is_some()
+}
+
+fn string(value: &ScalarValue) -> Option<&str> {
+    match value {
+        ScalarValue::Utf8(Some(value)) | ScalarValue::LargeUtf8(Some(value)) => Some(value),
+        _ => None,
+    }
+}
+
+fn is_integer(value: &ScalarValue) -> bool {
+    integer(value).is_some()
+}
+
+fn integer(value: &ScalarValue) -> Option<u64> {
+    match value {
+        ScalarValue::UInt8(Some(value)) => Some((*value).into()),
+        ScalarValue::UInt16(Some(value)) => Some((*value).into()),
+        ScalarValue::UInt32(Some(value)) => Some((*value).into()),
+        ScalarValue::UInt64(Some(value)) => Some(*value),
+        ScalarValue::Int8(Some(value)) => u64::try_from(*value).ok(),
+        ScalarValue::Int16(Some(value)) => u64::try_from(*value).ok(),
+        ScalarValue::Int32(Some(value)) => u64::try_from(*value).ok(),
+        ScalarValue::Int64(Some(value)) => u64::try_from(*value).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::logical_expr::{col, lit};
+
+    use super::*;
+
+    fn variant() -> PvarVariant {
+        PvarVariant {
+            chrom: "1".to_string(),
+            start: 9,
+            end: 10,
+            id: Some("rs1".to_string()),
+            reference: "A".to_string(),
+            alternate: vec!["C".to_string()],
+        }
+    }
+
+    #[test]
+    fn supports_and_evaluates_catalog_filters() {
+        let filter = col("chrom")
+            .eq(lit("1"))
+            .and(col("start").between(lit(5_u64), lit(10_u64)));
+        assert!(supports_exact_filter(&filter));
+        assert!(evaluate_exact_filter(&variant(), &filter));
+        assert!(supports_exact_filter(
+            &col("id").in_list(vec![lit("rs1"), lit("rs2")], false)
+        ));
+        assert!(!supports_exact_filter(&col("ref").eq(lit("A"))));
+    }
+
+    #[test]
+    fn preserves_sql_null_semantics_for_negated_id_lists() {
+        let mut without_id = variant();
+        without_id.id = None;
+        let filter = col("id").in_list(vec![lit("rs2")], true);
+        assert!(supports_exact_filter(&filter));
+        assert!(!evaluate_exact_filter(&without_id, &filter));
+    }
+}

--- a/datafusion/bio-format-pgen/src/lib.rs
+++ b/datafusion/bio-format-pgen/src/lib.rs
@@ -1,0 +1,13 @@
+//! Read-only DataFusion support for PLINK 2 PGEN/PVAR/PSAM filesets.
+
+#![warn(missing_docs)]
+
+mod decode;
+mod fileset;
+mod filter;
+mod physical_exec;
+mod source;
+mod table_provider;
+
+pub use physical_exec::PgenExec;
+pub use table_provider::{PgenReadOptions, PgenTableProvider, PsamIdMode};

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -948,6 +948,9 @@ fn build_genotype_array(
             "PGEN genotypes field is not a struct".to_string(),
         ));
     };
+    if fields.is_empty() {
+        return Ok(Arc::new(StructArray::new_empty_fields(rows.len(), None)));
+    }
     let arrays = genotype_fields
         .iter()
         .zip(fields)

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -591,7 +591,12 @@ fn execute_gt_only(
         let selected_sample_count = selected_samples.len();
         let estimated_row_bytes = estimate_genotype_bytes(selected_sample_count, &["GT".to_string()]);
         let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
-        let partition_row_capacity = max_rows.min(assignment.owned().len()).max(1);
+        let partition_row_capacity = initial_batch_row_capacity(
+            max_rows,
+            assignment.owned().len(),
+            soft_bytes,
+            estimated_row_bytes,
+        );
         let mut batch =
             GtBatchBuilder::new(&schema, partition_row_capacity, selected_sample_count)?;
         let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected_samples)?;
@@ -785,6 +790,20 @@ fn estimate_genotype_bytes(samples: usize, fields: &[String]) -> usize {
             _ => 0,
         })
     })
+}
+
+fn initial_batch_row_capacity(
+    max_rows: usize,
+    partition_rows: usize,
+    soft_bytes: usize,
+    estimated_row_bytes: usize,
+) -> usize {
+    let byte_limited_rows = if estimated_row_bytes == 0 {
+        max_rows
+    } else {
+        (soft_bytes / estimated_row_bytes).max(1)
+    };
+    max_rows.min(partition_rows).min(byte_limited_rows).max(1)
 }
 
 fn record_batch_metrics(metrics: &GenotypeScanMetrics, rows: usize, genotype_bytes: usize) {
@@ -1085,4 +1104,27 @@ fn build_hds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef
         builder.append(true);
     }
     Ok(Arc::new(builder.finish()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{estimate_genotype_bytes, initial_batch_row_capacity};
+
+    #[test]
+    fn bounds_gt_builder_capacity_by_the_soft_byte_budget() {
+        let estimated_row_bytes = estimate_genotype_bytes(100_000, &["GT".to_string()]);
+        assert_eq!(estimated_row_bytes, 500_000);
+        assert_eq!(
+            initial_batch_row_capacity(8192, 8192, 64 * 1024 * 1024, estimated_row_bytes),
+            134
+        );
+        assert_eq!(
+            initial_batch_row_capacity(8192, 8192, 1, estimated_row_bytes),
+            1
+        );
+        assert_eq!(
+            initial_batch_row_capacity(8192, 3, 64 * 1024 * 1024, estimated_row_bytes),
+            3
+        );
+    }
 }

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -180,7 +180,10 @@ impl ExecutionPlan for PgenExec {
                 let retained_bases = assignment
                     .required
                     .iter()
-                    .filter_map(|&index| fileset.records[index].ld_base)
+                    .map(|&index| fileset.records.record(index).map(|record| record.ld_base))
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .flatten()
                     .collect::<HashSet<_>>();
                 // The index assigns every LD record to the most recent eligible
                 // non-LD record. Required records are processed in source order,
@@ -198,7 +201,7 @@ impl ExecutionPlan for PgenExec {
                     metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
                     while let Some(&variant_index) = assignment.required.get(required_position) {
-                        let record = &fileset.records[variant_index];
+                        let record = fileset.records.record(variant_index)?;
                         if record.offset >= range.end {
                             break;
                         }
@@ -543,7 +546,10 @@ fn execute_gt_only(
         let retained_bases = assignment
             .required
             .iter()
-            .filter_map(|&index| fileset.records[index].ld_base)
+            .map(|&index| fileset.records.record(index).map(|record| record.ld_base))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
             .collect::<HashSet<_>>();
         let mut ld_base_index = None;
         let mut ld_base = Vec::with_capacity(fileset.sample_count);
@@ -559,7 +565,7 @@ fn execute_gt_only(
             metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
             while let Some(&variant_index) = assignment.required.get(required_position) {
-                let record = &fileset.records[variant_index];
+                let record = fileset.records.record(variant_index)?;
                 if record.offset >= range.end {
                     break;
                 }

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -5,7 +5,6 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use async_stream::try_stream;
-use bytes::Bytes;
 use datafusion::arrow::array::{
     ArrayRef, BooleanBuilder, FixedSizeListArray, FixedSizeListBuilder, Float32Builder, ListArray,
     ListBuilder, StringArray, StringBuilder, StructArray, UInt16Array, UInt16Builder, UInt64Array,
@@ -24,7 +23,7 @@ use datafusion_bio_format_core::range_planning::ByteRange;
 
 use crate::decode::{
     DecodedRecord, GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into,
-    decode_dense_biallelic_gt, decode_main_track, decode_record_and_main,
+    decode_dense_biallelic_gt, decode_main_track_and_validate, decode_record_and_main,
     supports_biallelic_gt_fast_path,
 };
 use crate::fileset::{PgenFileset, PgenMode};
@@ -246,11 +245,9 @@ impl ExecutionPlan for PgenExec {
                 let mut ld_base_index = None;
                 let mut ld_base = Vec::with_capacity(fileset.sample_count);
                 let mut required = assignment.required().peekable();
+                let mut range_reader = fileset.source.range_reader(&fileset.pgen_path).await?;
                 for range in assignment.ranges.iter().copied() {
-                    let bytes = fileset
-                        .source
-                        .read_range(&fileset.pgen_path, range.start..range.end)
-                        .await?;
+                    let bytes = range_reader.read_range(range.start..range.end).await?;
                     metrics.add(GenotypeMetric::RangeRequests, 1);
                     metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
@@ -269,7 +266,7 @@ impl ExecutionPlan for PgenExec {
                             )))?;
                         }
                         let payload =
-                            record_payload(range, &bytes, record.offset, record.end(), variant_index)?;
+                            record_payload(range, bytes, record.offset, record.end(), variant_index)?;
                         let base = record
                             .ld_base
                             .map(|base_index| {
@@ -282,12 +279,13 @@ impl ExecutionPlan for PgenExec {
                             })
                             .transpose()?;
                         if owned.binary_search(&variant_index).is_err() {
-                            let main = decode_main_track(
+                            let main = decode_main_track_and_validate(
                                 payload,
                                 fileset.mode,
                                 record.record_type,
                                 variant_index,
                                 fileset.sample_count,
+                                fileset.variants[variant_index].allele_count(),
                                 base,
                             )?;
                             if retained_bases.contains(&variant_index) {
@@ -612,12 +610,10 @@ fn execute_gt_only(
         let mut ld_base = Vec::with_capacity(fileset.sample_count);
         let mut required = assignment.required().peekable();
         let genotype_projection = GenotypeProjection::gt_only();
+        let mut range_reader = fileset.source.range_reader(&fileset.pgen_path).await?;
 
         for range in assignment.ranges.iter().copied() {
-            let bytes = fileset
-                .source
-                .read_range(&fileset.pgen_path, range.start..range.end)
-                .await?;
+            let bytes = range_reader.read_range(range.start..range.end).await?;
             metrics.add(GenotypeMetric::RangeRequests, 1);
             metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
@@ -636,7 +632,7 @@ fn execute_gt_only(
                     )))?;
                 }
                 let payload =
-                    record_payload(range, &bytes, record.offset, record.end(), variant_index)?;
+                    record_payload(range, bytes, record.offset, record.end(), variant_index)?;
                 let base = record
                     .ld_base
                     .map(|base_index| {
@@ -650,12 +646,13 @@ fn execute_gt_only(
                     .transpose()?;
 
                 if owned.binary_search(&variant_index).is_err() {
-                    let main = decode_main_track(
+                    let main = decode_main_track_and_validate(
                         payload,
                         fileset.mode,
                         record.record_type,
                         variant_index,
                         fileset.sample_count,
+                        fileset.variants[variant_index].allele_count(),
                         base,
                     )?;
                     if retained_bases.contains(&variant_index) {
@@ -759,7 +756,7 @@ fn execute_gt_only(
 
 fn record_payload(
     range: ByteRange,
-    bytes: &Bytes,
+    bytes: &[u8],
     start: u64,
     end: u64,
     variant_index: usize,

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -2,14 +2,16 @@ use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_stream::try_stream;
 use bytes::Bytes;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanBuilder, Float32Builder, ListBuilder, StringArray, StringBuilder, StructArray,
-    UInt16Builder, UInt64Array,
+    ArrayRef, BooleanBuilder, FixedSizeListArray, FixedSizeListBuilder, Float32Builder, ListArray,
+    ListBuilder, StringArray, StringBuilder, StructArray, UInt16Array, UInt16Builder, UInt64Array,
 };
-use datafusion::arrow::datatypes::{DataType, Fields, SchemaRef};
+use datafusion::arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
+use datafusion::arrow::datatypes::{DataType, FieldRef, Fields, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -20,8 +22,11 @@ use datafusion_bio_format_core::genotype::{
 };
 use datafusion_bio_format_core::range_planning::ByteRange;
 
-use crate::decode::{DecodedRecord, decode_main_track, decode_record_and_main};
-use crate::fileset::PgenFileset;
+use crate::decode::{
+    DecodedRecord, GtDecodeWorkspace, decode_biallelic_gt_into, decode_dense_biallelic_gt,
+    decode_main_track, decode_record_and_main, supports_biallelic_gt_fast_path,
+};
+use crate::fileset::{PgenFileset, PgenMode};
 
 #[derive(Clone, Debug)]
 pub(crate) struct PgenPartition {
@@ -129,6 +134,13 @@ impl ExecutionPlan for PgenExec {
         let genotype_fields = self.genotype_fields.clone();
         let genotypes_projected = schema.index_of("genotypes").is_ok();
 
+        if genotypes_projected
+            && !assignment.ranges.is_empty()
+            && genotype_fields.as_slice() == ["GT"]
+        {
+            return execute_gt_only(assignment, fileset, schema, metrics, max_rows, soft_bytes);
+        }
+
         let stream_schema = schema.clone();
         let stream = try_stream! {
             let selected_sample_count = fileset.selected_samples.source_indices().len();
@@ -156,6 +168,7 @@ impl ExecutionPlan for PgenExec {
                             gt: Vec::new(),
                             phased: Vec::new(),
                             ds: Vec::new(),
+                            ds_stored: Vec::new(),
                             hds: Vec::new(),
                         }),
                     });
@@ -282,6 +295,453 @@ impl ExecutionPlan for PgenExec {
     }
 }
 
+struct GtBatchBuilder {
+    variant_indices: Vec<usize>,
+    allele_values: Vec<u16>,
+    sample_validity: PackedValidityBuilder,
+    selected_sample_count: usize,
+    row_capacity: usize,
+    sample_field: FieldRef,
+    allele_field: FieldRef,
+}
+
+impl GtBatchBuilder {
+    fn new(schema: &SchemaRef, row_capacity: usize, selected_sample_count: usize) -> Result<Self> {
+        let genotype_field = schema.field_with_name("genotypes")?;
+        let DataType::Struct(children) = genotype_field.data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN genotypes field is not a struct".to_string(),
+            ));
+        };
+        if children.len() != 1 || children[0].name() != "GT" {
+            return Err(DataFusionError::Execution(
+                "PGEN GT fast path requires an exact GT-only genotype projection".to_string(),
+            ));
+        }
+        let DataType::List(sample_field) = children[0].data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN GT field is not a list".to_string(),
+            ));
+        };
+        let DataType::FixedSizeList(allele_field, 2) = sample_field.data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN GT sample field is not a fixed-size allele pair".to_string(),
+            ));
+        };
+        Ok(Self {
+            variant_indices: Vec::with_capacity(row_capacity),
+            allele_values: Vec::with_capacity(
+                row_capacity
+                    .saturating_mul(selected_sample_count)
+                    .saturating_mul(2),
+            ),
+            sample_validity: PackedValidityBuilder::new(
+                row_capacity.saturating_mul(selected_sample_count),
+            ),
+            selected_sample_count,
+            row_capacity,
+            sample_field: sample_field.clone(),
+            allele_field: allele_field.clone(),
+        })
+    }
+
+    fn append(&mut self, variant_index: usize, calls: &[Option<[u16; 2]>]) {
+        for call in calls {
+            if let Some(call) = call {
+                self.allele_values.extend_from_slice(call);
+                self.sample_validity.append(true);
+            } else {
+                self.allele_values.extend_from_slice(&[0, 0]);
+                self.sample_validity.append(false);
+            }
+        }
+        self.variant_indices.push(variant_index);
+    }
+
+    fn append_codes(&mut self, variant_index: usize, codes: &[u8]) -> Result<()> {
+        for &code in codes {
+            let (left, right, valid) = match code {
+                0 => (0, 0, true),
+                1 => (0, 1, true),
+                2 => (1, 1, true),
+                3 => (0, 0, false),
+                4 => (1, 0, true),
+                _ => {
+                    return Err(DataFusionError::Execution(format!(
+                        "invalid internal biallelic GT code {code}"
+                    )));
+                }
+            };
+            self.append_values(left, right, valid);
+        }
+        self.finish_variant(variant_index);
+        Ok(())
+    }
+
+    #[inline]
+    fn append_values(&mut self, left: u16, right: u16, valid: bool) {
+        self.allele_values.push(left);
+        self.allele_values.push(right);
+        self.sample_validity.append(valid);
+    }
+
+    #[inline]
+    fn append_chunk(&mut self, alleles: &[u16], validity: u8, sample_count: usize) {
+        self.allele_values.extend_from_slice(alleles);
+        self.sample_validity.append_packed(validity, sample_count);
+    }
+
+    fn finish_variant(&mut self, variant_index: usize) {
+        self.variant_indices.push(variant_index);
+    }
+
+    fn len(&self) -> usize {
+        self.variant_indices.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.variant_indices.is_empty()
+    }
+
+    fn finish(&mut self, fileset: &PgenFileset, schema: SchemaRef) -> Result<RecordBatch> {
+        let validity = self.sample_validity.finish();
+        let allele_values = std::mem::replace(
+            &mut self.allele_values,
+            Vec::with_capacity(
+                self.row_capacity
+                    .saturating_mul(self.selected_sample_count)
+                    .saturating_mul(2),
+            ),
+        );
+        self.sample_validity = PackedValidityBuilder::new(
+            self.row_capacity.saturating_mul(self.selected_sample_count),
+        );
+        let alleles = Arc::new(UInt16Array::from(allele_values)) as ArrayRef;
+        let samples = Arc::new(FixedSizeListArray::new(
+            self.allele_field.clone(),
+            2,
+            alleles,
+            validity,
+        )) as ArrayRef;
+        let gt = Arc::new(ListArray::new(
+            self.sample_field.clone(),
+            OffsetBuffer::from_repeated_length(self.selected_sample_count, self.len()),
+            samples,
+            None,
+        )) as ArrayRef;
+        let batch = build_gt_batch(fileset, schema, &self.variant_indices, gt)?;
+        self.variant_indices.clear();
+        Ok(batch)
+    }
+}
+
+struct PackedValidityBuilder {
+    bytes: Vec<u8>,
+    len: usize,
+    null_count: usize,
+    capacity: usize,
+}
+
+impl PackedValidityBuilder {
+    fn new(capacity: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(capacity.div_ceil(8)),
+            len: 0,
+            null_count: 0,
+            capacity,
+        }
+    }
+
+    #[inline]
+    fn append(&mut self, valid: bool) {
+        let shift = self.len % 8;
+        if shift == 0 {
+            self.bytes.push(0);
+        }
+        if valid {
+            let last = self.bytes.len() - 1;
+            self.bytes[last] |= 1 << shift;
+        } else {
+            self.null_count += 1;
+        }
+        self.len += 1;
+    }
+
+    #[inline]
+    fn append_packed(&mut self, bits: u8, count: usize) {
+        debug_assert!(count <= 8);
+        if count == 4 && self.len.is_multiple_of(4) {
+            let bits = bits & 0x0f;
+            if self.len.is_multiple_of(8) {
+                self.bytes.push(bits);
+            } else {
+                let last = self.bytes.len() - 1;
+                self.bytes[last] |= bits << 4;
+            }
+            self.len += 4;
+            self.null_count += 4 - bits.count_ones() as usize;
+            return;
+        }
+        let mask = if count == 8 {
+            u8::MAX
+        } else {
+            (1_u8 << count) - 1
+        };
+        let bits = bits & mask;
+        let byte_index = self.len / 8;
+        let shift = self.len % 8;
+        let new_len = self.len + count;
+        self.bytes.resize(new_len.div_ceil(8), 0);
+        self.bytes[byte_index] |= bits << shift;
+        if shift + count > 8 {
+            self.bytes[byte_index + 1] |= bits >> (8 - shift);
+        }
+        self.len = new_len;
+        self.null_count += count - bits.count_ones() as usize;
+    }
+
+    fn finish(&mut self) -> Option<NullBuffer> {
+        let bytes = std::mem::replace(
+            &mut self.bytes,
+            Vec::with_capacity(self.capacity.div_ceil(8)),
+        );
+        let len = std::mem::take(&mut self.len);
+        let null_count = std::mem::take(&mut self.null_count);
+        (null_count != 0).then(|| NullBuffer::new(BooleanBuffer::new(Buffer::from(bytes), 0, len)))
+    }
+}
+
+fn execute_gt_only(
+    assignment: PgenPartition,
+    fileset: Arc<PgenFileset>,
+    schema: SchemaRef,
+    metrics: Arc<GenotypeScanMetrics>,
+    max_rows: usize,
+    soft_bytes: usize,
+) -> Result<SendableRecordBatchStream> {
+    let stream_schema = schema.clone();
+    let stream = try_stream! {
+        let profile_enabled = std::env::var_os("PGEN_PROFILE").is_some();
+        let profile_started = Instant::now();
+        let mut read_elapsed = Duration::ZERO;
+        let mut decode_elapsed = Duration::ZERO;
+        let mut append_elapsed = Duration::ZERO;
+        let mut finish_elapsed = Duration::ZERO;
+        let mut representation_counts = [0_u64; 8];
+        let mut fast_records = 0_u64;
+        let mut fallback_records = 0_u64;
+        let selected_samples = fileset.selected_samples.source_indices();
+        let selected_sample_count = selected_samples.len();
+        let estimated_row_bytes = estimate_genotype_bytes(selected_sample_count, &["GT".to_string()]);
+        let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
+        let partition_row_capacity = max_rows.min(assignment.owned.len()).max(1);
+        let mut batch =
+            GtBatchBuilder::new(&schema, partition_row_capacity, selected_sample_count)?;
+        let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected_samples)?;
+
+        let owned = assignment.owned.iter().copied().collect::<HashSet<_>>();
+        let retained_bases = assignment
+            .required
+            .iter()
+            .filter_map(|&index| fileset.records[index].ld_base)
+            .collect::<HashSet<_>>();
+        let mut ld_base_index = None;
+        let mut ld_base = Vec::with_capacity(fileset.sample_count);
+        let mut required_position = 0;
+
+        for range in assignment.ranges {
+            let read_started = profile_enabled.then(Instant::now);
+            let bytes = fileset
+                .source
+                .read_range(&fileset.pgen_path, range.start..range.end)
+                .await?;
+            if let Some(started) = read_started {
+                read_elapsed += started.elapsed();
+            }
+            metrics.add(GenotypeMetric::RangeRequests, 1);
+            metrics.add(GenotypeMetric::CoalescedRanges, 1);
+            metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
+
+            while let Some(&variant_index) = assignment.required.get(required_position) {
+                let record = &fileset.records[variant_index];
+                if record.offset >= range.end {
+                    break;
+                }
+                if record.offset < range.start || record.end() > range.end {
+                    Err(DataFusionError::Execution(format!(
+                        "PGEN variant {variant_index} range {}..{} is not contained in planned range {}..{}",
+                        record.offset,
+                        record.end(),
+                        range.start,
+                        range.end
+                    )))?;
+                }
+                let payload =
+                    record_payload(range, &bytes, record.offset, record.end(), variant_index)?;
+                let base = record
+                    .ld_base
+                    .map(|base_index| {
+                        if ld_base_index != Some(base_index) {
+                            return Err(DataFusionError::Execution(format!(
+                                "PGEN variant {variant_index} dependency base {base_index} was not decoded first"
+                            )));
+                        }
+                        Ok(ld_base.as_slice())
+                    })
+                    .transpose()?;
+
+                if !owned.contains(&variant_index) {
+                    let main = decode_main_track(
+                        payload,
+                        fileset.mode,
+                        record.record_type,
+                        variant_index,
+                        fileset.sample_count,
+                        base,
+                    )?;
+                    if retained_bases.contains(&variant_index) {
+                        ld_base = main;
+                        ld_base_index = Some(variant_index);
+                    }
+                    metrics.add(GenotypeMetric::DependencyRecords, 1);
+                    required_position += 1;
+                    continue;
+                }
+
+                if sizer.should_flush_before(estimated_row_bytes) {
+                    let row_count = batch.len();
+                    let finish_started = profile_enabled.then(Instant::now);
+                    let finished = batch.finish(&fileset, schema.clone())?;
+                    if let Some(started) = finish_started {
+                        finish_elapsed += started.elapsed();
+                    }
+                    record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                    yield finished;
+                    sizer.reset();
+                }
+
+                let allele_count = fileset.variants[variant_index].allele_count();
+                representation_counts[usize::from(record.record_type & 7)] += 1;
+                let retain_main = retained_bases.contains(&variant_index);
+                let direct_dense = workspace.has_identity_selection()
+                    && !retain_main
+                    && supports_biallelic_gt_fast_path(record.record_type, allele_count)
+                    && (fileset.mode == PgenMode::Plink1 || record.record_type & 7 == 0);
+                if direct_dense {
+                    fast_records += 1;
+                    let decode_started = profile_enabled.then(Instant::now);
+                    decode_dense_biallelic_gt(
+                        payload,
+                        fileset.mode,
+                        record.record_type,
+                        variant_index,
+                        fileset.sample_count,
+                        |alleles, validity, samples| {
+                            batch.append_chunk(alleles, validity, samples)
+                        },
+                    )?;
+                    batch.finish_variant(variant_index);
+                    if let Some(started) = decode_started {
+                        decode_elapsed += started.elapsed();
+                    }
+                } else if supports_biallelic_gt_fast_path(record.record_type, allele_count) {
+                    fast_records += 1;
+                    let decode_started = profile_enabled.then(Instant::now);
+                    decode_biallelic_gt_into(
+                        &mut workspace,
+                        payload,
+                        fileset.mode,
+                        record.record_type,
+                        variant_index,
+                        fileset.sample_count,
+                        selected_samples,
+                        base,
+                        retain_main,
+                    )?;
+                    if let Some(started) = decode_started {
+                        decode_elapsed += started.elapsed();
+                    }
+                    let append_started = profile_enabled.then(Instant::now);
+                    batch.append_codes(variant_index, workspace.selected_codes())?;
+                    if let Some(started) = append_started {
+                        append_elapsed += started.elapsed();
+                    }
+                    if retained_bases.contains(&variant_index) {
+                        workspace.swap_main_track(&mut ld_base);
+                        ld_base_index = Some(variant_index);
+                    }
+                } else {
+                    fallback_records += 1;
+                    let decode_started = profile_enabled.then(Instant::now);
+                    let (decoded, main) = decode_record_and_main(
+                        payload,
+                        fileset.mode,
+                        record.record_type,
+                        variant_index,
+                        fileset.sample_count,
+                        allele_count,
+                        selected_samples,
+                        base,
+                    )?;
+                    if let Some(started) = decode_started {
+                        decode_elapsed += started.elapsed();
+                    }
+                    let append_started = profile_enabled.then(Instant::now);
+                    batch.append(variant_index, &decoded.gt);
+                    if let Some(started) = append_started {
+                        append_elapsed += started.elapsed();
+                    }
+                    if retained_bases.contains(&variant_index) {
+                        ld_base = main;
+                        ld_base_index = Some(variant_index);
+                    }
+                }
+                metrics.add(GenotypeMetric::SamplesDecoded, selected_sample_count as u64);
+                metrics.add(
+                    GenotypeMetric::SampleValuesSkipped,
+                    fileset.sample_count.saturating_sub(selected_sample_count) as u64,
+                );
+                sizer.push_row(estimated_row_bytes);
+                required_position += 1;
+            }
+        }
+
+        if required_position != assignment.required.len() {
+            Err(DataFusionError::Execution(format!(
+                "{} required PGEN records were not covered by planned ranges",
+                assignment.required.len() - required_position
+            )))?;
+        }
+        if !batch.is_empty() {
+            let row_count = batch.len();
+            let finish_started = profile_enabled.then(Instant::now);
+            let finished = batch.finish(&fileset, schema.clone())?;
+            if let Some(started) = finish_started {
+                finish_elapsed += started.elapsed();
+            }
+            record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+            yield finished;
+        }
+        if profile_enabled {
+            eprintln!(
+                "PGEN_PROFILE total_ns={} read_ns={} decode_ns={} append_ns={} finish_ns={} fast_records={} fallback_records={} representations={representation_counts:?}",
+                profile_started.elapsed().as_nanos(),
+                read_elapsed.as_nanos(),
+                decode_elapsed.as_nanos(),
+                append_elapsed.as_nanos(),
+                finish_elapsed.as_nanos(),
+                fast_records,
+                fallback_records,
+            );
+        }
+    };
+
+    Ok(Box::pin(RecordBatchStreamAdapter::new(
+        stream_schema,
+        stream,
+    )))
+}
+
 fn record_payload(
     range: ByteRange,
     bytes: &Bytes,
@@ -308,6 +768,7 @@ fn estimate_genotype_bytes(samples: usize, fields: &[String]) -> usize {
             "GT" => samples.saturating_mul(5),
             "PHASED" => samples.saturating_mul(2),
             "DS" => samples.saturating_mul(5),
+            "DS_STORED" => samples.saturating_mul(5),
             "HDS" => samples.saturating_mul(9),
             _ => 0,
         })
@@ -319,6 +780,84 @@ fn record_batch_metrics(metrics: &GenotypeScanMetrics, rows: usize, genotype_byt
     metrics.add(GenotypeMetric::BatchRows, rows as u64);
     metrics.add(GenotypeMetric::EmittedVariants, rows as u64);
     metrics.add(GenotypeMetric::GenotypeBytes, genotype_bytes as u64);
+}
+
+fn build_gt_batch(
+    fileset: &PgenFileset,
+    schema: SchemaRef,
+    variant_indices: &[usize],
+    gt: ArrayRef,
+) -> Result<RecordBatch> {
+    let arrays = schema
+        .fields()
+        .iter()
+        .map(|field| match field.name().as_str() {
+            "chrom" => Ok(Arc::new(StringArray::from_iter_values(
+                variant_indices
+                    .iter()
+                    .map(|&index| fileset.variants[index].chrom.as_str()),
+            )) as ArrayRef),
+            "start" => Ok(Arc::new(UInt64Array::from_iter_values(
+                variant_indices
+                    .iter()
+                    .map(|&index| fileset.variants[index].start),
+            )) as ArrayRef),
+            "end" => Ok(Arc::new(UInt64Array::from_iter_values(
+                variant_indices
+                    .iter()
+                    .map(|&index| fileset.variants[index].end),
+            )) as ArrayRef),
+            "id" => Ok(Arc::new(StringArray::from(
+                variant_indices
+                    .iter()
+                    .map(|&index| fileset.variants[index].id.as_deref())
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef),
+            "ref" => Ok(Arc::new(StringArray::from_iter_values(
+                variant_indices
+                    .iter()
+                    .map(|&index| fileset.variants[index].reference.as_str()),
+            )) as ArrayRef),
+            "alt" => build_alt_index_array(fileset, field.data_type(), variant_indices),
+            "genotypes" => {
+                let DataType::Struct(fields) = field.data_type() else {
+                    return Err(DataFusionError::Execution(
+                        "PGEN genotypes field is not a struct".to_string(),
+                    ));
+                };
+                Ok(Arc::new(StructArray::new(fields.clone(), vec![gt.clone()], None)) as ArrayRef)
+            }
+            name => Err(DataFusionError::Execution(format!(
+                "unsupported projected PGEN column {name}"
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RecordBatch::try_new_with_options(
+        schema,
+        arrays,
+        &RecordBatchOptions::new().with_row_count(Some(variant_indices.len())),
+    )
+    .map_err(DataFusionError::from)
+}
+
+fn build_alt_index_array(
+    fileset: &PgenFileset,
+    data_type: &DataType,
+    variant_indices: &[usize],
+) -> Result<ArrayRef> {
+    let DataType::List(allele_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN alt field is not a list".to_string(),
+        ));
+    };
+    let mut builder = ListBuilder::new(StringBuilder::new()).with_field(allele_field.clone());
+    for &variant_index in variant_indices {
+        for allele in &fileset.variants[variant_index].alternate {
+            builder.values().append_value(allele);
+        }
+        builder.append(true);
+    }
+    Ok(Arc::new(builder.finish()))
 }
 
 fn build_batch(
@@ -404,6 +943,7 @@ fn build_genotype_array(
             "GT" => build_gt_array(field.data_type(), rows),
             "PHASED" => build_phased_array(field.data_type(), rows),
             "DS" => build_ds_array(field.data_type(), rows),
+            "DS_STORED" => build_ds_stored_array(field.data_type(), rows),
             "HDS" => build_hds_array(field.data_type(), rows),
             _ => Err(DataFusionError::Execution(format!(
                 "unsupported PGEN genotype child {name}"
@@ -423,12 +963,13 @@ fn build_gt_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef>
             "PGEN GT field is not a list".to_string(),
         ));
     };
-    let DataType::List(allele_field) = sample_field.data_type() else {
+    let DataType::FixedSizeList(allele_field, 2) = sample_field.data_type() else {
         return Err(DataFusionError::Execution(
-            "PGEN GT sample field is not a list".to_string(),
+            "PGEN GT sample field is not a fixed-size allele pair".to_string(),
         ));
     };
-    let samples = ListBuilder::new(UInt16Builder::new()).with_field(allele_field.clone());
+    let samples =
+        FixedSizeListBuilder::new(UInt16Builder::new(), 2).with_field(allele_field.clone());
     let mut builder = ListBuilder::new(samples).with_field(sample_field.clone());
     for row in rows {
         let decoded = row.genotypes.as_ref().ok_or_else(|| {
@@ -439,6 +980,7 @@ fn build_gt_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef>
                 builder.values().values().append_slice(call);
                 builder.values().append(true);
             } else {
+                builder.values().values().append_slice(&[0, 0]);
                 builder.values().append(false);
             }
         }
@@ -467,17 +1009,30 @@ fn build_phased_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<Array
 }
 
 fn build_ds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    build_float_sample_array(data_type, rows, "DS", |decoded| &decoded.ds)
+}
+
+fn build_ds_stored_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    build_float_sample_array(data_type, rows, "DS_STORED", |decoded| &decoded.ds_stored)
+}
+
+fn build_float_sample_array<'a>(
+    data_type: &DataType,
+    rows: &'a [DecodedRow],
+    name: &str,
+    values: impl Fn(&'a DecodedRecord) -> &'a [Option<f32>],
+) -> Result<ArrayRef> {
     let DataType::List(sample_field) = data_type else {
-        return Err(DataFusionError::Execution(
-            "PGEN DS field is not a list".to_string(),
-        ));
+        return Err(DataFusionError::Execution(format!(
+            "PGEN {name} field is not a list"
+        )));
     };
     let mut builder = ListBuilder::new(Float32Builder::new()).with_field(sample_field.clone());
     for row in rows {
         let decoded = row.genotypes.as_ref().ok_or_else(|| {
             DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
         })?;
-        for value in &decoded.ds {
+        for value in values(decoded) {
             builder.values().append_option(*value);
         }
         builder.append(true);

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -1,8 +1,7 @@
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use async_stream::try_stream;
 use bytes::Bytes;
@@ -23,8 +22,9 @@ use datafusion_bio_format_core::genotype::{
 use datafusion_bio_format_core::range_planning::ByteRange;
 
 use crate::decode::{
-    DecodedRecord, GtDecodeWorkspace, decode_biallelic_gt_into, decode_dense_biallelic_gt,
-    decode_main_track, decode_record_and_main, supports_biallelic_gt_fast_path,
+    DecodedRecord, GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into,
+    decode_dense_biallelic_gt, decode_main_track, decode_record_and_main,
+    supports_biallelic_gt_fast_path,
 };
 use crate::fileset::{PgenFileset, PgenMode};
 
@@ -132,6 +132,7 @@ impl ExecutionPlan for PgenExec {
         let max_rows = context.session_config().batch_size();
         let soft_bytes = self.batch_soft_byte_limit;
         let genotype_fields = self.genotype_fields.clone();
+        let genotype_projection = GenotypeProjection::from_fields(&genotype_fields);
         let genotypes_projected = schema.index_of("genotypes").is_ok();
 
         if genotypes_projected
@@ -181,8 +182,12 @@ impl ExecutionPlan for PgenExec {
                     .iter()
                     .filter_map(|&index| fileset.records[index].ld_base)
                     .collect::<HashSet<_>>();
-                let mut main_tracks: HashMap<usize, Vec<u8>> =
-                    HashMap::with_capacity(retained_bases.len());
+                // The index assigns every LD record to the most recent eligible
+                // non-LD record. Required records are processed in source order,
+                // so one current base is sufficient and older bases can be
+                // dropped as soon as a newer retained base is decoded.
+                let mut ld_base_index = None;
+                let mut ld_base = Vec::with_capacity(fileset.sample_count);
                 let mut required_position = 0;
                 for range in assignment.ranges {
                     let bytes = fileset
@@ -190,7 +195,6 @@ impl ExecutionPlan for PgenExec {
                         .read_range(&fileset.pgen_path, range.start..range.end)
                         .await?;
                     metrics.add(GenotypeMetric::RangeRequests, 1);
-                    metrics.add(GenotypeMetric::CoalescedRanges, 1);
                     metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
                     while let Some(&variant_index) = assignment.required.get(required_position) {
@@ -209,17 +213,17 @@ impl ExecutionPlan for PgenExec {
                         }
                         let payload =
                             record_payload(range, &bytes, record.offset, record.end(), variant_index)?;
-                    let base_track = record
+                    let base = record
                         .ld_base
-                        .map(|base| {
-                            main_tracks.get(&base).cloned().ok_or_else(|| {
-                                DataFusionError::Execution(format!(
-                                    "PGEN variant {variant_index} dependency base {base} was not decoded first"
-                                ))
-                            })
+                        .map(|base_index| {
+                            if ld_base_index != Some(base_index) {
+                                return Err(DataFusionError::Execution(format!(
+                                    "PGEN variant {variant_index} dependency base {base_index} was not decoded first"
+                                )));
+                            }
+                            Ok(ld_base.as_slice())
                         })
                         .transpose()?;
-                    let base = base_track.as_deref();
                     if !owned.contains(&variant_index) {
                         let main = decode_main_track(
                             payload,
@@ -229,7 +233,10 @@ impl ExecutionPlan for PgenExec {
                             fileset.sample_count,
                             base,
                         )?;
-                        main_tracks.insert(variant_index, main);
+                        if retained_bases.contains(&variant_index) {
+                            ld_base = main;
+                            ld_base_index = Some(variant_index);
+                        }
                         metrics.add(GenotypeMetric::DependencyRecords, 1);
                         required_position += 1;
                         continue;
@@ -250,11 +257,13 @@ impl ExecutionPlan for PgenExec {
                         variant_index,
                         fileset.sample_count,
                         fileset.variants[variant_index].allele_count(),
+                        genotype_projection,
                         fileset.selected_samples.source_indices(),
                         base,
                     )?;
                     if retained_bases.contains(&variant_index) {
-                        main_tracks.insert(variant_index, main);
+                        ld_base = main;
+                        ld_base_index = Some(variant_index);
                     }
                     metrics.add(
                         GenotypeMetric::SamplesDecoded,
@@ -521,15 +530,6 @@ fn execute_gt_only(
 ) -> Result<SendableRecordBatchStream> {
     let stream_schema = schema.clone();
     let stream = try_stream! {
-        let profile_enabled = std::env::var_os("PGEN_PROFILE").is_some();
-        let profile_started = Instant::now();
-        let mut read_elapsed = Duration::ZERO;
-        let mut decode_elapsed = Duration::ZERO;
-        let mut append_elapsed = Duration::ZERO;
-        let mut finish_elapsed = Duration::ZERO;
-        let mut representation_counts = [0_u64; 8];
-        let mut fast_records = 0_u64;
-        let mut fallback_records = 0_u64;
         let selected_samples = fileset.selected_samples.source_indices();
         let selected_sample_count = selected_samples.len();
         let estimated_row_bytes = estimate_genotype_bytes(selected_sample_count, &["GT".to_string()]);
@@ -548,18 +548,14 @@ fn execute_gt_only(
         let mut ld_base_index = None;
         let mut ld_base = Vec::with_capacity(fileset.sample_count);
         let mut required_position = 0;
+        let genotype_projection = GenotypeProjection::gt_only();
 
         for range in assignment.ranges {
-            let read_started = profile_enabled.then(Instant::now);
             let bytes = fileset
                 .source
                 .read_range(&fileset.pgen_path, range.start..range.end)
                 .await?;
-            if let Some(started) = read_started {
-                read_elapsed += started.elapsed();
-            }
             metrics.add(GenotypeMetric::RangeRequests, 1);
-            metrics.add(GenotypeMetric::CoalescedRanges, 1);
             metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
             while let Some(&variant_index) = assignment.required.get(required_position) {
@@ -610,26 +606,19 @@ fn execute_gt_only(
 
                 if sizer.should_flush_before(estimated_row_bytes) {
                     let row_count = batch.len();
-                    let finish_started = profile_enabled.then(Instant::now);
                     let finished = batch.finish(&fileset, schema.clone())?;
-                    if let Some(started) = finish_started {
-                        finish_elapsed += started.elapsed();
-                    }
                     record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
                     yield finished;
                     sizer.reset();
                 }
 
                 let allele_count = fileset.variants[variant_index].allele_count();
-                representation_counts[usize::from(record.record_type & 7)] += 1;
                 let retain_main = retained_bases.contains(&variant_index);
                 let direct_dense = workspace.has_identity_selection()
                     && !retain_main
                     && supports_biallelic_gt_fast_path(record.record_type, allele_count)
                     && (fileset.mode == PgenMode::Plink1 || record.record_type & 7 == 0);
                 if direct_dense {
-                    fast_records += 1;
-                    let decode_started = profile_enabled.then(Instant::now);
                     decode_dense_biallelic_gt(
                         payload,
                         fileset.mode,
@@ -641,12 +630,7 @@ fn execute_gt_only(
                         },
                     )?;
                     batch.finish_variant(variant_index);
-                    if let Some(started) = decode_started {
-                        decode_elapsed += started.elapsed();
-                    }
                 } else if supports_biallelic_gt_fast_path(record.record_type, allele_count) {
-                    fast_records += 1;
-                    let decode_started = profile_enabled.then(Instant::now);
                     decode_biallelic_gt_into(
                         &mut workspace,
                         payload,
@@ -658,21 +642,12 @@ fn execute_gt_only(
                         base,
                         retain_main,
                     )?;
-                    if let Some(started) = decode_started {
-                        decode_elapsed += started.elapsed();
-                    }
-                    let append_started = profile_enabled.then(Instant::now);
                     batch.append_codes(variant_index, workspace.selected_codes())?;
-                    if let Some(started) = append_started {
-                        append_elapsed += started.elapsed();
-                    }
                     if retained_bases.contains(&variant_index) {
                         workspace.swap_main_track(&mut ld_base);
                         ld_base_index = Some(variant_index);
                     }
                 } else {
-                    fallback_records += 1;
-                    let decode_started = profile_enabled.then(Instant::now);
                     let (decoded, main) = decode_record_and_main(
                         payload,
                         fileset.mode,
@@ -680,17 +655,11 @@ fn execute_gt_only(
                         variant_index,
                         fileset.sample_count,
                         allele_count,
+                        genotype_projection,
                         selected_samples,
                         base,
                     )?;
-                    if let Some(started) = decode_started {
-                        decode_elapsed += started.elapsed();
-                    }
-                    let append_started = profile_enabled.then(Instant::now);
                     batch.append(variant_index, &decoded.gt);
-                    if let Some(started) = append_started {
-                        append_elapsed += started.elapsed();
-                    }
                     if retained_bases.contains(&variant_index) {
                         ld_base = main;
                         ld_base_index = Some(variant_index);
@@ -714,25 +683,9 @@ fn execute_gt_only(
         }
         if !batch.is_empty() {
             let row_count = batch.len();
-            let finish_started = profile_enabled.then(Instant::now);
             let finished = batch.finish(&fileset, schema.clone())?;
-            if let Some(started) = finish_started {
-                finish_elapsed += started.elapsed();
-            }
             record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
             yield finished;
-        }
-        if profile_enabled {
-            eprintln!(
-                "PGEN_PROFILE total_ns={} read_ns={} decode_ns={} append_ns={} finish_ns={} fast_records={} fallback_records={} representations={representation_counts:?}",
-                profile_started.elapsed().as_nanos(),
-                read_elapsed.as_nanos(),
-                decode_elapsed.as_nanos(),
-                append_elapsed.as_nanos(),
-                finish_elapsed.as_nanos(),
-                fast_records,
-                fallback_records,
-            );
         }
     };
 
@@ -763,6 +716,8 @@ fn record_payload(
 }
 
 fn estimate_genotype_bytes(samples: usize, fields: &[String]) -> usize {
+    // Conservative soft-budget estimates include values, validity, list offsets,
+    // and alignment overhead. They deliberately exceed the dense Arrow payload.
     fields.iter().fold(0_usize, |bytes, field| {
         bytes.saturating_add(match field.as_str() {
             "GT" => samples.saturating_mul(5),
@@ -1046,12 +1001,13 @@ fn build_hds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef
             "PGEN HDS field is not a list".to_string(),
         ));
     };
-    let DataType::List(haplotype_field) = sample_field.data_type() else {
+    let DataType::FixedSizeList(haplotype_field, 2) = sample_field.data_type() else {
         return Err(DataFusionError::Execution(
-            "PGEN HDS sample field is not a list".to_string(),
+            "PGEN HDS sample field is not a fixed-size haplotype pair".to_string(),
         ));
     };
-    let samples = ListBuilder::new(Float32Builder::new()).with_field(haplotype_field.clone());
+    let samples =
+        FixedSizeListBuilder::new(Float32Builder::new(), 2).with_field(haplotype_field.clone());
     let mut builder = ListBuilder::new(samples).with_field(sample_field.clone());
     for row in rows {
         let decoded = row.genotypes.as_ref().ok_or_else(|| {
@@ -1062,6 +1018,7 @@ fn build_hds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef
                 builder.values().values().append_slice(value);
                 builder.values().append(true);
             } else {
+                builder.values().values().append_slice(&[0.0, 0.0]);
                 builder.values().append(false);
             }
         }

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
 use std::sync::Arc;
 
 use async_stream::try_stream;
@@ -30,9 +31,64 @@ use crate::fileset::{PgenFileset, PgenMode};
 
 #[derive(Clone, Debug)]
 pub(crate) struct PgenPartition {
-    pub(crate) owned: Vec<usize>,
-    pub(crate) required: Vec<usize>,
+    pub(crate) selection: Arc<Vec<usize>>,
+    pub(crate) owned: Range<usize>,
+    pub(crate) dependencies: Vec<usize>,
     pub(crate) ranges: Vec<ByteRange>,
+}
+
+impl PgenPartition {
+    pub(crate) fn owned(&self) -> &[usize] {
+        &self.selection[self.owned.clone()]
+    }
+
+    pub(crate) fn required(&self) -> impl Iterator<Item = usize> + '_ {
+        MergedIndices {
+            owned: self.owned(),
+            dependencies: &self.dependencies,
+            owned_position: 0,
+            dependency_position: 0,
+        }
+    }
+}
+
+struct MergedIndices<'a> {
+    owned: &'a [usize],
+    dependencies: &'a [usize],
+    owned_position: usize,
+    dependency_position: usize,
+}
+
+impl Iterator for MergedIndices<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (
+            self.owned.get(self.owned_position).copied(),
+            self.dependencies.get(self.dependency_position).copied(),
+        ) {
+            (Some(owned), Some(dependency)) if owned <= dependency => {
+                self.owned_position += 1;
+                if owned == dependency {
+                    self.dependency_position += 1;
+                }
+                Some(owned)
+            }
+            (Some(_), Some(dependency)) => {
+                self.dependency_position += 1;
+                Some(dependency)
+            }
+            (Some(owned), None) => {
+                self.owned_position += 1;
+                Some(owned)
+            }
+            (None, Some(dependency)) => {
+                self.dependency_position += 1;
+                Some(dependency)
+            }
+            (None, None) => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -154,7 +210,7 @@ impl ExecutionPlan for PgenExec {
             let mut rows = Vec::with_capacity(max_rows);
 
             if assignment.ranges.is_empty() {
-                for variant_index in assignment.owned {
+                for &variant_index in assignment.owned() {
                     if sizer.should_flush_before(estimated_row_bytes) {
                         let row_count = rows.len();
                         let batch = build_batch(&fileset, schema.clone(), &genotype_fields, &rows)?;
@@ -176,9 +232,9 @@ impl ExecutionPlan for PgenExec {
                     sizer.push_row(estimated_row_bytes);
                 }
             } else {
-                let owned = assignment.owned.iter().copied().collect::<HashSet<_>>();
+                let owned = assignment.owned();
                 let mut retained_bases = HashSet::new();
-                for &index in &assignment.required {
+                for index in assignment.required() {
                     if let Some(base) = fileset.records.record(index)?.ld_base {
                         retained_bases.insert(base);
                     }
@@ -189,8 +245,8 @@ impl ExecutionPlan for PgenExec {
                 // dropped as soon as a newer retained base is decoded.
                 let mut ld_base_index = None;
                 let mut ld_base = Vec::with_capacity(fileset.sample_count);
-                let mut required_position = 0;
-                for range in assignment.ranges {
+                let mut required = assignment.required().peekable();
+                for range in assignment.ranges.iter().copied() {
                     let bytes = fileset
                         .source
                         .read_range(&fileset.pgen_path, range.start..range.end)
@@ -198,7 +254,7 @@ impl ExecutionPlan for PgenExec {
                     metrics.add(GenotypeMetric::RangeRequests, 1);
                     metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
-                    while let Some(&variant_index) = assignment.required.get(required_position) {
+                    while let Some(&variant_index) = required.peek() {
                         let record = fileset.records.record(variant_index)?;
                         if record.offset >= range.end {
                             break;
@@ -214,78 +270,78 @@ impl ExecutionPlan for PgenExec {
                         }
                         let payload =
                             record_payload(range, &bytes, record.offset, record.end(), variant_index)?;
-                    let base = record
-                        .ld_base
-                        .map(|base_index| {
-                            if ld_base_index != Some(base_index) {
-                                return Err(DataFusionError::Execution(format!(
-                                    "PGEN variant {variant_index} dependency base {base_index} was not decoded first"
-                                )));
+                        let base = record
+                            .ld_base
+                            .map(|base_index| {
+                                if ld_base_index != Some(base_index) {
+                                    return Err(DataFusionError::Execution(format!(
+                                        "PGEN variant {variant_index} dependency base {base_index} was not decoded first"
+                                    )));
+                                }
+                                Ok(ld_base.as_slice())
+                            })
+                            .transpose()?;
+                        if owned.binary_search(&variant_index).is_err() {
+                            let main = decode_main_track(
+                                payload,
+                                fileset.mode,
+                                record.record_type,
+                                variant_index,
+                                fileset.sample_count,
+                                base,
+                            )?;
+                            if retained_bases.contains(&variant_index) {
+                                ld_base = main;
+                                ld_base_index = Some(variant_index);
                             }
-                            Ok(ld_base.as_slice())
-                        })
-                        .transpose()?;
-                    if !owned.contains(&variant_index) {
-                        let main = decode_main_track(
+                            metrics.add(GenotypeMetric::DependencyRecords, 1);
+                            required.next();
+                            continue;
+                        }
+
+                        if sizer.should_flush_before(estimated_row_bytes) {
+                            let row_count = rows.len();
+                            let batch =
+                                build_batch(&fileset, schema.clone(), &genotype_fields, &rows)?;
+                            record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                            yield batch;
+                            rows.clear();
+                            sizer.reset();
+                        }
+                        let (decoded, main) = decode_record_and_main(
                             payload,
                             fileset.mode,
                             record.record_type,
                             variant_index,
                             fileset.sample_count,
+                            fileset.variants[variant_index].allele_count(),
+                            genotype_projection,
+                            fileset.selected_samples.source_indices(),
                             base,
                         )?;
                         if retained_bases.contains(&variant_index) {
                             ld_base = main;
                             ld_base_index = Some(variant_index);
                         }
-                        metrics.add(GenotypeMetric::DependencyRecords, 1);
-                        required_position += 1;
-                        continue;
-                    }
-
-                    if sizer.should_flush_before(estimated_row_bytes) {
-                        let row_count = rows.len();
-                        let batch = build_batch(&fileset, schema.clone(), &genotype_fields, &rows)?;
-                        record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
-                        yield batch;
-                        rows.clear();
-                        sizer.reset();
-                    }
-                    let (decoded, main) = decode_record_and_main(
-                        payload,
-                        fileset.mode,
-                        record.record_type,
-                        variant_index,
-                        fileset.sample_count,
-                        fileset.variants[variant_index].allele_count(),
-                        genotype_projection,
-                        fileset.selected_samples.source_indices(),
-                        base,
-                    )?;
-                    if retained_bases.contains(&variant_index) {
-                        ld_base = main;
-                        ld_base_index = Some(variant_index);
-                    }
-                    metrics.add(
-                        GenotypeMetric::SamplesDecoded,
-                        selected_sample_count as u64,
-                    );
-                    metrics.add(
-                        GenotypeMetric::SampleValuesSkipped,
-                        fileset.sample_count.saturating_sub(selected_sample_count) as u64,
-                    );
-                    rows.push(DecodedRow {
-                        variant_index,
-                        genotypes: Some(decoded),
-                    });
-                    sizer.push_row(estimated_row_bytes);
-                    required_position += 1;
+                        metrics.add(
+                            GenotypeMetric::SamplesDecoded,
+                            selected_sample_count as u64,
+                        );
+                        metrics.add(
+                            GenotypeMetric::SampleValuesSkipped,
+                            fileset.sample_count.saturating_sub(selected_sample_count) as u64,
+                        );
+                        rows.push(DecodedRow {
+                            variant_index,
+                            genotypes: Some(decoded),
+                        });
+                        sizer.push_row(estimated_row_bytes);
+                        required.next();
                     }
                 }
-                if required_position != assignment.required.len() {
+                if let Some(next) = required.next() {
                     Err(DataFusionError::Execution(format!(
-                        "{} required PGEN records were not covered by planned ranges",
-                        assignment.required.len() - required_position
+                        "required PGEN record {next} was not covered by planned ranges"
                     )))?;
                 }
             }
@@ -535,24 +591,24 @@ fn execute_gt_only(
         let selected_sample_count = selected_samples.len();
         let estimated_row_bytes = estimate_genotype_bytes(selected_sample_count, &["GT".to_string()]);
         let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
-        let partition_row_capacity = max_rows.min(assignment.owned.len()).max(1);
+        let partition_row_capacity = max_rows.min(assignment.owned().len()).max(1);
         let mut batch =
             GtBatchBuilder::new(&schema, partition_row_capacity, selected_sample_count)?;
         let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected_samples)?;
 
-        let owned = assignment.owned.iter().copied().collect::<HashSet<_>>();
+        let owned = assignment.owned();
         let mut retained_bases = HashSet::new();
-        for &index in &assignment.required {
+        for index in assignment.required() {
             if let Some(base) = fileset.records.record(index)?.ld_base {
                 retained_bases.insert(base);
             }
         }
         let mut ld_base_index = None;
         let mut ld_base = Vec::with_capacity(fileset.sample_count);
-        let mut required_position = 0;
+        let mut required = assignment.required().peekable();
         let genotype_projection = GenotypeProjection::gt_only();
 
-        for range in assignment.ranges {
+        for range in assignment.ranges.iter().copied() {
             let bytes = fileset
                 .source
                 .read_range(&fileset.pgen_path, range.start..range.end)
@@ -560,7 +616,7 @@ fn execute_gt_only(
             metrics.add(GenotypeMetric::RangeRequests, 1);
             metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
 
-            while let Some(&variant_index) = assignment.required.get(required_position) {
+            while let Some(&variant_index) = required.peek() {
                 let record = fileset.records.record(variant_index)?;
                 if record.offset >= range.end {
                     break;
@@ -588,7 +644,7 @@ fn execute_gt_only(
                     })
                     .transpose()?;
 
-                if !owned.contains(&variant_index) {
+                if owned.binary_search(&variant_index).is_err() {
                     let main = decode_main_track(
                         payload,
                         fileset.mode,
@@ -602,7 +658,7 @@ fn execute_gt_only(
                         ld_base_index = Some(variant_index);
                     }
                     metrics.add(GenotypeMetric::DependencyRecords, 1);
-                    required_position += 1;
+                    required.next();
                     continue;
                 }
 
@@ -673,14 +729,13 @@ fn execute_gt_only(
                     fileset.sample_count.saturating_sub(selected_sample_count) as u64,
                 );
                 sizer.push_row(estimated_row_bytes);
-                required_position += 1;
+                required.next();
             }
         }
 
-        if required_position != assignment.required.len() {
+        if let Some(next) = required.next() {
             Err(DataFusionError::Execution(format!(
-                "{} required PGEN records were not covered by planned ranges",
-                assignment.required.len() - required_position
+                "required PGEN record {next} was not covered by planned ranges"
             )))?;
         }
         if !batch.is_empty() {

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -1,0 +1,516 @@
+use std::any::Any;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use async_stream::try_stream;
+use bytes::Bytes;
+use datafusion::arrow::array::{
+    ArrayRef, BooleanBuilder, Float32Builder, ListBuilder, StringArray, StringBuilder, StructArray,
+    UInt16Builder, UInt64Array,
+};
+use datafusion::arrow::datatypes::{DataType, Fields, SchemaRef};
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_bio_format_core::genotype::{
+    GenotypeBatchSizer, GenotypeMetric, GenotypeScanMetrics,
+};
+use datafusion_bio_format_core::range_planning::ByteRange;
+
+use crate::decode::{DecodedRecord, decode_main_track, decode_record_and_main};
+use crate::fileset::PgenFileset;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PgenPartition {
+    pub(crate) owned: Vec<usize>,
+    pub(crate) required: Vec<usize>,
+    pub(crate) ranges: Vec<ByteRange>,
+}
+
+#[derive(Debug)]
+struct DecodedRow {
+    variant_index: usize,
+    genotypes: Option<DecodedRecord>,
+}
+
+/// Physical execution plan for a PGEN scan.
+pub struct PgenExec {
+    pub(crate) fileset: Arc<PgenFileset>,
+    pub(crate) schema: SchemaRef,
+    pub(crate) partitions: Arc<Vec<PgenPartition>>,
+    pub(crate) genotype_fields: Arc<Vec<String>>,
+    pub(crate) metrics: Arc<GenotypeScanMetrics>,
+    pub(crate) batch_soft_byte_limit: usize,
+    pub(crate) cache: Arc<PlanProperties>,
+}
+
+impl PgenExec {
+    /// Returns a snapshot of PGEN planning and execution counters.
+    pub fn metrics_snapshot(&self) -> [(GenotypeMetric, u64); 18] {
+        self.metrics.snapshot()
+    }
+}
+
+impl Debug for PgenExec {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PgenExec")
+            .field("pgen_path", &self.fileset.pgen_path)
+            .field("partitions", &self.partitions.len())
+            .field("schema", &self.schema)
+            .finish()
+    }
+}
+
+impl DisplayAs for PgenExec {
+    fn fmt_as(
+        &self,
+        _format: DisplayFormatType,
+        formatter: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        let columns = self
+            .schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            formatter,
+            "PgenExec: projection=[{columns}], partitions={}",
+            self.partitions.len()
+        )
+    }
+}
+
+impl ExecutionPlan for PgenExec {
+    fn name(&self) -> &str {
+        "PgenExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let assignment = self.partitions.get(partition).cloned().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "PGEN partition {partition} is out of bounds for {} partitions",
+                self.partitions.len()
+            ))
+        })?;
+        let fileset = self.fileset.clone();
+        let schema = self.schema.clone();
+        let metrics = self.metrics.clone();
+        let max_rows = context.session_config().batch_size();
+        let soft_bytes = self.batch_soft_byte_limit;
+        let genotype_fields = self.genotype_fields.clone();
+        let genotypes_projected = schema.index_of("genotypes").is_ok();
+
+        let stream_schema = schema.clone();
+        let stream = try_stream! {
+            let selected_sample_count = fileset.selected_samples.source_indices().len();
+            let estimated_row_bytes = if genotypes_projected {
+                estimate_genotype_bytes(selected_sample_count, &genotype_fields)
+            } else {
+                0
+            };
+            let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
+            let mut rows = Vec::with_capacity(max_rows);
+
+            if assignment.ranges.is_empty() {
+                for variant_index in assignment.owned {
+                    if sizer.should_flush_before(estimated_row_bytes) {
+                        let row_count = rows.len();
+                        let batch = build_batch(&fileset, schema.clone(), &genotype_fields, &rows)?;
+                        record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                        yield batch;
+                        rows.clear();
+                        sizer.reset();
+                    }
+                    rows.push(DecodedRow {
+                        variant_index,
+                        genotypes: genotypes_projected.then(|| DecodedRecord {
+                            gt: Vec::new(),
+                            phased: Vec::new(),
+                            ds: Vec::new(),
+                            hds: Vec::new(),
+                        }),
+                    });
+                    sizer.push_row(estimated_row_bytes);
+                }
+            } else {
+                let owned = assignment.owned.iter().copied().collect::<HashSet<_>>();
+                let retained_bases = assignment
+                    .required
+                    .iter()
+                    .filter_map(|&index| fileset.records[index].ld_base)
+                    .collect::<HashSet<_>>();
+                let mut main_tracks: HashMap<usize, Vec<u8>> =
+                    HashMap::with_capacity(retained_bases.len());
+                let mut required_position = 0;
+                for range in assignment.ranges {
+                    let bytes = fileset
+                        .source
+                        .read_range(&fileset.pgen_path, range.start..range.end)
+                        .await?;
+                    metrics.add(GenotypeMetric::RangeRequests, 1);
+                    metrics.add(GenotypeMetric::CoalescedRanges, 1);
+                    metrics.add(GenotypeMetric::PrimaryBytesRead, bytes.len() as u64);
+
+                    while let Some(&variant_index) = assignment.required.get(required_position) {
+                        let record = &fileset.records[variant_index];
+                        if record.offset >= range.end {
+                            break;
+                        }
+                        if record.offset < range.start || record.end() > range.end {
+                            Err(DataFusionError::Execution(format!(
+                                "PGEN variant {variant_index} range {}..{} is not contained in planned range {}..{}",
+                                record.offset,
+                                record.end(),
+                                range.start,
+                                range.end
+                            )))?;
+                        }
+                        let payload =
+                            record_payload(range, &bytes, record.offset, record.end(), variant_index)?;
+                    let base_track = record
+                        .ld_base
+                        .map(|base| {
+                            main_tracks.get(&base).cloned().ok_or_else(|| {
+                                DataFusionError::Execution(format!(
+                                    "PGEN variant {variant_index} dependency base {base} was not decoded first"
+                                ))
+                            })
+                        })
+                        .transpose()?;
+                    let base = base_track.as_deref();
+                    if !owned.contains(&variant_index) {
+                        let main = decode_main_track(
+                            payload,
+                            fileset.mode,
+                            record.record_type,
+                            variant_index,
+                            fileset.sample_count,
+                            base,
+                        )?;
+                        main_tracks.insert(variant_index, main);
+                        metrics.add(GenotypeMetric::DependencyRecords, 1);
+                        required_position += 1;
+                        continue;
+                    }
+
+                    if sizer.should_flush_before(estimated_row_bytes) {
+                        let row_count = rows.len();
+                        let batch = build_batch(&fileset, schema.clone(), &genotype_fields, &rows)?;
+                        record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                        yield batch;
+                        rows.clear();
+                        sizer.reset();
+                    }
+                    let (decoded, main) = decode_record_and_main(
+                        payload,
+                        fileset.mode,
+                        record.record_type,
+                        variant_index,
+                        fileset.sample_count,
+                        fileset.variants[variant_index].allele_count(),
+                        fileset.selected_samples.source_indices(),
+                        base,
+                    )?;
+                    if retained_bases.contains(&variant_index) {
+                        main_tracks.insert(variant_index, main);
+                    }
+                    metrics.add(
+                        GenotypeMetric::SamplesDecoded,
+                        selected_sample_count as u64,
+                    );
+                    metrics.add(
+                        GenotypeMetric::SampleValuesSkipped,
+                        fileset.sample_count.saturating_sub(selected_sample_count) as u64,
+                    );
+                    rows.push(DecodedRow {
+                        variant_index,
+                        genotypes: Some(decoded),
+                    });
+                    sizer.push_row(estimated_row_bytes);
+                    required_position += 1;
+                    }
+                }
+                if required_position != assignment.required.len() {
+                    Err(DataFusionError::Execution(format!(
+                        "{} required PGEN records were not covered by planned ranges",
+                        assignment.required.len() - required_position
+                    )))?;
+                }
+            }
+
+            if !rows.is_empty() {
+                let row_count = rows.len();
+                let batch = build_batch(&fileset, schema.clone(), &genotype_fields, &rows)?;
+                record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                yield batch;
+            }
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            stream_schema,
+            stream,
+        )))
+    }
+}
+
+fn record_payload(
+    range: ByteRange,
+    bytes: &Bytes,
+    start: u64,
+    end: u64,
+    variant_index: usize,
+) -> Result<&[u8]> {
+    let relative_start = usize::try_from(start - range.start).map_err(|_| {
+        DataFusionError::Execution("PGEN record start does not fit usize".to_string())
+    })?;
+    let relative_end = usize::try_from(end - range.start).map_err(|_| {
+        DataFusionError::Execution("PGEN record end does not fit usize".to_string())
+    })?;
+    bytes.get(relative_start..relative_end).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "PGEN variant {variant_index} slice is outside its loaded range"
+        ))
+    })
+}
+
+fn estimate_genotype_bytes(samples: usize, fields: &[String]) -> usize {
+    fields.iter().fold(0_usize, |bytes, field| {
+        bytes.saturating_add(match field.as_str() {
+            "GT" => samples.saturating_mul(5),
+            "PHASED" => samples.saturating_mul(2),
+            "DS" => samples.saturating_mul(5),
+            "HDS" => samples.saturating_mul(9),
+            _ => 0,
+        })
+    })
+}
+
+fn record_batch_metrics(metrics: &GenotypeScanMetrics, rows: usize, genotype_bytes: usize) {
+    metrics.add(GenotypeMetric::Batches, 1);
+    metrics.add(GenotypeMetric::BatchRows, rows as u64);
+    metrics.add(GenotypeMetric::EmittedVariants, rows as u64);
+    metrics.add(GenotypeMetric::GenotypeBytes, genotype_bytes as u64);
+}
+
+fn build_batch(
+    fileset: &PgenFileset,
+    schema: SchemaRef,
+    genotype_fields: &[String],
+    rows: &[DecodedRow],
+) -> Result<RecordBatch> {
+    let arrays = schema
+        .fields()
+        .iter()
+        .map(|field| match field.name().as_str() {
+            "chrom" => Ok(Arc::new(StringArray::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].chrom.as_str()),
+            )) as ArrayRef),
+            "start" => Ok(Arc::new(UInt64Array::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].start),
+            )) as ArrayRef),
+            "end" => Ok(Arc::new(UInt64Array::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].end),
+            )) as ArrayRef),
+            "id" => Ok(Arc::new(StringArray::from(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].id.as_deref())
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef),
+            "ref" => Ok(Arc::new(StringArray::from_iter_values(
+                rows.iter()
+                    .map(|row| fileset.variants[row.variant_index].reference.as_str()),
+            )) as ArrayRef),
+            "alt" => build_alt_array(fileset, field.data_type(), rows),
+            "genotypes" => build_genotype_array(field.data_type(), genotype_fields, rows),
+            name => Err(DataFusionError::Execution(format!(
+                "unsupported projected PGEN column {name}"
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RecordBatch::try_new_with_options(
+        schema,
+        arrays,
+        &RecordBatchOptions::new().with_row_count(Some(rows.len())),
+    )
+    .map_err(DataFusionError::from)
+}
+
+fn build_alt_array(
+    fileset: &PgenFileset,
+    data_type: &DataType,
+    rows: &[DecodedRow],
+) -> Result<ArrayRef> {
+    let DataType::List(allele_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN alt field is not a list".to_string(),
+        ));
+    };
+    let mut builder = ListBuilder::new(StringBuilder::new()).with_field(allele_field.clone());
+    for row in rows {
+        for allele in &fileset.variants[row.variant_index].alternate {
+            builder.values().append_value(allele);
+        }
+        builder.append(true);
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn build_genotype_array(
+    data_type: &DataType,
+    genotype_fields: &[String],
+    rows: &[DecodedRow],
+) -> Result<ArrayRef> {
+    let DataType::Struct(fields) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN genotypes field is not a struct".to_string(),
+        ));
+    };
+    let arrays = genotype_fields
+        .iter()
+        .zip(fields)
+        .map(|(name, field)| match name.as_str() {
+            "GT" => build_gt_array(field.data_type(), rows),
+            "PHASED" => build_phased_array(field.data_type(), rows),
+            "DS" => build_ds_array(field.data_type(), rows),
+            "HDS" => build_hds_array(field.data_type(), rows),
+            _ => Err(DataFusionError::Execution(format!(
+                "unsupported PGEN genotype child {name}"
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Arc::new(StructArray::new(
+        Fields::from(fields.iter().cloned().collect::<Vec<_>>()),
+        arrays,
+        None,
+    )))
+}
+
+fn build_gt_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    let DataType::List(sample_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN GT field is not a list".to_string(),
+        ));
+    };
+    let DataType::List(allele_field) = sample_field.data_type() else {
+        return Err(DataFusionError::Execution(
+            "PGEN GT sample field is not a list".to_string(),
+        ));
+    };
+    let samples = ListBuilder::new(UInt16Builder::new()).with_field(allele_field.clone());
+    let mut builder = ListBuilder::new(samples).with_field(sample_field.clone());
+    for row in rows {
+        let decoded = row.genotypes.as_ref().ok_or_else(|| {
+            DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+        })?;
+        for call in &decoded.gt {
+            if let Some(call) = call {
+                builder.values().values().append_slice(call);
+                builder.values().append(true);
+            } else {
+                builder.values().append(false);
+            }
+        }
+        builder.append(true);
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn build_phased_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    let DataType::List(sample_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN PHASED field is not a list".to_string(),
+        ));
+    };
+    let mut builder = ListBuilder::new(BooleanBuilder::new()).with_field(sample_field.clone());
+    for row in rows {
+        let decoded = row.genotypes.as_ref().ok_or_else(|| {
+            DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+        })?;
+        for value in &decoded.phased {
+            builder.values().append_option(*value);
+        }
+        builder.append(true);
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn build_ds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    let DataType::List(sample_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN DS field is not a list".to_string(),
+        ));
+    };
+    let mut builder = ListBuilder::new(Float32Builder::new()).with_field(sample_field.clone());
+    for row in rows {
+        let decoded = row.genotypes.as_ref().ok_or_else(|| {
+            DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+        })?;
+        for value in &decoded.ds {
+            builder.values().append_option(*value);
+        }
+        builder.append(true);
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn build_hds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    let DataType::List(sample_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN HDS field is not a list".to_string(),
+        ));
+    };
+    let DataType::List(haplotype_field) = sample_field.data_type() else {
+        return Err(DataFusionError::Execution(
+            "PGEN HDS sample field is not a list".to_string(),
+        ));
+    };
+    let samples = ListBuilder::new(Float32Builder::new()).with_field(haplotype_field.clone());
+    let mut builder = ListBuilder::new(samples).with_field(sample_field.clone());
+    for row in rows {
+        let decoded = row.genotypes.as_ref().ok_or_else(|| {
+            DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+        })?;
+        for value in &decoded.hds {
+            if let Some(value) = value {
+                builder.values().values().append_slice(value);
+                builder.values().append(true);
+            } else {
+                builder.values().append(false);
+            }
+        }
+        builder.append(true);
+    }
+    Ok(Arc::new(builder.finish()))
+}

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -177,14 +177,12 @@ impl ExecutionPlan for PgenExec {
                 }
             } else {
                 let owned = assignment.owned.iter().copied().collect::<HashSet<_>>();
-                let retained_bases = assignment
-                    .required
-                    .iter()
-                    .map(|&index| fileset.records.record(index).map(|record| record.ld_base))
-                    .collect::<Result<Vec<_>>>()?
-                    .into_iter()
-                    .flatten()
-                    .collect::<HashSet<_>>();
+                let mut retained_bases = HashSet::new();
+                for &index in &assignment.required {
+                    if let Some(base) = fileset.records.record(index)?.ld_base {
+                        retained_bases.insert(base);
+                    }
+                }
                 // The index assigns every LD record to the most recent eligible
                 // non-LD record. Required records are processed in source order,
                 // so one current base is sufficient and older bases can be
@@ -543,14 +541,12 @@ fn execute_gt_only(
         let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected_samples)?;
 
         let owned = assignment.owned.iter().copied().collect::<HashSet<_>>();
-        let retained_bases = assignment
-            .required
-            .iter()
-            .map(|&index| fileset.records.record(index).map(|record| record.ld_base))
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect::<HashSet<_>>();
+        let mut retained_bases = HashSet::new();
+        for &index in &assignment.required {
+            if let Some(base) = fileset.records.record(index)?.ld_base {
+                retained_bases.insert(base);
+            }
+        }
         let mut ld_base_index = None;
         let mut ld_base = Vec::with_capacity(fileset.sample_count);
         let mut required_position = 0;

--- a/datafusion/bio-format-pgen/src/source.rs
+++ b/datafusion/bio-format-pgen/src/source.rs
@@ -1,0 +1,153 @@
+use std::path::Path;
+
+use bytes::Bytes;
+use datafusion::common::{DataFusionError, Result};
+use datafusion_bio_format_core::companion::sanitize_location;
+use datafusion_bio_format_core::object_storage::{
+    ObjectStorageOptions, RemoteObject, StorageType, get_storage_type,
+};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+#[derive(Clone, Debug)]
+pub(crate) enum ObjectAccess {
+    Local(String),
+    Remote(RemoteObject),
+}
+
+impl ObjectAccess {
+    pub(crate) async fn open(path: &str, options: &ObjectStorageOptions) -> Result<Self> {
+        match get_storage_type(path.to_string()) {
+            StorageType::LOCAL => {
+                let local = local_path(path)?.to_string();
+                if !Path::new(&local).is_file() {
+                    return Err(DataFusionError::Plan(format!(
+                        "object does not exist: {}",
+                        sanitize_location(path)
+                    )));
+                }
+                Ok(Self::Local(local))
+            }
+            _ => {
+                let object = RemoteObject::open(path.to_string(), options.clone())
+                    .await
+                    .map_err(|error| external_error("open", path, error))?;
+                object
+                    .size()
+                    .await
+                    .map_err(|error| external_error("stat", path, error))?;
+                Ok(Self::Remote(object))
+            }
+        }
+    }
+
+    pub(crate) async fn exists(path: &str, options: &ObjectStorageOptions) -> Result<bool> {
+        match get_storage_type(path.to_string()) {
+            StorageType::LOCAL => Ok(Path::new(local_path(path)?).is_file()),
+            _ => match RemoteObject::open(path.to_string(), options.clone()).await {
+                Ok(object) => match object.size().await {
+                    Ok(_) => Ok(true),
+                    Err(error) if error.kind() == opendal::ErrorKind::NotFound => Ok(false),
+                    Err(error) => Err(external_error("stat", path, error)),
+                },
+                Err(error) if error.kind() == opendal::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(external_error("open", path, error)),
+            },
+        }
+    }
+
+    pub(crate) async fn size(&self, display_path: &str) -> Result<u64> {
+        match self {
+            Self::Local(path) => std::fs::metadata(path)
+                .map(|metadata| metadata.len())
+                .map_err(|error| io_error("stat", display_path, error)),
+            Self::Remote(object) => object
+                .size()
+                .await
+                .map_err(|error| external_error("stat", display_path, error)),
+        }
+    }
+
+    pub(crate) async fn read_range(
+        &self,
+        display_path: &str,
+        range: std::ops::Range<u64>,
+    ) -> Result<Bytes> {
+        if range.end < range.start {
+            return Err(DataFusionError::Execution(format!(
+                "invalid object range {}..{}",
+                range.start, range.end
+            )));
+        }
+        let expected = usize::try_from(range.end - range.start).map_err(|_| {
+            DataFusionError::Execution("object range does not fit usize".to_string())
+        })?;
+        if expected == 0 {
+            return Ok(Bytes::new());
+        }
+        match self {
+            Self::Local(path) => {
+                let mut file = tokio::fs::File::open(path)
+                    .await
+                    .map_err(|error| io_error("open", display_path, error))?;
+                file.seek(std::io::SeekFrom::Start(range.start))
+                    .await
+                    .map_err(|error| io_error("seek", display_path, error))?;
+                let mut bytes = vec![0; expected];
+                file.read_exact(&mut bytes)
+                    .await
+                    .map_err(|error| io_error("read", display_path, error))?;
+                Ok(Bytes::from(bytes))
+            }
+            Self::Remote(object) => object
+                .read_range(range)
+                .await
+                .map_err(|error| external_error("read", display_path, error)),
+        }
+    }
+
+    pub(crate) async fn read_all_bounded(
+        &self,
+        display_path: &str,
+        max_bytes: usize,
+    ) -> Result<Bytes> {
+        let size = self.size(display_path).await?;
+        if size > max_bytes as u64 {
+            return Err(DataFusionError::Plan(format!(
+                "object {} is {size} bytes, exceeding configured limit {max_bytes}",
+                sanitize_location(display_path)
+            )));
+        }
+        self.read_range(display_path, 0..size).await
+    }
+}
+
+fn local_path(path: &str) -> Result<&str> {
+    if let Some(path) = path.strip_prefix("file://") {
+        if path.is_empty() {
+            return Err(DataFusionError::Plan(
+                "local file URL has an empty path".to_string(),
+            ));
+        }
+        Ok(path)
+    } else {
+        Ok(path)
+    }
+}
+
+fn io_error(action: &str, path: &str, error: std::io::Error) -> DataFusionError {
+    DataFusionError::External(Box::new(std::io::Error::new(
+        error.kind(),
+        format!("{action} {}: {error}", sanitize_location(path)),
+    )))
+}
+
+fn external_error(
+    action: &str,
+    path: &str,
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(std::io::Error::other(format!(
+        "{action} {}: {error}",
+        sanitize_location(path)
+    ))))
+}

--- a/datafusion/bio-format-pgen/src/source.rs
+++ b/datafusion/bio-format-pgen/src/source.rs
@@ -14,6 +14,19 @@ pub(crate) enum ObjectAccess {
     Remote(RemoteObject),
 }
 
+pub(crate) enum ObjectRangeReader {
+    Local {
+        file: tokio::fs::File,
+        display_path: String,
+        buffer: Vec<u8>,
+    },
+    Remote {
+        object: RemoteObject,
+        display_path: String,
+        buffer: Bytes,
+    },
+}
+
 impl ObjectAccess {
     pub(crate) async fn open(path: &str, options: &ObjectStorageOptions) -> Result<Self> {
         match get_storage_type(path.to_string()) {
@@ -72,36 +85,25 @@ impl ObjectAccess {
         display_path: &str,
         range: std::ops::Range<u64>,
     ) -> Result<Bytes> {
-        if range.end < range.start {
-            return Err(DataFusionError::Execution(format!(
-                "invalid object range {}..{}",
-                range.start, range.end
-            )));
-        }
-        let expected = usize::try_from(range.end - range.start).map_err(|_| {
-            DataFusionError::Execution("object range does not fit usize".to_string())
-        })?;
-        if expected == 0 {
-            return Ok(Bytes::new());
-        }
+        let mut reader = self.range_reader(display_path).await?;
+        reader.read_range(range).await?;
+        Ok(reader.into_bytes())
+    }
+
+    pub(crate) async fn range_reader(&self, display_path: &str) -> Result<ObjectRangeReader> {
         match self {
-            Self::Local(path) => {
-                let mut file = tokio::fs::File::open(path)
+            Self::Local(path) => Ok(ObjectRangeReader::Local {
+                file: tokio::fs::File::open(path)
                     .await
-                    .map_err(|error| io_error("open", display_path, error))?;
-                file.seek(std::io::SeekFrom::Start(range.start))
-                    .await
-                    .map_err(|error| io_error("seek", display_path, error))?;
-                let mut bytes = vec![0; expected];
-                file.read_exact(&mut bytes)
-                    .await
-                    .map_err(|error| io_error("read", display_path, error))?;
-                Ok(Bytes::from(bytes))
-            }
-            Self::Remote(object) => object
-                .read_range(range)
-                .await
-                .map_err(|error| external_error("read", display_path, error)),
+                    .map_err(|error| io_error("open", display_path, error))?,
+                display_path: display_path.to_string(),
+                buffer: Vec::new(),
+            }),
+            Self::Remote(object) => Ok(ObjectRangeReader::Remote {
+                object: object.clone(),
+                display_path: display_path.to_string(),
+                buffer: Bytes::new(),
+            }),
         }
     }
 
@@ -118,6 +120,66 @@ impl ObjectAccess {
             )));
         }
         self.read_range(display_path, 0..size).await
+    }
+}
+
+impl ObjectRangeReader {
+    pub(crate) async fn read_range(&mut self, range: std::ops::Range<u64>) -> Result<&[u8]> {
+        if range.end < range.start {
+            return Err(DataFusionError::Execution(format!(
+                "invalid object range {}..{}",
+                range.start, range.end
+            )));
+        }
+        let expected = usize::try_from(range.end - range.start).map_err(|_| {
+            DataFusionError::Execution("object range does not fit usize".to_string())
+        })?;
+        if expected == 0 {
+            return match self {
+                Self::Local { buffer, .. } => {
+                    buffer.clear();
+                    Ok(buffer)
+                }
+                Self::Remote { buffer, .. } => {
+                    *buffer = Bytes::new();
+                    Ok(buffer)
+                }
+            };
+        }
+        match self {
+            Self::Local {
+                file,
+                display_path,
+                buffer,
+            } => {
+                file.seek(std::io::SeekFrom::Start(range.start))
+                    .await
+                    .map_err(|error| io_error("seek", display_path, error))?;
+                buffer.resize(expected, 0);
+                file.read_exact(buffer)
+                    .await
+                    .map_err(|error| io_error("read", display_path, error))?;
+                Ok(buffer)
+            }
+            Self::Remote {
+                object,
+                display_path,
+                buffer,
+            } => {
+                *buffer = object
+                    .read_range(range)
+                    .await
+                    .map_err(|error| external_error("read", display_path, error))?;
+                Ok(buffer)
+            }
+        }
+    }
+
+    fn into_bytes(self) -> Bytes {
+        match self {
+            Self::Local { buffer, .. } => Bytes::from(buffer),
+            Self::Remote { buffer, .. } => buffer,
+        }
     }
 }
 
@@ -150,4 +212,25 @@ fn external_error(
         "{action} {}: {error}",
         sanitize_location(path)
     ))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ObjectAccess;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_range_reader_reuses_its_open_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("ranges.bin");
+        std::fs::write(&path, b"0123456789").unwrap();
+        let source = ObjectAccess::Local(path.to_string_lossy().into_owned());
+        let mut reader = source.range_reader("ranges.bin").await.unwrap();
+
+        // An open Unix file remains readable after unlinking. A range reader
+        // that reopened by path for every request would fail this regression.
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(reader.read_range(1..4).await.unwrap(), b"123");
+        assert_eq!(reader.read_range(7..10).await.unwrap(), b"789");
+    }
 }

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -499,7 +499,7 @@ fn plan_payload_partitions(
     let selected_ranges = selected
         .iter()
         .map(|&index| {
-            let record = &fileset.records[index];
+            let record = fileset.records.record(index)?;
             ByteRange::new(record.offset, record.end()).map(|range| (index, range))
         })
         .collect::<Result<Vec<_>>>()?;
@@ -513,23 +513,24 @@ fn plan_payload_partitions(
                 .collect::<Vec<_>>();
             let mut required = owned.iter().copied().collect::<HashSet<_>>();
             for &index in &owned {
-                if let Some(base) = fileset.records[index].ld_base {
+                if let Some(base) = fileset.records.record(index)?.ld_base {
                     required.insert(base);
                 }
             }
             let mut required = required.into_iter().collect::<Vec<_>>();
             required.sort_unstable();
-            let ranges = coalesce_byte_ranges(
-                required.iter().map(|&index| {
-                    let record = &fileset.records[index];
-                    ByteRange {
+            let required_ranges = required
+                .iter()
+                .map(|&index| {
+                    let record = fileset.records.record(index)?;
+                    Ok(ByteRange {
                         start: record.offset,
                         end: record.end(),
-                    }
-                }),
-                max_gap,
-                max_range_bytes,
-            )?;
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let ranges =
+                coalesce_byte_ranges(required_ranges.into_iter(), max_gap, max_range_bytes)?;
             Ok(PgenPartition {
                 owned,
                 required,
@@ -611,7 +612,7 @@ mod tests {
             .unwrap(),
             selected_identities: Arc::new(Vec::new()),
             sample_count: 0,
-            records: Arc::new(vec![
+            records: Arc::new(crate::fileset::RecordIndex::explicit(vec![
                 RecordInfo {
                     offset: 100,
                     length: 10,
@@ -624,7 +625,7 @@ mod tests {
                     record_type: 2,
                     ld_base: Some(0),
                 },
-            ]),
+            ])),
             mode: crate::fileset::PgenMode::Variable,
             companion_bytes: 0,
             header_bytes: 0,

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -232,7 +232,9 @@ impl TableProvider for PgenTableProvider {
         }
 
         let genotype_projected = schema.index_of("genotypes").is_ok();
-        let needs_payload = genotype_projected && !self.fileset.selected_samples.is_empty();
+        let needs_payload = genotype_projected
+            && !self.genotype_fields.is_empty()
+            && !self.fileset.selected_samples.is_empty();
         let selected = Arc::new(selected);
         let partitions = if needs_payload {
             plan_payload_partitions(

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -18,7 +18,7 @@ use datafusion_bio_format_core::genotype::{
     PredicateGuarantee, can_push_limit_below_filters, resolve_genotype_fields,
 };
 use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
-use datafusion_bio_format_core::range_planning::{ByteRange, coalesce_byte_ranges};
+use datafusion_bio_format_core::range_planning::{ByteRange, try_coalesce_sorted_byte_ranges};
 
 use crate::fileset::{PGEN_SPEC_BASELINE, PgenFileset};
 use crate::filter::{evaluate_exact_filter, supports_exact_filter};
@@ -519,18 +519,17 @@ fn plan_payload_partitions(
             }
             let mut required = required.into_iter().collect::<Vec<_>>();
             required.sort_unstable();
-            let required_ranges = required
-                .iter()
-                .map(|&index| {
+            let ranges = try_coalesce_sorted_byte_ranges(
+                required.iter().map(|&index| {
                     let record = fileset.records.record(index)?;
                     Ok(ByteRange {
                         start: record.offset,
                         end: record.end(),
                     })
-                })
-                .collect::<Result<Vec<_>>>()?;
-            let ranges =
-                coalesce_byte_ranges(required_ranges.into_iter(), max_gap, max_range_bytes)?;
+                }),
+                max_gap,
+                max_range_bytes,
+            )?;
             Ok(PgenPartition {
                 owned,
                 required,

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -1,0 +1,622 @@
+use std::any::Any;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
+use datafusion_bio_format_core::COORDINATE_SYSTEM_METADATA_KEY;
+use datafusion_bio_format_core::genotype::{
+    CoordinateSystem, GENOTYPE_ALLELE_ORDER_KEY, GENOTYPE_COUNTED_ALLELE_KEY,
+    GENOTYPE_OUTPUT_MODE_KEY, GenotypeMetric, GenotypeScanMetrics, MissingSamplePolicy,
+    PredicateGuarantee, can_push_limit_below_filters, resolve_genotype_fields,
+};
+use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
+use datafusion_bio_format_core::range_planning::{ByteRange, coalesce_byte_ranges};
+
+use crate::fileset::{PGEN_SPEC_BASELINE, PgenFileset};
+use crate::filter::{evaluate_exact_filter, supports_exact_filter};
+use crate::physical_exec::{PgenExec, PgenPartition};
+
+/// Field metadata containing selected original PSAM identities as JSON.
+pub const PGEN_SAMPLE_IDENTITIES_KEY: &str = "bio.pgen.sample_identities";
+
+/// Policy used to construct selectable sample names from PSAM identifiers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PsamIdMode {
+    /// Use IID alone and reject duplicate selected IIDs.
+    #[default]
+    Iid,
+    /// Use an escaped `FID:IID` name.
+    FidIid,
+    /// Use an escaped `FID:IID:SID` name.
+    FidIidSid,
+}
+
+/// Read and planning options for a PGEN/PVAR/PSAM fileset.
+#[derive(Debug, Clone)]
+pub struct PgenReadOptions {
+    /// Explicit PVAR location; `.pvar` then `.pvar.zst` are tried when absent.
+    pub pvar_path: Option<String>,
+    /// Explicit PSAM location; the shared-basename `.psam` is used when absent.
+    pub psam_path: Option<String>,
+    /// Explicit external PGEN index location.
+    pub pgi_path: Option<String>,
+    /// Requested sample names in output order, or all samples when absent.
+    pub samples: Option<Vec<String>>,
+    /// Behavior for requested sample names absent from PSAM.
+    pub missing_sample_policy: MissingSamplePolicy,
+    /// PSAM identifier policy.
+    pub psam_id_mode: PsamIdMode,
+    /// Selected genotype children from `GT`, `PHASED`, `DS`, and `HDS`.
+    pub genotype_fields: Option<Vec<String>>,
+    /// Output coordinate presentation.
+    pub coordinate_system: CoordinateSystem,
+    /// Credentials and transport configuration for remote objects.
+    pub object_storage_options: Option<ObjectStorageOptions>,
+    /// Maximum compressed bytes accepted for either text companion.
+    pub max_companion_bytes: usize,
+    /// Maximum decoded bytes accepted for PVAR.
+    pub max_decompressed_companion_bytes: usize,
+    /// Maximum bytes accepted for a PGEN or PGI header.
+    pub max_header_bytes: usize,
+    /// Maximum encoded bytes accepted for one PGEN variant record.
+    pub max_record_bytes: u64,
+    /// Maximum accepted PVAR row count.
+    pub max_variants: usize,
+    /// Maximum accepted PSAM row count.
+    pub max_samples: usize,
+    /// Maximum unselected byte gap bridged by one PGEN range.
+    pub max_range_gap: u64,
+    /// Maximum size of a coalesced PGEN range.
+    pub max_range_bytes: u64,
+    /// Soft target for genotype bytes in one RecordBatch.
+    pub batch_soft_byte_limit: usize,
+}
+
+impl Default for PgenReadOptions {
+    fn default() -> Self {
+        Self {
+            pvar_path: None,
+            psam_path: None,
+            pgi_path: None,
+            samples: None,
+            missing_sample_policy: MissingSamplePolicy::Error,
+            psam_id_mode: PsamIdMode::Iid,
+            genotype_fields: None,
+            coordinate_system: CoordinateSystem::ZeroBasedHalfOpen,
+            object_storage_options: None,
+            max_companion_bytes: 512 * 1024 * 1024,
+            max_decompressed_companion_bytes: 1024 * 1024 * 1024,
+            max_header_bytes: 1024 * 1024 * 1024,
+            max_record_bytes: 512 * 1024 * 1024,
+            max_variants: 100_000_000,
+            max_samples: 10_000_000,
+            max_range_gap: 0,
+            max_range_bytes: 16 * 1024 * 1024,
+            batch_soft_byte_limit: 64 * 1024 * 1024,
+        }
+    }
+}
+
+/// Read-only DataFusion table provider for a PLINK 2 fileset.
+#[derive(Clone, Debug)]
+pub struct PgenTableProvider {
+    pub(crate) fileset: Arc<PgenFileset>,
+    schema: SchemaRef,
+    options: PgenReadOptions,
+    genotype_fields: Arc<Vec<String>>,
+}
+
+impl PgenTableProvider {
+    /// Opens and validates a local or remote PGEN/PVAR/PSAM fileset.
+    pub async fn try_new(pgen_path: impl Into<String>, options: PgenReadOptions) -> Result<Self> {
+        validate_options(&options)?;
+        let available = ["GT", "PHASED", "DS", "HDS"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let selected = resolve_genotype_fields(&available, options.genotype_fields.as_deref())?;
+        let genotype_fields = Arc::new(selected.names().to_vec());
+        let fileset = Arc::new(PgenFileset::open(pgen_path.into(), &options).await?);
+        let schema = build_schema(&fileset, &genotype_fields, &options)?;
+        Ok(Self {
+            fileset,
+            schema,
+            options,
+            genotype_fields,
+        })
+    }
+
+    /// Returns the resolved PVAR companion location.
+    pub fn pvar_path(&self) -> &str {
+        &self.fileset.pvar_path
+    }
+
+    /// Returns the resolved PSAM companion location.
+    pub fn psam_path(&self) -> &str {
+        &self.fileset.psam_path
+    }
+
+    /// Returns the resolved PGI location when the PGEN uses an external index.
+    pub fn pgi_path(&self) -> Option<&str> {
+        self.fileset.pgi_path.as_deref()
+    }
+
+    /// Returns selected sample names in emitted list order.
+    pub fn sample_names(&self) -> &[String] {
+        self.fileset.selected_samples.names()
+    }
+}
+
+#[async_trait]
+impl TableProvider for PgenTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if supports_exact_filter(filter) {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let schema = project_schema(&self.schema, projection)?;
+        let guarantees = filters
+            .iter()
+            .map(|filter| {
+                if supports_exact_filter(filter) {
+                    PredicateGuarantee::Exact
+                } else {
+                    PredicateGuarantee::Unsupported
+                }
+            })
+            .collect::<Vec<_>>();
+        let exact_filters = filters
+            .iter()
+            .filter(|filter| supports_exact_filter(filter))
+            .collect::<Vec<_>>();
+        let mut selected = self
+            .fileset
+            .variants
+            .iter()
+            .enumerate()
+            .filter(|(_, variant)| {
+                exact_filters
+                    .iter()
+                    .all(|filter| evaluate_exact_filter(variant, filter))
+            })
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if can_push_limit_below_filters(&guarantees)
+            && let Some(limit) = limit
+        {
+            selected.truncate(limit);
+        }
+        if selected.is_empty() {
+            return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                schema,
+            )));
+        }
+
+        let genotype_projected = schema.index_of("genotypes").is_ok();
+        let needs_payload = genotype_projected && !self.fileset.selected_samples.is_empty();
+        let partitions = if needs_payload {
+            plan_payload_partitions(
+                &selected,
+                &self.fileset,
+                state.config().target_partitions(),
+                self.options.max_range_gap,
+                self.options.max_range_bytes,
+            )?
+        } else {
+            plan_metadata_partitions(&selected, state.config().target_partitions())
+        };
+        let metrics = Arc::new(GenotypeScanMetrics::default());
+        metrics.add(GenotypeMetric::PrimaryBytesRead, self.fileset.header_bytes);
+        metrics.add(
+            GenotypeMetric::CompanionBytesRead,
+            self.fileset.companion_bytes,
+        );
+        metrics.add(
+            GenotypeMetric::MetadataCandidates,
+            self.fileset.variants.len() as u64,
+        );
+        metrics.add(GenotypeMetric::SelectedVariants, selected.len() as u64);
+        metrics.add(
+            GenotypeMetric::SamplesRequested,
+            self.fileset.selected_samples.source_indices().len() as u64,
+        );
+        if !needs_payload {
+            metrics.add(GenotypeMetric::PayloadsSkipped, selected.len() as u64);
+        }
+        let partition_count = partitions.len();
+        Ok(Arc::new(PgenExec {
+            fileset: self.fileset.clone(),
+            schema: schema.clone(),
+            partitions: Arc::new(partitions),
+            genotype_fields: self.genotype_fields.clone(),
+            metrics,
+            batch_soft_byte_limit: self.options.batch_soft_byte_limit,
+            cache: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(partition_count),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )),
+        }))
+    }
+}
+
+fn validate_options(options: &PgenReadOptions) -> Result<()> {
+    for (name, value) in [
+        ("max_companion_bytes", options.max_companion_bytes),
+        (
+            "max_decompressed_companion_bytes",
+            options.max_decompressed_companion_bytes,
+        ),
+        ("max_header_bytes", options.max_header_bytes),
+        ("max_variants", options.max_variants),
+        ("max_samples", options.max_samples),
+        ("batch_soft_byte_limit", options.batch_soft_byte_limit),
+    ] {
+        if value == 0 {
+            return Err(DataFusionError::Plan(format!(
+                "{name} must be greater than zero"
+            )));
+        }
+    }
+    if options.max_range_bytes == 0 {
+        return Err(DataFusionError::Plan(
+            "max_range_bytes must be greater than zero".to_string(),
+        ));
+    }
+    if options.max_record_bytes == 0 {
+        return Err(DataFusionError::Plan(
+            "max_record_bytes must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn build_schema(
+    fileset: &PgenFileset,
+    genotype_fields: &[String],
+    options: &PgenReadOptions,
+) -> Result<SchemaRef> {
+    let sample_metadata = fileset.selected_samples.field_metadata();
+    let mut children = Vec::with_capacity(genotype_fields.len());
+    for name in genotype_fields {
+        let field = match name.as_str() {
+            "GT" => Field::new(
+                "GT",
+                DataType::List(Arc::new(Field::new(
+                    "sample",
+                    DataType::List(Arc::new(Field::new("allele", DataType::UInt16, false))),
+                    true,
+                ))),
+                false,
+            )
+            .with_metadata(HashMap::from([
+                (
+                    GENOTYPE_OUTPUT_MODE_KEY.to_string(),
+                    "raw_alleles".to_string(),
+                ),
+                (
+                    GENOTYPE_ALLELE_ORDER_KEY.to_string(),
+                    "PVAR REF=0, ALT source order=1..n".to_string(),
+                ),
+            ])),
+            "PHASED" => Field::new(
+                "PHASED",
+                DataType::List(Arc::new(Field::new("sample", DataType::Boolean, true))),
+                false,
+            ),
+            "DS" => Field::new(
+                "DS",
+                DataType::List(Arc::new(Field::new("sample", DataType::Float32, true))),
+                false,
+            )
+            .with_metadata(HashMap::from([
+                (GENOTYPE_OUTPUT_MODE_KEY.to_string(), "dosage".to_string()),
+                (
+                    GENOTYPE_COUNTED_ALLELE_KEY.to_string(),
+                    "PVAR ALT allele index 1".to_string(),
+                ),
+                (
+                    "bio.pgen.dosage_scale".to_string(),
+                    "uint16/16384".to_string(),
+                ),
+            ])),
+            "HDS" => Field::new(
+                "HDS",
+                DataType::List(Arc::new(Field::new(
+                    "sample",
+                    DataType::List(Arc::new(Field::new("haplotype", DataType::Float32, false))),
+                    true,
+                ))),
+                false,
+            )
+            .with_metadata(HashMap::from([(
+                GENOTYPE_COUNTED_ALLELE_KEY.to_string(),
+                "PVAR ALT allele index 1".to_string(),
+            )])),
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "unsupported PGEN genotype field {name}"
+                )));
+            }
+        };
+        children.push(field);
+    }
+    let identities =
+        serde_json::to_string(fileset.selected_identities.as_ref()).map_err(|error| {
+            DataFusionError::Plan(format!("failed to serialize PSAM identities: {error}"))
+        })?;
+    let mut genotype_metadata = sample_metadata;
+    genotype_metadata.insert(PGEN_SAMPLE_IDENTITIES_KEY.to_string(), identities);
+    let genotypes = Field::new("genotypes", DataType::Struct(Fields::from(children)), false)
+        .with_metadata(genotype_metadata);
+    Ok(Arc::new(Schema::new_with_metadata(
+        vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt64, false),
+            Field::new("end", DataType::UInt64, false),
+            Field::new("id", DataType::Utf8, true),
+            Field::new("ref", DataType::Utf8, false),
+            Field::new(
+                "alt",
+                DataType::List(Arc::new(Field::new("allele", DataType::Utf8, false))),
+                false,
+            ),
+            genotypes,
+        ],
+        HashMap::from([
+            (
+                COORDINATE_SYSTEM_METADATA_KEY.to_string(),
+                options.coordinate_system.metadata_value().to_string(),
+            ),
+            (
+                "bio.pgen.storage_mode".to_string(),
+                format!("0x{:02x}", fileset.mode.byte()),
+            ),
+            (
+                "bio.pgen.index".to_string(),
+                if fileset.pgi_path.is_some() {
+                    "external"
+                } else {
+                    "embedded"
+                }
+                .to_string(),
+            ),
+            (
+                "bio.pgen.specification_baseline".to_string(),
+                PGEN_SPEC_BASELINE.to_string(),
+            ),
+        ]),
+    )))
+}
+
+fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> Result<SchemaRef> {
+    match projection {
+        Some(indices) => Ok(Arc::new(Schema::new_with_metadata(
+            indices
+                .iter()
+                .map(|&index| {
+                    schema.fields().get(index).cloned().ok_or_else(|| {
+                        DataFusionError::Plan(format!(
+                            "PGEN projection column index {index} is out of bounds"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+            schema.metadata().clone(),
+        ))),
+        None => Ok(schema.clone()),
+    }
+}
+
+fn plan_payload_partitions(
+    selected: &[usize],
+    fileset: &PgenFileset,
+    target_partitions: usize,
+    max_gap: u64,
+    max_range_bytes: u64,
+) -> Result<Vec<PgenPartition>> {
+    let selected_ranges = selected
+        .iter()
+        .map(|&index| {
+            let record = &fileset.records[index];
+            ByteRange::new(record.offset, record.end()).map(|range| (index, range))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let assignments = contiguous_byte_partitions(&selected_ranges, target_partitions)?;
+    assignments
+        .into_iter()
+        .map(|assignment| {
+            let owned = assignment
+                .iter()
+                .map(|(index, _)| *index)
+                .collect::<Vec<_>>();
+            let mut required = owned.iter().copied().collect::<HashSet<_>>();
+            for &index in &owned {
+                if let Some(base) = fileset.records[index].ld_base {
+                    required.insert(base);
+                }
+            }
+            let mut required = required.into_iter().collect::<Vec<_>>();
+            required.sort_unstable();
+            let ranges = coalesce_byte_ranges(
+                required.iter().map(|&index| {
+                    let record = &fileset.records[index];
+                    ByteRange {
+                        start: record.offset,
+                        end: record.end(),
+                    }
+                }),
+                max_gap,
+                max_range_bytes,
+            )?;
+            Ok(PgenPartition {
+                owned,
+                required,
+                ranges,
+            })
+        })
+        .collect()
+}
+
+fn contiguous_byte_partitions(
+    ranges: &[(usize, ByteRange)],
+    target_partitions: usize,
+) -> Result<Vec<Vec<(usize, ByteRange)>>> {
+    if ranges.is_empty() {
+        return Ok(Vec::new());
+    }
+    let partition_count = target_partitions.max(1).min(ranges.len());
+    let mut remaining_bytes = ranges.iter().try_fold(0_u64, |total, (_, range)| {
+        total.checked_add(range.len()).ok_or_else(|| {
+            DataFusionError::Plan("PGEN selected payload byte count overflowed".to_string())
+        })
+    })?;
+    let mut cursor = 0;
+    let mut partitions = Vec::with_capacity(partition_count);
+    for partition_index in 0..partition_count {
+        let remaining_partitions = partition_count - partition_index;
+        let max_take = ranges.len() - cursor - (remaining_partitions - 1);
+        let target_bytes = remaining_bytes.div_ceil(remaining_partitions as u64);
+        let mut bytes = 0_u64;
+        let mut take = 0;
+        while take < max_take && (take == 0 || bytes < target_bytes) {
+            bytes = bytes
+                .checked_add(ranges[cursor + take].1.len())
+                .ok_or_else(|| {
+                    DataFusionError::Plan("PGEN partition byte count overflowed".to_string())
+                })?;
+            take += 1;
+        }
+        partitions.push(ranges[cursor..cursor + take].to_vec());
+        cursor += take;
+        remaining_bytes -= bytes;
+    }
+    debug_assert_eq!(cursor, ranges.len());
+    Ok(partitions)
+}
+
+fn plan_metadata_partitions(selected: &[usize], target_partitions: usize) -> Vec<PgenPartition> {
+    let partition_count = target_partitions.max(1).min(selected.len());
+    let chunk_size = selected.len().div_ceil(partition_count);
+    selected
+        .chunks(chunk_size)
+        .map(|variants| PgenPartition {
+            owned: variants.to_vec(),
+            required: Vec::new(),
+            ranges: Vec::new(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fileset::RecordInfo;
+
+    #[test]
+    fn plans_ld_dependencies_without_transferring_ownership() {
+        let fileset = PgenFileset {
+            pgen_path: String::new(),
+            pvar_path: String::new(),
+            psam_path: String::new(),
+            pgi_path: None,
+            source: crate::source::ObjectAccess::Local(String::new()),
+            variants: Arc::new(Vec::new()),
+            selected_samples: datafusion_bio_format_core::genotype::resolve_samples(
+                &[],
+                None,
+                MissingSamplePolicy::Error,
+            )
+            .unwrap(),
+            selected_identities: Arc::new(Vec::new()),
+            sample_count: 0,
+            records: Arc::new(vec![
+                RecordInfo {
+                    offset: 100,
+                    length: 10,
+                    record_type: 0,
+                    ld_base: None,
+                },
+                RecordInfo {
+                    offset: 110,
+                    length: 4,
+                    record_type: 2,
+                    ld_base: Some(0),
+                },
+            ]),
+            mode: crate::fileset::PgenMode::Variable,
+            companion_bytes: 0,
+            header_bytes: 0,
+        };
+        let partitions = plan_payload_partitions(&[1], &fileset, 4, 0, 1024).unwrap();
+        assert_eq!(partitions[0].owned, vec![1]);
+        assert_eq!(partitions[0].required, vec![0, 1]);
+    }
+
+    #[test]
+    fn preserves_locality_while_balancing_equal_records() {
+        let ranges = (0..8)
+            .map(|index| {
+                (
+                    index,
+                    ByteRange {
+                        start: index as u64 * 10,
+                        end: (index as u64 + 1) * 10,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let partitions = contiguous_byte_partitions(&ranges, 4).unwrap();
+        assert_eq!(
+            partitions
+                .iter()
+                .map(|partition| {
+                    partition
+                        .iter()
+                        .map(|(index, _)| *index)
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3], vec![4, 5], vec![6, 7]]
+        );
+    }
+}

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -54,7 +54,7 @@ pub struct PgenReadOptions {
     pub missing_sample_policy: MissingSamplePolicy,
     /// PSAM identifier policy.
     pub psam_id_mode: PsamIdMode,
-    /// Selected genotype children from `GT`, `PHASED`, `DS`, and `HDS`.
+    /// Selected genotype children from `GT`, `PHASED`, `DS`, `DS_STORED`, and `HDS`.
     pub genotype_fields: Option<Vec<String>>,
     /// Output coordinate presentation.
     pub coordinate_system: CoordinateSystem,
@@ -118,7 +118,7 @@ impl PgenTableProvider {
     /// Opens and validates a local or remote PGEN/PVAR/PSAM fileset.
     pub async fn try_new(pgen_path: impl Into<String>, options: PgenReadOptions) -> Result<Self> {
         validate_options(&options)?;
-        let available = ["GT", "PHASED", "DS", "HDS"]
+        let available = ["GT", "PHASED", "DS", "DS_STORED", "HDS"]
             .into_iter()
             .map(str::to_string)
             .collect::<Vec<_>>();
@@ -323,7 +323,10 @@ fn build_schema(
                 "GT",
                 DataType::List(Arc::new(Field::new(
                     "sample",
-                    DataType::List(Arc::new(Field::new("allele", DataType::UInt16, false))),
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("allele", DataType::UInt16, false)),
+                        2,
+                    ),
                     true,
                 ))),
                 false,
@@ -336,6 +339,10 @@ fn build_schema(
                 (
                     GENOTYPE_ALLELE_ORDER_KEY.to_string(),
                     "PVAR REF=0, ALT source order=1..n".to_string(),
+                ),
+                (
+                    "bio.pgen.ploidy_semantics".to_string(),
+                    "encoded_diploid".to_string(),
                 ),
             ])),
             "PHASED" => Field::new(
@@ -350,6 +357,25 @@ fn build_schema(
             )
             .with_metadata(HashMap::from([
                 (GENOTYPE_OUTPUT_MODE_KEY.to_string(), "dosage".to_string()),
+                (
+                    GENOTYPE_COUNTED_ALLELE_KEY.to_string(),
+                    "PVAR ALT allele index 1".to_string(),
+                ),
+                (
+                    "bio.pgen.dosage_scale".to_string(),
+                    "uint16/16384".to_string(),
+                ),
+            ])),
+            "DS_STORED" => Field::new(
+                "DS_STORED",
+                DataType::List(Arc::new(Field::new("sample", DataType::Float32, true))),
+                false,
+            )
+            .with_metadata(HashMap::from([
+                (
+                    GENOTYPE_OUTPUT_MODE_KEY.to_string(),
+                    "stored_dosage".to_string(),
+                ),
                 (
                     GENOTYPE_COUNTED_ALLELE_KEY.to_string(),
                     "PVAR ALT allele index 1".to_string(),

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -220,15 +220,11 @@ impl TableProvider for PgenTableProvider {
             })
             .map(|(index, _)| index)
             .collect::<Vec<_>>();
+        let exact_filter_rejections = (self.fileset.variants.len() - selected.len()) as u64;
         if can_push_limit_below_filters(&guarantees)
             && let Some(limit) = limit
         {
             selected.truncate(limit);
-        }
-        if selected.is_empty() {
-            return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
-                schema,
-            )));
         }
 
         let genotype_projected = schema.index_of("genotypes").is_ok();
@@ -236,7 +232,14 @@ impl TableProvider for PgenTableProvider {
             && !self.genotype_fields.is_empty()
             && !self.fileset.selected_samples.is_empty();
         let selected = Arc::new(selected);
-        let partitions = if needs_payload {
+        let partitions = if selected.is_empty() {
+            vec![PgenPartition {
+                selection: selected.clone(),
+                owned: 0..0,
+                dependencies: Vec::new(),
+                ranges: Vec::new(),
+            }]
+        } else if needs_payload {
             plan_payload_partitions(
                 selected.clone(),
                 &self.fileset,
@@ -267,6 +270,10 @@ impl TableProvider for PgenTableProvider {
             self.fileset.variants.len() as u64,
         );
         metrics.add(GenotypeMetric::SelectedVariants, selected.len() as u64);
+        metrics.add(
+            GenotypeMetric::ExactFilterRejections,
+            exact_filter_rejections,
+        );
         metrics.add(
             GenotypeMetric::SamplesRequested,
             self.fileset.selected_samples.source_indices().len() as u64,

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::ops::Range;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -232,16 +233,17 @@ impl TableProvider for PgenTableProvider {
 
         let genotype_projected = schema.index_of("genotypes").is_ok();
         let needs_payload = genotype_projected && !self.fileset.selected_samples.is_empty();
+        let selected = Arc::new(selected);
         let partitions = if needs_payload {
             plan_payload_partitions(
-                &selected,
+                selected.clone(),
                 &self.fileset,
                 state.config().target_partitions(),
                 self.options.max_range_gap,
                 self.options.max_range_bytes,
             )?
         } else {
-            plan_metadata_partitions(&selected, state.config().target_partitions())
+            plan_metadata_partitions(selected.clone(), state.config().target_partitions())
         };
         let metrics = Arc::new(GenotypeScanMetrics::default());
         // CoalescedRanges describes the planned post-coalescing ranges;
@@ -490,37 +492,37 @@ fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> Result
 }
 
 fn plan_payload_partitions(
-    selected: &[usize],
+    selected: Arc<Vec<usize>>,
     fileset: &PgenFileset,
     target_partitions: usize,
     max_gap: u64,
     max_range_bytes: u64,
 ) -> Result<Vec<PgenPartition>> {
-    let selected_ranges = selected
-        .iter()
-        .map(|&index| {
-            let record = fileset.records.record(index)?;
-            ByteRange::new(record.offset, record.end()).map(|range| (index, range))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let assignments = contiguous_byte_partitions(&selected_ranges, target_partitions)?;
+    let assignments = contiguous_partition_bounds(&selected, target_partitions, |index| {
+        Ok(u64::from(fileset.records.record(index)?.length))
+    })?;
     assignments
         .into_iter()
-        .map(|assignment| {
-            let owned = assignment
-                .iter()
-                .map(|(index, _)| *index)
-                .collect::<Vec<_>>();
-            let mut required = owned.iter().copied().collect::<HashSet<_>>();
-            for &index in &owned {
-                if let Some(base) = fileset.records.record(index)?.ld_base {
-                    required.insert(base);
+        .map(|owned| {
+            let owned_indices = &selected[owned.clone()];
+            let mut dependencies = Vec::new();
+            for &index in owned_indices {
+                if let Some(base) = fileset.records.record(index)?.ld_base
+                    && owned_indices.binary_search(&base).is_err()
+                {
+                    dependencies.push(base);
                 }
             }
-            let mut required = required.into_iter().collect::<Vec<_>>();
-            required.sort_unstable();
+            dependencies.sort_unstable();
+            dependencies.dedup();
+            let mut partition = PgenPartition {
+                selection: selected.clone(),
+                owned,
+                dependencies,
+                ranges: Vec::new(),
+            };
             let ranges = try_coalesce_sorted_byte_ranges(
-                required.iter().map(|&index| {
+                partition.required().map(|index| {
                     let record = fileset.records.record(index)?;
                     Ok(ByteRange {
                         start: record.offset,
@@ -530,25 +532,23 @@ fn plan_payload_partitions(
                 max_gap,
                 max_range_bytes,
             )?;
-            Ok(PgenPartition {
-                owned,
-                required,
-                ranges,
-            })
+            partition.ranges = ranges;
+            Ok(partition)
         })
         .collect()
 }
 
-fn contiguous_byte_partitions(
-    ranges: &[(usize, ByteRange)],
+fn contiguous_partition_bounds(
+    selected: &[usize],
     target_partitions: usize,
-) -> Result<Vec<Vec<(usize, ByteRange)>>> {
-    if ranges.is_empty() {
+    mut record_bytes: impl FnMut(usize) -> Result<u64>,
+) -> Result<Vec<Range<usize>>> {
+    if selected.is_empty() {
         return Ok(Vec::new());
     }
-    let partition_count = target_partitions.max(1).min(ranges.len());
-    let mut remaining_bytes = ranges.iter().try_fold(0_u64, |total, (_, range)| {
-        total.checked_add(range.len()).ok_or_else(|| {
+    let partition_count = target_partitions.max(1).min(selected.len());
+    let mut remaining_bytes = selected.iter().try_fold(0_u64, |total, &index| {
+        total.checked_add(record_bytes(index)?).ok_or_else(|| {
             DataFusionError::Plan("PGEN selected payload byte count overflowed".to_string())
         })
     })?;
@@ -556,34 +556,38 @@ fn contiguous_byte_partitions(
     let mut partitions = Vec::with_capacity(partition_count);
     for partition_index in 0..partition_count {
         let remaining_partitions = partition_count - partition_index;
-        let max_take = ranges.len() - cursor - (remaining_partitions - 1);
+        let max_take = selected.len() - cursor - (remaining_partitions - 1);
         let target_bytes = remaining_bytes.div_ceil(remaining_partitions as u64);
         let mut bytes = 0_u64;
         let mut take = 0;
         while take < max_take && (take == 0 || bytes < target_bytes) {
             bytes = bytes
-                .checked_add(ranges[cursor + take].1.len())
+                .checked_add(record_bytes(selected[cursor + take])?)
                 .ok_or_else(|| {
                     DataFusionError::Plan("PGEN partition byte count overflowed".to_string())
                 })?;
             take += 1;
         }
-        partitions.push(ranges[cursor..cursor + take].to_vec());
+        partitions.push(cursor..cursor + take);
         cursor += take;
         remaining_bytes -= bytes;
     }
-    debug_assert_eq!(cursor, ranges.len());
+    debug_assert_eq!(cursor, selected.len());
     Ok(partitions)
 }
 
-fn plan_metadata_partitions(selected: &[usize], target_partitions: usize) -> Vec<PgenPartition> {
+fn plan_metadata_partitions(
+    selected: Arc<Vec<usize>>,
+    target_partitions: usize,
+) -> Vec<PgenPartition> {
     let partition_count = target_partitions.max(1).min(selected.len());
     let chunk_size = selected.len().div_ceil(partition_count);
-    selected
-        .chunks(chunk_size)
-        .map(|variants| PgenPartition {
-            owned: variants.to_vec(),
-            required: Vec::new(),
+    (0..selected.len())
+        .step_by(chunk_size)
+        .map(|start| PgenPartition {
+            selection: selected.clone(),
+            owned: start..(start + chunk_size).min(selected.len()),
+            dependencies: Vec::new(),
             ranges: Vec::new(),
         })
         .collect()
@@ -629,34 +633,19 @@ mod tests {
             companion_bytes: 0,
             header_bytes: 0,
         };
-        let partitions = plan_payload_partitions(&[1], &fileset, 4, 0, 1024).unwrap();
-        assert_eq!(partitions[0].owned, vec![1]);
-        assert_eq!(partitions[0].required, vec![0, 1]);
+        let partitions = plan_payload_partitions(Arc::new(vec![1]), &fileset, 4, 0, 1024).unwrap();
+        assert_eq!(partitions[0].owned(), &[1]);
+        assert_eq!(partitions[0].required().collect::<Vec<_>>(), vec![0, 1]);
     }
 
     #[test]
     fn preserves_locality_while_balancing_equal_records() {
-        let ranges = (0..8)
-            .map(|index| {
-                (
-                    index,
-                    ByteRange {
-                        start: index as u64 * 10,
-                        end: (index as u64 + 1) * 10,
-                    },
-                )
-            })
-            .collect::<Vec<_>>();
-        let partitions = contiguous_byte_partitions(&ranges, 4).unwrap();
+        let selected = (0..8).collect::<Vec<_>>();
+        let partitions = contiguous_partition_bounds(&selected, 4, |_| Ok(10)).unwrap();
         assert_eq!(
             partitions
                 .iter()
-                .map(|partition| {
-                    partition
-                        .iter()
-                        .map(|(index, _)| *index)
-                        .collect::<Vec<_>>()
-                })
+                .map(|partition| selected[partition.clone()].to_vec())
                 .collect::<Vec<_>>(),
             vec![vec![0, 1], vec![2, 3], vec![4, 5], vec![6, 7]]
         );

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -62,7 +62,7 @@ pub struct PgenReadOptions {
     pub object_storage_options: Option<ObjectStorageOptions>,
     /// Maximum compressed bytes accepted for either text companion.
     pub max_companion_bytes: usize,
-    /// Maximum decoded bytes accepted for PVAR.
+    /// Maximum decoded bytes accepted for either text companion.
     pub max_decompressed_companion_bytes: usize,
     /// Maximum bytes accepted for a PGEN or PGI header.
     pub max_header_bytes: usize,
@@ -244,6 +244,15 @@ impl TableProvider for PgenTableProvider {
             plan_metadata_partitions(&selected, state.config().target_partitions())
         };
         let metrics = Arc::new(GenotypeScanMetrics::default());
+        // CoalescedRanges describes the planned post-coalescing ranges;
+        // RangeRequests is incremented only when execution issues each read.
+        metrics.add(
+            GenotypeMetric::CoalescedRanges,
+            partitions
+                .iter()
+                .map(|partition| partition.ranges.len() as u64)
+                .sum(),
+        );
         metrics.add(GenotypeMetric::PrimaryBytesRead, self.fileset.header_bytes);
         metrics.add(
             GenotypeMetric::CompanionBytesRead,
@@ -349,7 +358,11 @@ fn build_schema(
                 "PHASED",
                 DataType::List(Arc::new(Field::new("sample", DataType::Boolean, true))),
                 false,
-            ),
+            )
+            .with_metadata(HashMap::from([(
+                "bio.pgen.phase_semantics".to_string(),
+                "null=missing call, false=unphased, true=phased".to_string(),
+            )])),
             "DS" => Field::new(
                 "DS",
                 DataType::List(Arc::new(Field::new("sample", DataType::Float32, true))),
@@ -389,7 +402,10 @@ fn build_schema(
                 "HDS",
                 DataType::List(Arc::new(Field::new(
                     "sample",
-                    DataType::List(Arc::new(Field::new("haplotype", DataType::Float32, false))),
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("haplotype", DataType::Float32, false)),
+                        2,
+                    ),
                     true,
                 ))),
                 false,

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -271,6 +271,36 @@ fn variable_fixture(
     }
 }
 
+fn variable_fixture_without_header_allele_counts(
+    record_type: u8,
+    record: &[u8],
+    allele_count: usize,
+) -> Fixture {
+    assert!(record.len() < 256);
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let pgen = root.join("cohort.pgen");
+    let (pvar, psam) = write_metadata(root, &[allele_count], 4);
+    let header_len = 12 + 8 + 1 + 1;
+    let mut bytes = vec![0x6c, 0x1b, 0x10];
+    bytes.extend(1_u32.to_le_bytes());
+    bytes.extend(4_u32.to_le_bytes());
+    // 8-bit record type, 1-byte record length, allele counts supplied by PVAR,
+    // and no provisional reference alleles.
+    bytes.push(0x44);
+    bytes.extend((header_len as u64).to_le_bytes());
+    bytes.push(record_type);
+    bytes.push(record.len() as u8);
+    bytes.extend(record);
+    fs::write(&pgen, bytes).unwrap();
+    Fixture {
+        _temp: temp,
+        pgen,
+        pvar,
+        psam,
+    }
+}
+
 fn fixed_fixture(mode: u8) -> Fixture {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();
@@ -823,6 +853,39 @@ async fn reads_zstd_pvar_and_rejects_hybrid_or_inconsistent_filesets() {
         .unwrap_err()
         .to_string();
     assert!(error.contains("sample count"), "{error}");
+
+    let fixture = variable_fixture_without_header_allele_counts(
+        0x08,
+        &[0b11_00_10_01, 0x00, 0x01, 0x01, 0x00],
+        3,
+    );
+    PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+
+    for mode in [2, 3, 4] {
+        let fixture = fixed_fixture(mode);
+        let pvar = fs::read_to_string(&fixture.pvar)
+            .unwrap()
+            .replacen("\tA1\n", "\tA1,A2\n", 1);
+        fs::write(&fixture.pvar, pvar).unwrap();
+        let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("biallelic-only"), "{error}");
+    }
+
+    let fixture = plink1_mode_fixture();
+    let pvar = fs::read_to_string(&fixture.pvar)
+        .unwrap()
+        .replacen("\tA1\n", "\tA1,A2\n", 1);
+    fs::write(&fixture.pvar, pvar).unwrap();
+    let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("biallelic-only"), "{error}");
 
     let temp = tempfile::tempdir().unwrap();
     let pgen = temp.path().join("hybrid.pgen");

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -815,6 +815,10 @@ async fn applies_exact_pvar_pushdowns_limits_and_metadata_projection() {
         2
     );
     assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::ExactFilterRejections as usize].1,
+        1
+    );
+    assert_eq!(
         exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
         0
     );
@@ -846,6 +850,31 @@ async fn applies_exact_pvar_pushdowns_limits_and_metadata_projection() {
     assert_eq!(
         count_exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
         0
+    );
+    assert_eq!(
+        count_exec.metrics_snapshot()[GenotypeMetric::ExactFilterRejections as usize].1,
+        7
+    );
+
+    let rejected_plan = provider
+        .scan(
+            &state,
+            Some(&Vec::new()),
+            &[col("id").eq(lit("absent"))],
+            None,
+        )
+        .await
+        .unwrap();
+    let rejected_exec = rejected_plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    assert!(
+        collect(rejected_plan.clone(), context.task_ctx())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        rejected_exec.metrics_snapshot()[GenotypeMetric::ExactFilterRejections as usize].1,
+        9
     );
 }
 
@@ -1022,6 +1051,20 @@ async fn rejects_malformed_indexes_records_and_unsupported_multiallelic_dosage()
             .await
             .is_err()
     );
+
+    let fixture = variable_fixture(0x20, &[0x00], &[pack_codes(&[0, 1, 2, 3])], &[2]);
+    let pgi = fixture.pgen.with_extension("pgen.pgi");
+    let mut index_bytes = fs::read(&pgi).unwrap();
+    index_bytes[12..20].copy_from_slice(&4_u64.to_le_bytes());
+    fs::write(&pgi, index_bytes).unwrap();
+    let mut primary_bytes = fs::read(&fixture.pgen).unwrap();
+    primary_bytes.insert(3, 0);
+    fs::write(&fixture.pgen, primary_bytes).unwrap();
+    let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("must start at byte 3"), "{error}");
 
     let fixture = variable_fixture(0x10, &[0x00], &[vec![0]], &[2]);
     let mut bytes = fs::read(&fixture.pgen).unwrap();

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -9,7 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use datafusion::arrow::array::{
-    Array, BooleanArray, Float32Array, ListArray, StringArray, StructArray, UInt16Array,
+    Array, BooleanArray, FixedSizeListArray, Float32Array, ListArray, StringArray, StructArray,
+    UInt16Array,
 };
 use datafusion::catalog::TableProvider;
 use datafusion::logical_expr::{TableProviderFilterPushDown, col, lit};
@@ -391,7 +392,10 @@ fn gt_values(
         .downcast_ref::<ListArray>()
         .unwrap();
     let samples = gt.value(row);
-    let samples = samples.as_any().downcast_ref::<ListArray>().unwrap();
+    let samples = samples
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .unwrap();
     (0..samples.len())
         .map(|sample| {
             if samples.is_null(sample) {
@@ -427,8 +431,25 @@ fn ds_values(
     column: usize,
     row: usize,
 ) -> Vec<Option<f32>> {
+    float_sample_values(batch, column, row, "DS")
+}
+
+fn ds_stored_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+) -> Vec<Option<f32>> {
+    float_sample_values(batch, column, row, "DS_STORED")
+}
+
+fn float_sample_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+    field: &str,
+) -> Vec<Option<f32>> {
     let values = genotype_struct(batch, column)
-        .column_by_name("DS")
+        .column_by_name(field)
         .unwrap()
         .as_any()
         .downcast_ref::<ListArray>()
@@ -478,6 +499,24 @@ async fn decodes_all_fixed_width_and_plink1_modes() {
         )
         .await
         .unwrap();
+        if mode == 2 {
+            let schema = provider.schema();
+            let genotypes = schema.field_with_name("genotypes").unwrap();
+            let datafusion::arrow::datatypes::DataType::Struct(children) = genotypes.data_type()
+            else {
+                panic!("PGEN genotypes field is not a struct");
+            };
+            assert_eq!(
+                children
+                    .find("GT")
+                    .unwrap()
+                    .1
+                    .metadata()
+                    .get("bio.pgen.ploidy_semantics")
+                    .map(String::as_str),
+                Some("encoded_diploid")
+            );
+        }
         let context = context(1);
         context.register_table("p", Arc::new(provider)).unwrap();
         let batches = context
@@ -491,14 +530,18 @@ async fn decodes_all_fixed_width_and_plink1_modes() {
             gt_values(&batches[0], 1, 0),
             vec![Some(vec![1, 1]), Some(vec![0, 0]), None]
         );
-        if mode >= 3 {
-            assert_eq!(
-                ds_values(&batches[0], 1, 0),
+        assert_eq!(
+            ds_values(&batches[0], 1, 0),
+            vec![Some(2.0), Some(0.0), None]
+        );
+        assert_eq!(
+            ds_stored_values(&batches[0], 1, 0),
+            if mode >= 3 {
                 vec![Some(2.0), Some(0.0), None]
-            );
-        } else {
-            assert_eq!(ds_values(&batches[0], 1, 0), vec![None, None, None]);
-        }
+            } else {
+                vec![None, None, None]
+            }
+        );
         if mode == 4 {
             assert_eq!(
                 hds_values(&batches[0], 1, 0),
@@ -535,9 +578,11 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
             .await
             .unwrap();
         assert_eq!(provider.pgi_path().is_some(), mode >= 0x20);
-        let context = context(3);
-        context.register_table("p", Arc::new(provider)).unwrap();
-        let batches = context
+        let query_context = context(3);
+        query_context
+            .register_table("p", Arc::new(provider))
+            .unwrap();
+        let batches = query_context
             .sql("SELECT id, genotypes FROM p ORDER BY start")
             .await
             .unwrap()
@@ -571,6 +616,10 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
             vec![Some(0.0), Some(1.0), Some(2.0), None]
         );
         assert_eq!(
+            ds_stored_values(batch, 1, 5),
+            vec![Some(0.0), None, Some(2.0), None]
+        );
+        assert_eq!(
             hds_values(batch, 1, 6),
             vec![Some(vec![0.5, 0.5]), None, None, None]
         );
@@ -585,6 +634,31 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
         assert_eq!(
             phased_values(batch, 1, 8),
             vec![Some(true), Some(false), Some(false), None]
+        );
+
+        let gt_provider = PgenTableProvider::try_new(
+            path(&fixture.pgen),
+            PgenReadOptions {
+                genotype_fields: Some(vec!["GT".to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let gt_context = context(1);
+        gt_context
+            .register_table("gt", Arc::new(gt_provider))
+            .unwrap();
+        let gt_batches = gt_context
+            .sql("SELECT genotypes FROM gt ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            gt_values(&gt_batches[0], 0, 8),
+            vec![Some(vec![1, 0]), Some(vec![0, 1]), Some(vec![0, 0]), None]
         );
     }
 }
@@ -788,6 +862,27 @@ async fn rejects_malformed_indexes_records_and_unsupported_multiallelic_dosage()
     let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
         .await
         .unwrap();
+    let invalid_context = context(1);
+    invalid_context
+        .register_table("p", Arc::new(provider))
+        .unwrap();
+    let error = invalid_context
+        .sql("SELECT genotypes FROM p")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("unsupported multiallelic"), "{error}");
+
+    let fixture = fixed_fixture(3);
+    let mut bytes = fs::read(&fixture.pgen).unwrap();
+    bytes[13..15].copy_from_slice(&u16::MAX.to_le_bytes());
+    fs::write(&fixture.pgen, bytes).unwrap();
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
     let context = context(1);
     context.register_table("p", Arc::new(provider)).unwrap();
     let error = context
@@ -798,7 +893,10 @@ async fn rejects_malformed_indexes_records_and_unsupported_multiallelic_dosage()
         .await
         .unwrap_err()
         .to_string();
-    assert!(error.contains("unsupported multiallelic"), "{error}");
+    assert!(
+        error.contains("fixed-width dosage is missing while the hardcall is present"),
+        "{error}"
+    );
 }
 
 #[tokio::test]

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -754,6 +754,30 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
             vec![Some(vec![1, 1]), Some(vec![0, 0])]
         );
     }
+
+    // pgenlib's multiallelic writer emits an ordinary biallelic main track
+    // when no sample uses ALT2+, while PVAR still supplies the larger allele
+    // count. Such a record has no patch payload and remains valid.
+    let fixture =
+        variable_fixture_without_header_allele_counts(0x00, &pack_codes(&[0, 1, 2, 3]), 3);
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+    let no_patch_context = context(1);
+    no_patch_context
+        .register_table("no_patch", Arc::new(provider))
+        .unwrap();
+    let batches = no_patch_context
+        .sql("SELECT genotypes FROM no_patch")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        gt_values(&batches[0], 0, 0),
+        vec![Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), None]
+    );
 }
 
 #[tokio::test]
@@ -1280,6 +1304,22 @@ observed_dosages = np.empty(4, dtype=np.float64)
 reader.read_dosages(0, observed_dosages)
 reader.close()
 np.testing.assert_allclose(observed_dosages, dosages)
+
+unused_alt = p.parent / 'unused_alt'
+unused_alt_alleles = np.array([0, 0, 0, 1, 1, 1, -9, -9], dtype=np.int32)
+with pgenlib.PgenWriter(bytes(unused_alt.with_suffix('.pgen')), 4, 1, False,
+                        allele_ct_limit=3) as writer:
+    writer.append_alleles(unused_alt_alleles, allele_ct=3)
+unused_alt.with_suffix('.pvar').write_text(
+    '#CHROM\tPOS\tID\tREF\tALT\n1\t10\tunused-alt\tA\tC,G\n')
+unused_alt.with_suffix('.psam').write_text('#IID\ns1\ns2\ns3\ns4\n')
+reader = pgenlib.PgenReader(
+    bytes(unused_alt.with_suffix('.pgen')),
+    allele_idx_offsets=np.array([0, 3], dtype=np.uintp))
+observed_unused_alt = np.empty(8, dtype=np.int32)
+reader.read_alleles(0, observed_unused_alt)
+reader.close()
+np.testing.assert_array_equal(observed_unused_alt, unused_alt_alleles)
 "#;
     let mut command = Command::new(&python);
     command.args(["-c", script, prefix.to_str().unwrap()]);
@@ -1392,6 +1432,28 @@ np.testing.assert_allclose(observed_dosages, dosages)
     assert_eq!(
         phased_values(&phase_batches[0], 0, 0),
         vec![Some(true), Some(true), Some(false), None]
+    );
+
+    let unused_alt_provider = PgenTableProvider::try_new(
+        path(&temp.path().join("unused_alt.pgen")),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    let unused_alt_context = context(1);
+    unused_alt_context
+        .register_table("unused_alt", Arc::new(unused_alt_provider))
+        .unwrap();
+    let unused_alt_batches = unused_alt_context
+        .sql("SELECT genotypes FROM unused_alt")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        gt_values(&unused_alt_batches[0], 0, 0),
+        vec![Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), None]
     );
 
     let dosage_provider = PgenTableProvider::try_new(

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -1050,6 +1050,32 @@ async fn rejects_malformed_indexes_records_and_unsupported_multiallelic_dosage()
         "{error}"
     );
 
+    let fixture = variable_fixture(
+        0x10,
+        &[0x60, 0x02],
+        &[pack_codes(&[0, 1, 2, 3]), vec![1, 1, 3]],
+        &[2, 2],
+    );
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+    let dependency_context = context(1);
+    dependency_context
+        .register_table("dependency", Arc::new(provider))
+        .unwrap();
+    let error = dependency_context
+        .sql("SELECT genotypes FROM dependency WHERE id = 'v2'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("truncated dosage-presence bitarray"),
+        "{error}"
+    );
+
     let fixture = variable_fixture(0x10, &[0x01], &[vec![0; 5]], &[2]);
     let error = PgenTableProvider::try_new(
         path(&fixture.pgen),

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -838,6 +838,32 @@ async fn honors_empty_sample_and_genotype_field_selection() {
     )
     .await
     .unwrap();
+    let empty_context = context(2);
+    let state = empty_context.state();
+    let plan = provider
+        .scan(&state, Some(&vec![6]), &[], None)
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    let batches = collect(plan.clone(), empty_context.task_ctx())
+        .await
+        .unwrap();
+    assert_eq!(ds_values(&batches[0], 0, 0), Vec::<Option<f32>>::new());
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
+        0
+    );
+
+    let fixture = fixed_fixture(3);
+    let provider = PgenTableProvider::try_new(
+        path(&fixture.pgen),
+        PgenReadOptions {
+            genotype_fields: Some(Vec::new()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
     let context = context(2);
     let state = context.state();
     let plan = provider
@@ -846,10 +872,20 @@ async fn honors_empty_sample_and_genotype_field_selection() {
         .unwrap();
     let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
     let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
-    assert_eq!(ds_values(&batches[0], 0, 0), Vec::<Option<f32>>::new());
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        2
+    );
+    let genotypes = genotype_struct(&batches[0], 0);
+    assert_eq!(genotypes.len(), batches[0].num_rows());
+    assert_eq!(genotypes.num_columns(), 0);
     assert_eq!(
         exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
         0
+    );
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::PayloadsSkipped as usize].1,
+        2
     );
 }
 
@@ -979,6 +1015,16 @@ async fn rejects_malformed_indexes_records_and_unsupported_multiallelic_dosage()
         .unwrap_err()
         .to_string();
     assert!(error.contains("has no base"), "{error}");
+
+    let fixture = variable_fixture(0x10, &[0x80], &[vec![0]], &[2]);
+    let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("phased-dosage track without a dosage track"),
+        "{error}"
+    );
 
     let fixture = variable_fixture(0x10, &[0x01], &[vec![0; 5]], &[2]);
     let error = PgenTableProvider::try_new(

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -473,7 +473,10 @@ fn hds_values(
         .downcast_ref::<ListArray>()
         .unwrap()
         .value(row);
-    let values = values.as_any().downcast_ref::<ListArray>().unwrap();
+    let values = values
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .unwrap();
     (0..values.len())
         .map(|index| {
             if values.is_null(index) {
@@ -660,6 +663,32 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
             gt_values(&gt_batches[0], 0, 8),
             vec![Some(vec![1, 0]), Some(vec![0, 1]), Some(vec![0, 0]), None]
         );
+
+        let subset_provider = PgenTableProvider::try_new(
+            path(&fixture.pgen),
+            PgenReadOptions {
+                samples: Some(vec!["s3".to_string(), "s1".to_string()]),
+                genotype_fields: Some(vec!["GT".to_string(), "PHASED".to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let subset_context = context(1);
+        subset_context
+            .register_table("subset", Arc::new(subset_provider))
+            .unwrap();
+        let subset_batches = subset_context
+            .sql("SELECT genotypes FROM subset ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            gt_values(&subset_batches[0], 0, 3),
+            vec![Some(vec![1, 1]), Some(vec![0, 0])]
+        );
     }
 }
 
@@ -771,6 +800,21 @@ async fn reads_zstd_pvar_and_rejects_hybrid_or_inconsistent_filesets() {
     PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
         .await
         .unwrap();
+
+    let fixture = fixed_fixture(2);
+    let compressed =
+        zstd::stream::encode_all(fs::read(&fixture.psam).unwrap().as_slice(), 1).unwrap();
+    let psam_zst = fixture.psam.with_extension("psam.zst");
+    fs::write(&psam_zst, compressed).unwrap();
+    PgenTableProvider::try_new(
+        path(&fixture.pgen),
+        PgenReadOptions {
+            psam_path: Some(path(&psam_zst)),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
 
     let fixture = fixed_fixture(2);
     fs::write(&fixture.psam, "#IID\ns1\n").unwrap();
@@ -951,10 +995,13 @@ async fn remote_sparse_scan_uses_bounded_pgen_ranges() {
         })
         .sum::<u64>();
     let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    let snapshot = exec.metrics_snapshot();
     assert_eq!(
-        exec.metrics_snapshot()[GenotypeMetric::PrimaryBytesRead as usize].1,
+        snapshot[GenotypeMetric::PrimaryBytesRead as usize].1,
         requested_bytes
     );
+    assert_eq!(snapshot[GenotypeMetric::RangeRequests as usize].1, 1);
+    assert_eq!(snapshot[GenotypeMetric::CoalescedRanges as usize].1, 1);
 }
 
 #[tokio::test]

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -661,6 +661,10 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
             vec![Some(vec![0, 2]), Some(vec![1, 2]), Some(vec![0, 0]), None]
         );
         assert_eq!(
+            ds_values(batch, 1, 7),
+            vec![Some(0.0), Some(1.0), Some(0.0), None]
+        );
+        assert_eq!(
             gt_values(batch, 1, 8),
             vec![Some(vec![1, 0]), Some(vec![0, 1]), Some(vec![0, 0]), None]
         );

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -61,6 +61,7 @@ impl RangeServer {
                     }
                     Err(error) => panic!("range server failed: {error}"),
                 };
+                stream.set_nonblocking(false).unwrap();
                 let mut request_bytes = [0_u8; 8192];
                 let size = stream.read(&mut request_bytes).unwrap();
                 let request = String::from_utf8_lossy(&request_bytes[..size]);
@@ -356,6 +357,10 @@ fn plink1_mode_fixture() -> Fixture {
 }
 
 fn empty_extension_fixture() -> Fixture {
+    empty_extension_fixture_with_footer(0)
+}
+
+fn empty_extension_fixture_with_footer(footer_bytes: usize) -> Fixture {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();
     let pgen = root.join("cohort.pgen");
@@ -364,7 +369,13 @@ fn empty_extension_fixture() -> Fixture {
     bytes.extend(0_u32.to_le_bytes());
     bytes.extend(1_u32.to_le_bytes());
     bytes.push(0x40);
-    bytes.extend([0, 0]);
+    if footer_bytes == 0 {
+        bytes.extend([0, 0]);
+    } else {
+        bytes.extend([0, 1]);
+        bytes.extend(22_u64.to_le_bytes());
+        bytes.resize(bytes.len() + footer_bytes, 0xa5);
+    }
     fs::write(&pgen, bytes).unwrap();
     Fixture {
         _temp: temp,
@@ -1105,6 +1116,43 @@ async fn remote_sparse_scan_uses_bounded_pgen_ranges() {
     );
     assert_eq!(snapshot[GenotypeMetric::RangeRequests as usize].1, 1);
     assert_eq!(snapshot[GenotypeMetric::CoalescedRanges as usize].1, 1);
+}
+
+#[tokio::test]
+async fn empty_extension_footer_is_not_fetched_during_open() {
+    let fixture = empty_extension_fixture_with_footer(1024 * 1024);
+    let server = RangeServer::start(
+        fs::read(&fixture.pgen).unwrap(),
+        fs::read(&fixture.pvar).unwrap(),
+        fs::read(&fixture.psam).unwrap(),
+    );
+    let provider = PgenTableProvider::try_new(server.url("cohort.pgen"), Default::default())
+        .await
+        .unwrap();
+    let context = context(1);
+    provider
+        .scan(&context.state(), None, &[], None)
+        .await
+        .unwrap();
+    let requests = server.get_requests("cohort.pgen");
+    assert!(
+        requests.iter().all(|request| {
+            request
+                .range
+                .is_some_and(|(_, inclusive_end)| inclusive_end < 22)
+        }),
+        "empty-file header reads must stop before the footer: {requests:?}"
+    );
+    let requested_bytes = requests
+        .iter()
+        .map(|request| {
+            request
+                .range
+                .map(|(start, end)| (end - start + 1) as u64)
+                .unwrap_or(0)
+        })
+        .sum::<u64>();
+    assert_eq!(requested_bytes, 37);
 }
 
 #[tokio::test]

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -1,0 +1,1079 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use datafusion::arrow::array::{
+    Array, BooleanArray, Float32Array, ListArray, StringArray, StructArray, UInt16Array,
+};
+use datafusion::catalog::TableProvider;
+use datafusion::logical_expr::{TableProviderFilterPushDown, col, lit};
+use datafusion::physical_plan::collect;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_core::genotype::GenotypeMetric;
+use datafusion_bio_format_pgen::{PgenExec, PgenReadOptions, PgenTableProvider};
+use tempfile::TempDir;
+
+struct Fixture {
+    _temp: TempDir,
+    pgen: PathBuf,
+    pvar: PathBuf,
+    psam: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct HttpRequest {
+    path: String,
+    method: String,
+    range: Option<(usize, usize)>,
+}
+
+struct RangeServer {
+    address: std::net::SocketAddr,
+    requests: Arc<Mutex<Vec<HttpRequest>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl RangeServer {
+    fn start(pgen: Vec<u8>, pvar: Vec<u8>, psam: Vec<u8>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let server_requests = requests.clone();
+        let server_stop = stop.clone();
+        let thread = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while !server_stop.load(Ordering::Relaxed) && Instant::now() < deadline {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(connection) => connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(error) => panic!("range server failed: {error}"),
+                };
+                let mut request_bytes = [0_u8; 8192];
+                let size = stream.read(&mut request_bytes).unwrap();
+                let request = String::from_utf8_lossy(&request_bytes[..size]);
+                let mut lines = request.lines();
+                let mut request_line = lines.next().unwrap().split_whitespace();
+                let method = request_line.next().unwrap().to_string();
+                let path = request_line.next().unwrap().to_string();
+                let range = lines.find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    if !name.eq_ignore_ascii_case("range") {
+                        return None;
+                    }
+                    let value = value.trim().strip_prefix("bytes=")?;
+                    let (start, end) = value.split_once('-')?;
+                    Some((start.parse().ok()?, end.parse().ok()?))
+                });
+                server_requests.lock().unwrap().push(HttpRequest {
+                    path: path.clone(),
+                    method: method.clone(),
+                    range,
+                });
+                let body = match path.as_str() {
+                    "/cohort.pgen" => &pgen,
+                    "/cohort.pvar" => &pvar,
+                    "/cohort.psam" => &psam,
+                    _ => {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        );
+                        continue;
+                    }
+                };
+                if method == "HEAD" {
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                } else if let Some((start, end)) = range {
+                    let end = end.min(body.len() - 1);
+                    let selected = &body[start..=end];
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {}-{}/{}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        selected.len(),
+                        start,
+                        end,
+                        body.len()
+                    );
+                    let _ = stream.write_all(selected);
+                } else {
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(body);
+                }
+            }
+        });
+        Self {
+            address,
+            requests,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn url(&self, name: &str) -> String {
+        format!("http://{}/{name}", self.address)
+    }
+
+    fn get_requests(&self, name: &str) -> Vec<HttpRequest> {
+        self.requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| request.path == format!("/{name}") && request.method == "GET")
+            .cloned()
+            .collect()
+    }
+}
+
+impl Drop for RangeServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+fn path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn context(partitions: usize) -> SessionContext {
+    SessionContext::new_with_config(
+        SessionConfig::new()
+            .with_batch_size(1024)
+            .with_target_partitions(partitions),
+    )
+}
+
+fn pack_codes(codes: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0_u8; codes.len().div_ceil(4)];
+    for (index, code) in codes.iter().copied().enumerate() {
+        bytes[index / 4] |= code << ((index % 4) * 2);
+    }
+    bytes
+}
+
+fn write_metadata(root: &Path, allele_counts: &[usize], samples: usize) -> (PathBuf, PathBuf) {
+    let pvar = root.join("cohort.pvar");
+    let psam = root.join("cohort.psam");
+    let mut pvar_text = "#CHROM\tPOS\tID\tREF\tALT\n".to_string();
+    for (index, &allele_count) in allele_counts.iter().enumerate() {
+        let alternate = (1..allele_count)
+            .map(|allele| format!("A{allele}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        pvar_text.push_str(&format!(
+            "{}\t{}\tv{}\tR\t{}\n",
+            if index + 1 == allele_counts.len() {
+                "2"
+            } else {
+                "1"
+            },
+            (index + 1) * 10,
+            index + 1,
+            alternate
+        ));
+    }
+    fs::write(&pvar, pvar_text).unwrap();
+    let mut psam_text = "#FID\tIID\tSID\n".to_string();
+    for sample in 0..samples {
+        psam_text.push_str(&format!(
+            "f{}\ts{}\tsrc{}\n",
+            sample % 2,
+            sample + 1,
+            sample
+        ));
+    }
+    fs::write(&psam, psam_text).unwrap();
+    (pvar, psam)
+}
+
+fn variable_fixture(
+    mode: u8,
+    record_types: &[u8],
+    records: &[Vec<u8>],
+    allele_counts: &[usize],
+) -> Fixture {
+    assert_eq!(record_types.len(), records.len());
+    assert_eq!(records.len(), allele_counts.len());
+    assert!(records.iter().all(|record| record.len() < 256));
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let pgen = root.join("cohort.pgen");
+    let pgi = matches!(mode, 0x20 | 0x21).then(|| root.join("cohort.pgen.pgi"));
+    let (pvar, psam) = write_metadata(root, allele_counts, 4);
+    let extension = if matches!(mode, 0x11 | 0x21) {
+        vec![0, 0]
+    } else {
+        Vec::new()
+    };
+    let header_len =
+        12 + 8 + record_types.len() + records.len() + allele_counts.len() + extension.len();
+    let block_offset = if pgi.is_some() {
+        3_u64
+    } else {
+        header_len as u64
+    };
+    let index_magic = match mode {
+        0x20 => 0x30,
+        0x21 => 0x31,
+        _ => mode,
+    };
+    let mut header = vec![0x6c, 0x1b, index_magic];
+    header.extend((records.len() as u32).to_le_bytes());
+    header.extend(4_u32.to_le_bytes());
+    header.push(0x54);
+    header.extend(block_offset.to_le_bytes());
+    header.extend(record_types);
+    header.extend(records.iter().map(|record| record.len() as u8));
+    header.extend(allele_counts.iter().map(|&count| count as u8));
+    header.extend(extension);
+
+    if let Some(pgi) = &pgi {
+        fs::write(pgi, header).unwrap();
+        let mut primary = vec![0x6c, 0x1b, mode];
+        for record in records {
+            primary.extend(record);
+        }
+        fs::write(&pgen, primary).unwrap();
+    } else {
+        for record in records {
+            header.extend(record);
+        }
+        fs::write(&pgen, header).unwrap();
+    }
+    Fixture {
+        _temp: temp,
+        pgen,
+        pvar,
+        psam,
+    }
+}
+
+fn fixed_fixture(mode: u8) -> Fixture {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let pgen = root.join("cohort.pgen");
+    let (pvar, psam) = write_metadata(root, &[2, 2], 4);
+    let mut bytes = vec![0x6c, 0x1b, mode];
+    bytes.extend(2_u32.to_le_bytes());
+    bytes.extend(4_u32.to_le_bytes());
+    bytes.push(0x40);
+    for codes in [[0, 1, 2, 3], [2, 1, 0, 3]] {
+        bytes.extend(pack_codes(&codes));
+        if mode >= 3 {
+            for code in codes {
+                let value = match code {
+                    0 => 0_u16,
+                    1 => 16_384,
+                    2 => 32_768,
+                    3 => u16::MAX,
+                    _ => unreachable!(),
+                };
+                bytes.extend(value.to_le_bytes());
+            }
+        }
+        if mode == 4 {
+            for value in [0_i16, 0, 0, i16::MIN] {
+                bytes.extend(value.to_le_bytes());
+            }
+        }
+    }
+    fs::write(&pgen, bytes).unwrap();
+    Fixture {
+        _temp: temp,
+        pgen,
+        pvar,
+        psam,
+    }
+}
+
+fn plink1_mode_fixture() -> Fixture {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let pgen = root.join("cohort.pgen");
+    let (pvar, psam) = write_metadata(root, &[2], 4);
+    let mut bytes = vec![0x6c, 0x1b, 0x01];
+    bytes.extend(pack_codes(&[3, 2, 0, 1]));
+    fs::write(&pgen, bytes).unwrap();
+    Fixture {
+        _temp: temp,
+        pgen,
+        pvar,
+        psam,
+    }
+}
+
+fn variable_records() -> (Vec<u8>, Vec<Vec<u8>>, Vec<usize>) {
+    let mut types = Vec::new();
+    let mut records = Vec::new();
+    let mut alleles = Vec::new();
+
+    types.push(0x00);
+    records.push(pack_codes(&[0, 1, 2, 3]));
+    alleles.push(2);
+
+    types.push(0x01);
+    records.push(vec![2, 0b0000_1010, 1, 2, 1]);
+    alleles.push(2);
+
+    types.push(0x04);
+    records.push(vec![1, 2, 2]);
+    alleles.push(2);
+
+    types.push(0x02);
+    records.push(vec![1, 1, 3]);
+    alleles.push(2);
+
+    types.push(0x10);
+    records.push(vec![0b11_01_00_01, 0b0000_0100]);
+    alleles.push(2);
+
+    types.push(0x60);
+    records.push(vec![0b11_10_01_00, 0b0000_0101, 0, 0, 0, 128]);
+    alleles.push(2);
+
+    types.push(0xe0);
+    records.push(vec![0xff, 0b0000_0001, 0, 64, 0b0000_0001, 0, 0]);
+    alleles.push(2);
+
+    types.push(0x08);
+    records.push(vec![0b11_00_10_01, 0x00, 0x01, 0x01, 0x00]);
+    alleles.push(3);
+
+    types.push(0x10);
+    records.push(vec![0b11_00_01_01, 0b0000_0011, 0b0000_0001]);
+    alleles.push(2);
+
+    (types, records, alleles)
+}
+
+fn genotype_struct(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+) -> &StructArray {
+    batch
+        .column(column)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap()
+}
+
+fn gt_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+) -> Vec<Option<Vec<u16>>> {
+    let gt = genotype_struct(batch, column)
+        .column_by_name("GT")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    let samples = gt.value(row);
+    let samples = samples.as_any().downcast_ref::<ListArray>().unwrap();
+    (0..samples.len())
+        .map(|sample| {
+            if samples.is_null(sample) {
+                return None;
+            }
+            let values = samples.value(sample);
+            let values = values.as_any().downcast_ref::<UInt16Array>().unwrap();
+            Some(values.values().to_vec())
+        })
+        .collect()
+}
+
+fn phased_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+) -> Vec<Option<bool>> {
+    let values = genotype_struct(batch, column)
+        .column_by_name("PHASED")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(row);
+    let values = values.as_any().downcast_ref::<BooleanArray>().unwrap();
+    (0..values.len())
+        .map(|index| (!values.is_null(index)).then(|| values.value(index)))
+        .collect()
+}
+
+fn ds_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+) -> Vec<Option<f32>> {
+    let values = genotype_struct(batch, column)
+        .column_by_name("DS")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(row);
+    let values = values.as_any().downcast_ref::<Float32Array>().unwrap();
+    (0..values.len())
+        .map(|index| (!values.is_null(index)).then(|| values.value(index)))
+        .collect()
+}
+
+fn hds_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+) -> Vec<Option<Vec<f32>>> {
+    let values = genotype_struct(batch, column)
+        .column_by_name("HDS")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(row);
+    let values = values.as_any().downcast_ref::<ListArray>().unwrap();
+    (0..values.len())
+        .map(|index| {
+            if values.is_null(index) {
+                return None;
+            }
+            let haplotypes = values.value(index);
+            let haplotypes = haplotypes.as_any().downcast_ref::<Float32Array>().unwrap();
+            Some(haplotypes.values().to_vec())
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn decodes_all_fixed_width_and_plink1_modes() {
+    for mode in [2_u8, 3, 4] {
+        let fixture = fixed_fixture(mode);
+        let provider = PgenTableProvider::try_new(
+            path(&fixture.pgen),
+            PgenReadOptions {
+                samples: Some(vec!["s3".to_string(), "s1".to_string(), "s4".to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let context = context(1);
+        context.register_table("p", Arc::new(provider)).unwrap();
+        let batches = context
+            .sql("SELECT id, genotypes FROM p ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            gt_values(&batches[0], 1, 0),
+            vec![Some(vec![1, 1]), Some(vec![0, 0]), None]
+        );
+        if mode >= 3 {
+            assert_eq!(
+                ds_values(&batches[0], 1, 0),
+                vec![Some(2.0), Some(0.0), None]
+            );
+        } else {
+            assert_eq!(ds_values(&batches[0], 1, 0), vec![None, None, None]);
+        }
+        if mode == 4 {
+            assert_eq!(
+                hds_values(&batches[0], 1, 0),
+                vec![Some(vec![1.0, 1.0]), Some(vec![0.0, 0.0]), None]
+            );
+        }
+    }
+
+    let fixture = plink1_mode_fixture();
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+    let context = context(1);
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM p")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        gt_values(&batches[0], 0, 0),
+        vec![Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), None]
+    );
+}
+
+#[tokio::test]
+async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
+    let (types, records, alleles) = variable_records();
+    for mode in [0x10_u8, 0x11, 0x20, 0x21] {
+        let fixture = variable_fixture(mode, &types, &records, &alleles);
+        let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+            .await
+            .unwrap();
+        assert_eq!(provider.pgi_path().is_some(), mode >= 0x20);
+        let context = context(3);
+        context.register_table("p", Arc::new(provider)).unwrap();
+        let batches = context
+            .sql("SELECT id, genotypes FROM p ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            9
+        );
+        let batch = &batches[0];
+        assert_eq!(
+            gt_values(batch, 1, 1),
+            vec![
+                Some(vec![0, 0]),
+                Some(vec![1, 1]),
+                Some(vec![0, 1]),
+                Some(vec![1, 1])
+            ]
+        );
+        assert_eq!(
+            gt_values(batch, 1, 3),
+            vec![Some(vec![0, 0]), None, Some(vec![1, 1]), Some(vec![0, 0])]
+        );
+        assert_eq!(
+            phased_values(batch, 1, 4),
+            vec![Some(true), Some(false), Some(true), None]
+        );
+        assert_eq!(
+            ds_values(batch, 1, 5),
+            vec![Some(0.0), Some(1.0), Some(2.0), None]
+        );
+        assert_eq!(
+            hds_values(batch, 1, 6),
+            vec![Some(vec![0.5, 0.5]), None, None, None]
+        );
+        assert_eq!(
+            gt_values(batch, 1, 7),
+            vec![Some(vec![0, 2]), Some(vec![1, 2]), Some(vec![0, 0]), None]
+        );
+        assert_eq!(
+            gt_values(batch, 1, 8),
+            vec![Some(vec![1, 0]), Some(vec![0, 1]), Some(vec![0, 0]), None]
+        );
+        assert_eq!(
+            phased_values(batch, 1, 8),
+            vec![Some(true), Some(false), Some(false), None]
+        );
+    }
+}
+
+#[tokio::test]
+async fn applies_exact_pvar_pushdowns_limits_and_metadata_projection() {
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        provider
+            .supports_filters_pushdown(&[&col("chrom").eq(lit("1"))])
+            .unwrap(),
+        vec![TableProviderFilterPushDown::Exact]
+    );
+    let context = context(4);
+    let state = context.state();
+    let plan = provider
+        .scan(
+            &state,
+            Some(&vec![3]),
+            &[col("chrom").eq(lit("1"))],
+            Some(2),
+        )
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        2
+    );
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::PayloadsSkipped as usize].1,
+        2
+    );
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
+        0
+    );
+
+    let count_plan = provider
+        .scan(
+            &state,
+            Some(&Vec::new()),
+            &[col("id").in_list(vec![lit("v2"), lit("v4")], false)],
+            None,
+        )
+        .await
+        .unwrap();
+    let count_exec = count_plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    let count_batches = collect(count_plan.clone(), context.task_ctx())
+        .await
+        .unwrap();
+    assert_eq!(
+        count_batches
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>(),
+        2
+    );
+    assert_eq!(
+        count_exec.metrics_snapshot()[GenotypeMetric::PayloadsSkipped as usize].1,
+        2
+    );
+    assert_eq!(
+        count_exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
+        0
+    );
+}
+
+#[tokio::test]
+async fn honors_empty_sample_and_genotype_field_selection() {
+    let fixture = fixed_fixture(3);
+    let provider = PgenTableProvider::try_new(
+        path(&fixture.pgen),
+        PgenReadOptions {
+            samples: Some(Vec::new()),
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(2);
+    let state = context.state();
+    let plan = provider
+        .scan(&state, Some(&vec![6]), &[], None)
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+    assert_eq!(ds_values(&batches[0], 0, 0), Vec::<Option<f32>>::new());
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::RangeRequests as usize].1,
+        0
+    );
+}
+
+#[tokio::test]
+async fn reads_zstd_pvar_and_rejects_hybrid_or_inconsistent_filesets() {
+    let fixture = fixed_fixture(2);
+    let compressed =
+        zstd::stream::encode_all(fs::read(&fixture.pvar).unwrap().as_slice(), 1).unwrap();
+    let pvar_zst = fixture.pvar.with_extension("pvar.zst");
+    fs::write(&pvar_zst, compressed).unwrap();
+    fs::remove_file(&fixture.pvar).unwrap();
+    PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+
+    let fixture = fixed_fixture(2);
+    fs::write(&fixture.psam, "#IID\ns1\n").unwrap();
+    let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("sample count"), "{error}");
+
+    let temp = tempfile::tempdir().unwrap();
+    let pgen = temp.path().join("hybrid.pgen");
+    fs::write(&pgen, [0x6c, 0x1b, 0x01]).unwrap();
+    fs::write(temp.path().join("hybrid.bim"), b"1 v 0 1 A C\n").unwrap();
+    fs::write(temp.path().join("hybrid.fam"), b"f s 0 0 0 -9\n").unwrap();
+    let error = PgenTableProvider::try_new(path(&pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("hybrid"), "{error}");
+}
+
+#[tokio::test]
+async fn rejects_malformed_indexes_records_and_unsupported_multiallelic_dosage() {
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+    let mut bytes = fs::read(&fixture.pgen).unwrap();
+    bytes[12..20].copy_from_slice(&u64::MAX.to_le_bytes());
+    fs::write(&fixture.pgen, bytes).unwrap();
+    assert!(
+        PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+            .await
+            .is_err()
+    );
+
+    let fixture = variable_fixture(0x10, &[0x00], &[vec![0]], &[2]);
+    let mut bytes = fs::read(&fixture.pgen).unwrap();
+    bytes.push(0);
+    fs::write(&fixture.pgen, bytes).unwrap();
+    let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("object ends"), "{error}");
+
+    let fixture = variable_fixture(0x10, &[0x02], &[vec![0]], &[2]);
+    let error = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("has no base"), "{error}");
+
+    let fixture = variable_fixture(0x10, &[0x01], &[vec![0; 5]], &[2]);
+    let error = PgenTableProvider::try_new(
+        path(&fixture.pgen),
+        PgenReadOptions {
+            max_record_bytes: 4,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("max_record_bytes"), "{error}");
+
+    let fixture = variable_fixture(0x10, &[0x04], &[vec![2, 0, 0, 0]], &[2]);
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+    let first_context = context(1);
+    first_context
+        .register_table("p", Arc::new(provider))
+        .unwrap();
+    let error = first_context
+        .sql("SELECT genotypes FROM p")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("delta is zero"), "{error}");
+
+    let fixture = variable_fixture(
+        0x10,
+        &[0x68],
+        &[vec![0, 0xff, 0, 0, 0, 0, 0, 0, 0, 0]],
+        &[3],
+    );
+    let provider = PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
+    let context = context(1);
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let error = context
+        .sql("SELECT genotypes FROM p")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("unsupported multiallelic"), "{error}");
+}
+
+#[tokio::test]
+async fn remote_sparse_scan_uses_bounded_pgen_ranges() {
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+    let pgen = fs::read(&fixture.pgen).unwrap();
+    let pgen_len = pgen.len();
+    let server = RangeServer::start(
+        pgen,
+        fs::read(&fixture.pvar).unwrap(),
+        fs::read(&fixture.psam).unwrap(),
+    );
+    let provider = PgenTableProvider::try_new(server.url("cohort.pgen"), Default::default())
+        .await
+        .unwrap();
+    let context = context(4);
+    let state = context.state();
+    let plan = provider
+        .scan(&state, Some(&vec![3, 6]), &[col("id").eq(lit("v4"))], None)
+        .await
+        .unwrap();
+    let batches = collect(plan.clone(), context.task_ctx()).await.unwrap();
+    assert_eq!(batches[0].num_rows(), 1);
+    let requests = server.get_requests("cohort.pgen");
+    assert!(!requests.is_empty());
+    assert!(
+        requests.iter().all(|request| request.range.is_some()),
+        "PGEN object access must remain range-based: {requests:?}"
+    );
+    assert!(
+        requests.iter().all(|request| {
+            request
+                .range
+                .is_some_and(|(start, end)| end - start + 1 < pgen_len)
+        }),
+        "a sparse query must not GET the complete PGEN object: {requests:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.range.is_some_and(|(start, _)| start > 0)),
+        "the selected payload must be fetched independently of the header"
+    );
+    let requested_bytes = requests
+        .iter()
+        .map(|request| {
+            request
+                .range
+                .map(|(start, end)| (end - start + 1) as u64)
+                .unwrap_or(0)
+        })
+        .sum::<u64>();
+    let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::PrimaryBytesRead as usize].1,
+        requested_bytes
+    );
+}
+
+#[tokio::test]
+async fn differential_pgenlib_and_snputils_oracles_when_installed() {
+    let python = std::env::var("PGEN_REFERENCE_PYTHON").unwrap_or_else(|_| "python3".to_string());
+    let pythonpath = std::env::var("PGEN_REFERENCE_PYTHONPATH").ok();
+    let require = std::env::var_os("PGEN_REQUIRE_REFERENCE_ORACLES").is_some();
+    let mut probe = Command::new(&python);
+    probe.args(["-c", "import pgenlib, snputils"]);
+    if let Some(path) = &pythonpath {
+        probe.env("PYTHONPATH", path);
+    }
+    if !probe.status().is_ok_and(|status| status.success()) {
+        assert!(
+            !require,
+            "required pgenlib/snputils reference oracles are unavailable"
+        );
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let prefix = temp.path().join("oracle");
+    let script = r#"
+import pathlib, sys
+import numpy as np
+import pgenlib
+from snputils import PGENReader
+p = pathlib.Path(sys.argv[1])
+rows = np.array([
+  [0, 1, 2, -9, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 2, 0],
+  [0, 1, 2, -9, 0, 2, 0, 0],
+], dtype=np.int8)
+with pgenlib.PgenWriter(bytes(p.with_suffix('.pgen')), 8, 3, False) as writer:
+    for row in rows:
+        writer.append_biallelic(row)
+p.with_suffix('.pvar').write_text('#CHROM\tPOS\tID\tREF\tALT\n1\t10\tv1\tA\tC\n1\t20\tv2\tG\tT\n2\t30\tv3\tC\tG\n')
+p.with_suffix('.psam').write_text('#IID\n' + ''.join(f's{i+1}\n' for i in range(8)))
+reader = pgenlib.PgenReader(bytes(p.with_suffix('.pgen')))
+observed = np.empty_like(rows)
+reader.read_range(0, 3, observed)
+reader.close()
+np.testing.assert_array_equal(observed, rows)
+snp = PGENReader(p).read(genotype_mode='dosage')
+expected = rows.T
+if snp.genotypes.shape == rows.shape:
+    expected = rows
+np.testing.assert_array_equal(snp.genotypes, expected)
+
+phase = p.parent / 'phase'
+alleles = np.array([0, 1, 1, 0, 0, 0, -9, -9], dtype=np.int32)
+phase_present = np.array([1, 1, 0, 0], dtype=np.uint8)
+with pgenlib.PgenWriter(bytes(phase.with_suffix('.pgen')), 4, 1, False,
+                        hardcall_phase_present=True) as writer:
+    writer.append_partially_phased(alleles, phase_present)
+phase.with_suffix('.pvar').write_text(
+    '#CHROM\tPOS\tID\tREF\tALT\n1\t10\tphase1\tA\tC\n')
+phase.with_suffix('.psam').write_text('#IID\ns1\ns2\ns3\ns4\n')
+reader = pgenlib.PgenReader(bytes(phase.with_suffix('.pgen')))
+observed_alleles = np.empty(8, dtype=np.int32)
+observed_phase = np.empty(4, dtype=np.uint8)
+reader.read_alleles_and_phasepresent(0, observed_alleles, observed_phase)
+reader.close()
+np.testing.assert_array_equal(observed_alleles, alleles)
+np.testing.assert_array_equal(
+    PGENReader(phase).read(genotype_mode='phased').genotypes,
+    np.array([[[0, 1], [1, 0], [0, 0], [-9, -9]]], dtype=np.int8))
+
+dosage = p.parent / 'dosage'
+dosages = np.array([0.125, 1.0, 1.875, -9.0], dtype=np.float32)
+with pgenlib.PgenWriter(bytes(dosage.with_suffix('.pgen')), 4, 1, False,
+                        dosage_present=True) as writer:
+    writer.append_dosages(dosages)
+dosage.with_suffix('.pvar').write_text(
+    '#CHROM\tPOS\tID\tREF\tALT\n1\t10\tdosage1\tA\tC\n')
+dosage.with_suffix('.psam').write_text('#IID\ns1\ns2\ns3\ns4\n')
+reader = pgenlib.PgenReader(bytes(dosage.with_suffix('.pgen')))
+observed_dosages = np.empty(4, dtype=np.float64)
+reader.read_dosages(0, observed_dosages)
+reader.close()
+np.testing.assert_allclose(observed_dosages, dosages)
+"#;
+    let mut command = Command::new(&python);
+    command.args(["-c", script, prefix.to_str().unwrap()]);
+    if let Some(path) = &pythonpath {
+        command.env("PYTHONPATH", path);
+    }
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "reference fixture generation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let plink2 = std::env::var("PGEN_REFERENCE_PLINK2").unwrap_or_else(|_| "plink2".to_string());
+    let require_plink2 = std::env::var_os("PGEN_REQUIRE_PLINK2_ORACLE").is_some();
+    let plink2_available = Command::new(&plink2)
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if plink2_available {
+        let export_prefix = temp.path().join("plink2-export");
+        let output = Command::new(&plink2)
+            .args([
+                "--pfile",
+                prefix.to_str().unwrap(),
+                "--export",
+                "vcf",
+                "--out",
+                export_prefix.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "PLINK 2 oracle failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let vcf = fs::read_to_string(export_prefix.with_extension("vcf")).unwrap();
+        let first = vcf.lines().find(|line| !line.starts_with('#')).unwrap();
+        let calls = first
+            .split('\t')
+            .skip(9)
+            .map(|sample| sample.split(':').next().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            calls,
+            vec!["0/0", "0/1", "1/1", "./.", "0/0", "0/0", "0/0", "0/0"]
+        );
+    } else {
+        assert!(!require_plink2, "required PLINK 2 oracle is unavailable");
+    }
+
+    let provider = PgenTableProvider::try_new(
+        path(&prefix.with_extension("pgen")),
+        PgenReadOptions {
+            samples: Some(vec!["s8".to_string(), "s2".to_string(), "s1".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let oracle_context = context(1);
+    oracle_context
+        .register_table("p", Arc::new(provider))
+        .unwrap();
+    let batches = oracle_context
+        .sql("SELECT id, genotypes FROM p ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(
+        ids.iter().collect::<Vec<_>>(),
+        vec![Some("v1"), Some("v2"), Some("v3")]
+    );
+    assert_eq!(
+        gt_values(&batches[0], 1, 0),
+        vec![Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![0, 0])]
+    );
+    assert_eq!(
+        gt_values(&batches[0], 1, 1),
+        vec![Some(vec![0, 0]), Some(vec![0, 0]), Some(vec![0, 0])]
+    );
+
+    let phase_provider =
+        PgenTableProvider::try_new(path(&temp.path().join("phase.pgen")), Default::default())
+            .await
+            .unwrap();
+    let phase_context = context(1);
+    phase_context
+        .register_table("phase", Arc::new(phase_provider))
+        .unwrap();
+    let phase_batches = phase_context
+        .sql("SELECT genotypes FROM phase")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        gt_values(&phase_batches[0], 0, 0),
+        vec![Some(vec![0, 1]), Some(vec![1, 0]), Some(vec![0, 0]), None]
+    );
+    assert_eq!(
+        phased_values(&phase_batches[0], 0, 0),
+        vec![Some(true), Some(true), Some(false), None]
+    );
+
+    let dosage_provider = PgenTableProvider::try_new(
+        path(&temp.path().join("dosage.pgen")),
+        PgenReadOptions {
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let dosage_context = context(1);
+    dosage_context
+        .register_table("dosage", Arc::new(dosage_provider))
+        .unwrap();
+    let dosage_batches = dosage_context
+        .sql("SELECT genotypes FROM dosage")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        ds_values(&dosage_batches[0], 0, 0),
+        vec![Some(0.125), Some(1.0), Some(1.875), None]
+    );
+}

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -355,6 +355,25 @@ fn plink1_mode_fixture() -> Fixture {
     }
 }
 
+fn empty_extension_fixture() -> Fixture {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let pgen = root.join("cohort.pgen");
+    let (pvar, psam) = write_metadata(root, &[], 1);
+    let mut bytes = vec![0x6c, 0x1b, 0x11];
+    bytes.extend(0_u32.to_le_bytes());
+    bytes.extend(1_u32.to_le_bytes());
+    bytes.push(0x40);
+    bytes.extend([0, 0]);
+    fs::write(&pgen, bytes).unwrap();
+    Fixture {
+        _temp: temp,
+        pgen,
+        pvar,
+        psam,
+    }
+}
+
 fn variable_records() -> (Vec<u8>, Vec<Vec<u8>>, Vec<usize>) {
     let mut types = Vec::new();
     let mut records = Vec::new();
@@ -838,9 +857,11 @@ async fn reads_zstd_pvar_and_rejects_hybrid_or_inconsistent_filesets() {
     let fixture = fixed_fixture(2);
     let compressed =
         zstd::stream::encode_all(fs::read(&fixture.psam).unwrap().as_slice(), 1).unwrap();
+    let expected_companion_bytes =
+        fs::metadata(&fixture.pvar).unwrap().len() + compressed.len() as u64;
     let psam_zst = fixture.psam.with_extension("psam.zst");
-    fs::write(&psam_zst, compressed).unwrap();
-    PgenTableProvider::try_new(
+    fs::write(&psam_zst, &compressed).unwrap();
+    let provider = PgenTableProvider::try_new(
         path(&fixture.pgen),
         PgenReadOptions {
             psam_path: Some(path(&psam_zst)),
@@ -849,6 +870,21 @@ async fn reads_zstd_pvar_and_rejects_hybrid_or_inconsistent_filesets() {
     )
     .await
     .unwrap();
+    let metric_context = context(1);
+    let plan = provider
+        .scan(&metric_context.state(), None, &[], None)
+        .await
+        .unwrap();
+    let exec = plan.as_any().downcast_ref::<PgenExec>().unwrap();
+    assert_eq!(
+        exec.metrics_snapshot()[GenotypeMetric::CompanionBytesRead as usize].1,
+        expected_companion_bytes
+    );
+
+    let fixture = empty_extension_fixture();
+    PgenTableProvider::try_new(path(&fixture.pgen), Default::default())
+        .await
+        .unwrap();
 
     let fixture = fixed_fixture(2);
     fs::write(&fixture.psam, "#IID\ns1\n").unwrap();

--- a/openspec/changes/add-genotype-format-providers/design.md
+++ b/openspec/changes/add-genotype-format-providers/design.md
@@ -42,20 +42,23 @@ PLINK 2 `pgenlib` for PGEN, and Python `grgl` for GRG. `snputils` is useful for
 cross-format behavioral comparisons, but its whole-file and delegated-reader
 paths are not the target execution architecture.
 
-### Reference baseline (2026-07-27)
+### Reference baseline (reviewed 2026-08-16)
 
 | Capability | Normative source | Implementation/oracle snapshot |
 | --- | --- | --- |
 | BCF | [`BCFv2_qref`](https://github.com/samtools/hts-specs/blob/da617203a9527537746e200abda2885bec3a822c/BCFv2_qref.pdf) and [`CSIv1`](https://github.com/samtools/hts-specs/blob/da617203a9527537746e200abda2885bec3a822c/CSIv1.pdf) | `noodles` `fe2b112566a5d509910303841bb9df47dd007fcf`; htslib/bcftools |
 | PLINK 1 | [PLINK binary format appendix](https://www.cog-genomics.org/plink/1.9/formats#bed) | Apache-2.0 `bed-reader` `0128fc755745c8e1cbe49d677479e5cfc3b2f49e`; PLINK |
 | BGEN | [BGEN v1.3 latest specification](https://www.chg.ox.ac.uk/~gav/bgen_format/spec/latest.html) | MIT `limix/bgen` `0c3bae807d00e03499f8b04ac0db83f7f20dd1c4`; bgenix/qctool |
-| PGEN | [`pgen_spec` draft](https://github.com/chrchang/plink-ng/tree/9ee41ce224ea7cd091760d69392a98835715b5b2/pgen_spec) | PLINK 2/`pgenlib` at `9ee41ce224ea7cd091760d69392a98835715b5b2`; external oracle only for LGPL components |
+| PGEN | [`pgen_spec` draft](https://github.com/chrchang/plink-ng/tree/9ee41ce224ea7cd091760d69392a98835715b5b2/pgen_spec) | PLINK 2 at `7b30cf1733c4f50c6699268a9f07fb6af206ed49` and Python `pgenlib` 0.94.1; external oracle only for LGPL components |
 | GRG | [Official GRG model/documentation](https://github.com/aprilweilab/grgl/tree/7b896a00d8b23821e5a779048580f64ae9c34368) plus the required independent on-disk contract | Python/C++ GRGL at `7b896a00d8b23821e5a779048580f64ae9c34368`; external GPL oracle only |
-| Cross-format | Format sources above | BSD-3-Clause `snputils` at `2cf1511ef1c1fb2effddb969075cce69202e079e` |
+| Cross-format | Format sources above | BSD-3-Clause `snputils` at `482c6d1dfd6c4001935dfaec81ae01a5e0ec3e53` |
 
 These commit pins make conformance results reproducible; they are not permission
 to copy implementation code. Before implementation, each pin is reviewed for
 newer format corrections and upgraded only with corresponding fixture changes.
+The PGEN specification tree at the PLINK 2 oracle commit above is byte-for-byte
+unchanged from the normative `9ee41ce` pin. The newer PLINK 2 commit is therefore
+an implementation-oracle update, not a format-contract update.
 
 ## Goals
 
@@ -70,6 +73,8 @@ newer format corrections and upgraded only with corresponding fixture changes.
 - Support local files and object stores where the format admits range access.
 - Keep DataFusion in control of scan concurrency.
 - Make compatibility and performance independently testable.
+- Meet or beat the pinned `snputils` single-thread biallelic `GT` baseline before
+  enabling PGEN in release artifacts, while retaining bounded-memory streaming.
 
 ## Non-Goals
 
@@ -162,8 +167,8 @@ The format-specific child fields are:
 | PLINK 1 | `GT: List<UInt8>` containing A1 dosage 0, 1, 2, or null |
 | BGEN probability | `GP: List<List<Float32>>`, `PLOIDY: List<UInt8>`, and variant `phased` |
 | BGEN dosage | `DS: List<Float32>` and `PLOIDY: List<UInt8>` |
-| PGEN allele | `GT: List<List<UInt16>>`, `PHASED: List<Boolean>` |
-| PGEN dosage | available `DS` and `HDS` fields plus requested hardcall fields |
+| PGEN allele | `GT: List<FixedSizeList<UInt16, 2>>`, `PHASED: List<Boolean>` |
+| PGEN dosage | effective `DS`, optional source-only `DS_STORED`, `HDS`, and requested hardcall fields |
 | GRG haplotype | `GT: List<UInt8>` with mutation presence 0/1 or null |
 | GRG individual | `GT: List<UInt8>` with alternate count 0..ploidy or null |
 
@@ -395,6 +400,33 @@ the first owned record. Unsupported or not-yet-standardized multiallelic dosage
 sections fail explicitly. Hybrid `.pgen + .bim + .fam` filesets are outside the
 initial contract.
 
+PGEN itself does not encode biological ploidy. Initial raw `GT` output therefore
+reports the two encoded allele slots and labels them with
+`ploidy_semantics=encoded_diploid`; it does not guess chromosome build, PAR
+boundaries, or sex-chromosome ploidy from PVAR/PSAM. A future chromosome-aware
+mode requires an explicit genome-build/ploidy policy. The performance oracle is
+run with `snputils`' `chromosome_ploidy="autosomal"` so both sides implement the
+same contract.
+
+The two encoded allele slots use an Arrow `FixedSizeList<UInt16, 2>` per sample
+instead of a variable inner list. Missing samples remain null at the fixed-size
+list level. This removes one 32-bit offset per sample while preserving the exact
+two-slot PGEN representation and materially reduces wide-cohort memory traffic.
+
+`DS` uses effective biallelic alternate-allele dosage semantics, matching
+PLINK 2/`pgenlib`: a stored dosage overrides the hardcall, an otherwise-called
+hardcall contributes exact dosage 0, 1, or 2, and the value is null only when
+both are missing. `DS_STORED`, when projected, exposes only the physically
+stored dosage and is null for hardcall fallback. This keeps the common fast path
+oracle-compatible without losing the distinction between source dosage and a
+hardcall-derived value.
+
+The first implementation supports allele indices representable by the public
+`UInt16` schema (at most 65,536 alleles per variant) and rejects larger encoded
+widths before allocation. Differential fixtures additionally stay within the
+current official `pgenlib` limit of 255 alleles; this oracle limit is not
+misreported as a file-format limit.
+
 #### GRG
 
 GRG is graph-native rather than record-native. The provider opens one immutable
@@ -408,7 +440,88 @@ counts. Graph missingness maps to null. A `contig_name` option supplies `chrom`
 when the graph does not store one. Remote GRG access and graph analytics remain
 out of scope for the first provider.
 
-### 14. Error model
+### 14. PGEN hot-path and workspace design
+
+PGEN has a dedicated projection-driven decode pipeline. Planning creates a
+`ProjectionPlan` bitset and a `SamplePlan` once. Each physical partition owns a
+single reusable `DecodeWorkspace` containing its range buffer, packed hardcall
+scratch, selected-sample scratch, auxiliary-track scratch, Arrow builders, and
+one LD-base workspace. The partition appends decoded values directly to Arrow
+builders; it does not retain a `DecodedRecord` or a second row representation.
+
+Unprojected tracks are validated and skipped from declared lengths without
+allocating logical values. A `GT`-only scan does not allocate `PHASED`, `DS`,
+`DS_STORED`, or `HDS`; a metadata-only scan does not read record payloads. The
+identity-sample path uses specialized packed-byte/word decoding, while sparse
+selection gathers directly into request order. Generic per-sample bit readers
+remain a correctness fallback, not the dense hot loop.
+
+LD state contains only the most recent eligible non-LD base required by the
+specification. It is updated in place and represented at the narrowest level
+needed by the projection/sample plan. The decoder does not keep a map of every
+base variant and does not clone a full cohort vector for each LD record.
+
+Local scans open one read handle per partition and reuse buffers with positional
+reads. Object-store scans retain bounded coalesced range reads. The header index
+is decoded by `2^16`-variant blocks on demand instead of requiring an owned
+record descriptor for every variant. PVAR/PSAM parsing is streaming or compactly
+interned so metadata memory does not multiply the source text with per-cell
+`String` allocations.
+
+Partitions remain contiguous for locality and are balanced with a cost model
+combining encoded bytes, projected decoded values, record representation, and
+LD prelude work. Boundaries prefer valid non-LD anchors. DataFusion target
+partitions are the only outer parallelism; the decoder creates no nested pool.
+
+### 15. PGEN performance qualification
+
+The initial audit of draft PR #221 used an official-writer, fully phased
+biallelic fixture with 16,384 variants and 1,024 samples on an Apple M3 Max.
+Both implementations read all variants and samples and materialized `GT`; all
+Python/native numerical thread pools and DataFusion target partitions were set
+to one for the single-thread comparison.
+
+| Implementation | Median/representative wall time | Materialized value bytes |
+| --- | ---: | ---: |
+| `snputils` `482c6d1` / `pgenlib` 0.94.1 | 70.4 ms | 32.0 MiB compact `int8` alleles |
+| Draft Rust PR #221, one partition | 391.4 ms | 203.6 MB Arrow array estimate |
+| Draft Rust PR #221, four partitions | 114.3 ms | 203.6 MB Arrow array estimate |
+
+The formats differ in output width, so qualification reports output bytes and
+does not claim identical memory bandwidth. The observed roughly 5.5x
+single-partition gap is nevertheless a release blocker. The dominant structural
+causes are eager construction of every genotype child, full-cohort intermediate
+rows, generic per-sample packed reads, repeated LD-base copies, and per-range
+file/buffer setup.
+
+The hard gate uses a release build, identical fixture and selection, warm page
+cache, one DataFusion partition/Tokio worker, one thread for every oracle pool,
+and at least ten measured iterations after warmup. It compares median steady
+state decode-plus-materialize time for biallelic phased `GT`; provider-open and
+full-fileset end-to-end times are reported separately. Rust SHALL be no slower
+than the pinned `snputils` median on the same host. The benchmark command,
+fixture generator seed, hardware, compiler flags, oracle versions, result
+samples, output bytes, and peak RSS are published with the result.
+
+Additional suites cover dense, one-bit, difflist, LD-heavy, phase, dosage,
+multiallelic hardcall, metadata-only, sparse-variant, sparse-sample, local, and
+object-store paths. Multi-partition results must remain complete and bounded;
+on a host with at least four physical cores, four partitions target at least
+2.5x the one-partition throughput without nested concurrency. A noisy general
+CI runner may track regressions with a tolerance, but cannot waive the dedicated
+no-slower-than-`snputils` release gate.
+
+Gate 1 implementation on 2026-08-16 replaced the draft row intermediates with
+a direct fixed-size allele-pair Arrow path and a four-call dense/phase lookup
+kernel. On the pinned generated fixture, ten post-warmup iterations produced
+32.92 ms for one Rust partition versus 71.60 ms for one-thread `snputils`.
+Rust output was 69,272,392 bytes with maximum RSS 163,889,152 bytes; `snputils`
+output was 33,554,432 bytes with maximum RSS 587,841,536 bytes. Both produced
+the same genotype digest. Rust scans measured 18.26, 9.72, and 7.03 ms with two,
+four, and eight partitions respectively, so the one-thread parity and four-core
+scaling gates pass for this fixture.
+
+### 16. Error model
 
 Format, version, count, offset, compression, allocation-limit, and companion
 errors are detected as early as possible and include the primary object and
@@ -420,7 +533,7 @@ No hot-path decoder uses `unwrap` or trusts file-declared sizes without checked
 arithmetic. Partial output followed by a corruption error is allowed for
 streaming execution, but the error is not suppressed.
 
-### 15. Metrics and observability
+### 17. Metrics and observability
 
 Every scan exposes, at minimum:
 
@@ -437,7 +550,7 @@ Every scan exposes, at minimum:
 Metrics permit proving that a pushdown avoided I/O rather than merely discarding
 values after decoding.
 
-### 16. Testing and benchmarking
+### 18. Testing and benchmarking
 
 Each format receives:
 
@@ -462,7 +575,7 @@ interleaved runs are summarized by their median. The optimized streaming BCF
 path must have a lower median wall time than the pinned independent snputils
 GT-dosage baseline before the performance task is complete.
 
-### 17. Licensing boundary
+### 19. Licensing boundary
 
 Runtime code may depend on libraries with project-compatible licenses after
 normal dependency review. LGPL `pgenlib` and GPL `grgl` SHALL NOT be linked,

--- a/openspec/changes/add-genotype-format-providers/design.md
+++ b/openspec/changes/add-genotype-format-providers/design.md
@@ -466,9 +466,11 @@ reads. Object-store scans retain bounded coalesced range reads. Variable-width
 header indexes retain their encoded `2^16`-variant blocks, packed block-relative
 offsets, and 16-bit within-block LD deltas; fixed-width modes retain only their
 offset formula. Record descriptors are reconstructed on demand instead of being
-allocated per variant. PVAR/PSAM parsing is streaming or compactly interned so
-metadata memory does not multiply the source text with per-cell `String`
-allocations.
+allocated per variant. Dependency discovery folds directly into the retained
+base set, and sorted record ranges stream into a fallible coalescer without a
+second catalog-sized staging buffer. PVAR/PSAM parsing is streaming or compactly
+interned so metadata memory does not multiply the source text with per-cell
+`String` allocations.
 
 Partitions remain contiguous for locality and are balanced with a cost model
 combining encoded bytes, projected decoded values, record representation, and

--- a/openspec/changes/add-genotype-format-providers/design.md
+++ b/openspec/changes/add-genotype-format-providers/design.md
@@ -462,11 +462,13 @@ needed by the projection/sample plan. The decoder does not keep a map of every
 base variant and does not clone a full cohort vector for each LD record.
 
 Local scans open one read handle per partition and reuse buffers with positional
-reads. Object-store scans retain bounded coalesced range reads. The header index
-is decoded by `2^16`-variant blocks on demand instead of requiring an owned
-record descriptor for every variant. PVAR/PSAM parsing is streaming or compactly
-interned so metadata memory does not multiply the source text with per-cell
-`String` allocations.
+reads. Object-store scans retain bounded coalesced range reads. Variable-width
+header indexes retain their encoded `2^16`-variant blocks, packed block-relative
+offsets, and 16-bit within-block LD deltas; fixed-width modes retain only their
+offset formula. Record descriptors are reconstructed on demand instead of being
+allocated per variant. PVAR/PSAM parsing is streaming or compactly interned so
+metadata memory does not multiply the source text with per-cell `String`
+allocations.
 
 Partitions remain contiguous for locality and are balanced with a cost model
 combining encoded bytes, projected decoded values, record representation, and

--- a/openspec/changes/add-genotype-format-providers/design.md
+++ b/openspec/changes/add-genotype-format-providers/design.md
@@ -467,10 +467,14 @@ header indexes retain their encoded `2^16`-variant blocks, packed block-relative
 offsets, and 16-bit within-block LD deltas; fixed-width modes retain only their
 offset formula. Record descriptors are reconstructed on demand instead of being
 allocated per variant. Dependency discovery folds directly into the retained
-base set, and sorted record ranges stream into a fallible coalescer without a
-second catalog-sized staging buffer. PVAR/PSAM parsing is streaming or compactly
-interned so metadata memory does not multiply the source text with per-cell
-`String` allocations.
+base set. The sorted selected-index buffer is shared across partitions; each
+partition stores only slice bounds and its true out-of-slice LD dependencies.
+Byte-balanced boundaries are computed in two streaming passes, required record
+indexes are merged without materialization, and their ranges stream into a
+fallible coalescer. Planning therefore does not clone or stage another
+catalog-sized selection or range buffer. PVAR/PSAM parsing is streaming or
+compactly interned so metadata memory does not multiply the source text with
+per-cell `String` allocations.
 
 Partitions remain contiguous for locality and are balanced with a cost model
 combining encoded bytes, projected decoded values, record representation, and

--- a/openspec/changes/add-genotype-format-providers/design.md
+++ b/openspec/changes/add-genotype-format-providers/design.md
@@ -168,7 +168,7 @@ The format-specific child fields are:
 | BGEN probability | `GP: List<List<Float32>>`, `PLOIDY: List<UInt8>`, and variant `phased` |
 | BGEN dosage | `DS: List<Float32>` and `PLOIDY: List<UInt8>` |
 | PGEN allele | `GT: List<FixedSizeList<UInt16, 2>>`, `PHASED: List<Boolean>` |
-| PGEN dosage | effective `DS`, optional source-only `DS_STORED`, `HDS`, and requested hardcall fields |
+| PGEN dosage | effective `DS`, optional source-only `DS_STORED`, `HDS: List<FixedSizeList<Float32, 2>>`, and requested hardcall fields |
 | GRG haplotype | `GT: List<UInt8>` with mutation presence 0/1 or null |
 | GRG individual | `GT: List<UInt8>` with alternate count 0..ploidy or null |
 

--- a/openspec/changes/add-genotype-format-providers/pgen-audit.md
+++ b/openspec/changes/add-genotype-format-providers/pgen-audit.md
@@ -1,0 +1,348 @@
+# PGEN Provider Audit And Performance Plan
+
+## Scope And Evidence
+
+This audit was performed on 2026-08-16 before production implementation work.
+It covers the open genotype-provider pull-request stack, the draft PGEN
+provider in PR #221, the pinned PLINK 2 PGEN specification, current PLINK 2 and
+`pgenlib` behavior, and current `AI-sandbox/snputils` behavior and performance.
+
+Reviewed baselines:
+
+- repository `master`: `7b7b9bf`;
+- genotype specification PR #216: `b12e28d`;
+- genotype core/BCF rollup PR #217: `558503c`;
+- draft PGEN PR #221: `d13ac8e`;
+- normative PGEN specification: PLINK 2 `pgen_spec` at `9ee41ce`;
+- current PLINK 2 oracle: `7b30cf1`;
+- Python `pgenlib`: 0.94.1; and
+- current `snputils`: `482c6d1`.
+
+The current PLINK 2 `pgen_spec` tree is byte-for-byte unchanged from the pinned
+`9ee41ce` tree. The oracle implementation and `snputils` have advanced, but the
+normative byte-level contract reviewed by PR #216 has not changed.
+
+## Pull-Request Stack
+
+| PR | State | Role | Audit conclusion |
+| --- | --- | --- | --- |
+| #216 | Draft | OpenSpec contract for BCF, PLINK 1, BGEN, PGEN, and GRG | Correct place for this amendment; it lacked a measurable PGEN parity gate and explicit ploidy/effective-dosage contracts. |
+| #217 | Ready | Shared genotype provider core plus merged BCF work | Current stack base. Its head moved after #221 was created. |
+| #219 | Draft | PLINK 1 provider | Sibling implementation; does not block PGEN design. |
+| #220 | Ready | BGEN provider | Sibling implementation; later review fixes are stacked in #229. |
+| #221 | Draft | PGEN provider | Broad feature coverage and passing tests, but its base is stale and its hot path is not release-ready. |
+| #222 | Draft | GRG licensing/compatibility gate | Independent of PGEN. |
+| #229 | Ready | BGEN review fixes | Demonstrates that the genotype stack is still moving under #221. |
+
+PR #221 is based on the older #217 base `db5db5f`, while #217 now points at
+`558503c`. A direct comparison against the current core therefore contains
+unrelated reversions. Rebase/restack is a correctness prerequisite before any
+PGEN optimization is reviewed.
+
+## PGEN Physical Contract
+
+### Headers And Indexing
+
+The supported modes `0x01`, `0x02`, `0x03`, `0x04`, `0x10`, `0x11`, `0x20`,
+and `0x21` select fixed or variable-width header/index arrangements. Variable
+records are grouped into blocks of exactly `2^16` variants. The implementation
+must validate control bytes, count widths, record widths, offsets, monotonicity,
+and object bounds before using file-declared values for allocation or I/O.
+
+The index should be consumed blockwise. A vector of rich `RecordInfo` objects
+for the entire dataset delays first output and multiplies memory on very large
+cohorts. A compact block descriptor plus on-demand record metadata is sufficient
+for range planning and streaming execution.
+
+### Main Hardcall Representations
+
+The low record-type bits distinguish:
+
+- dense two-bit hardcalls (`0`);
+- one-bit base values plus exceptions (`1`);
+- LD delta from the most recent eligible non-LD record (`2`);
+- inverse LD delta (`3`); and
+- difflists with common hardcall categories 0, 2, or 3 (`4`, `6`, `7`).
+
+Type `5` is reserved. In ordinary PGEN hardcall encoding, category 0 is
+homozygous reference, 1 is heterozygous, 2 is homozygous alternate, and 3 is
+missing. These codes must not be confused with PLINK 1 BED bit semantics.
+
+An LD record depends on the most recent eligible non-LD record in the same
+`2^16` block and cannot be the block's first record. A partition may need a
+dependency prelude, but only its owned records are emitted. One current base
+workspace is sufficient; retaining every prior base is neither required by the
+specification nor scalable.
+
+### Auxiliary Tracks
+
+Up to ten auxiliary portions can follow the main hardcall representation,
+including multiallelic hardcall patches, phase presence/information, dosage
+presence/values, multiallelic dosage, phased dosage, and multiallelic phased
+dosage. Some multiallelic dosage layouts remain non-finalized in the draft
+specification and must be rejected distinctly rather than guessed.
+
+Biallelic dosage integers use the PLINK 2 fixed-point scaling; for encoded
+diploid dosage the integer is divided by 16384. PGEN does not encode biological
+ploidy. PVAR chromosome and PSAM sex alone cannot safely imply a biological
+ploidy without a genome build and PAR policy.
+
+The public raw genotype schema uses `UInt16` allele indices, so its independent
+implementation limit is 65,536 alleles per variant. Current official `pgenlib`
+uses an 8-bit allele code and limits differential fixtures to 255 alleles. The
+oracle's implementation limit is not a normative PGEN limit.
+
+## Oracle Findings
+
+### PLINK 2 And `pgenlib`
+
+The official reader uses aligned word/vector workspaces, direct copies for
+dense packed genotype vectors, reusable buffers, and alternative compact
+difflist/genovec states. It retains only the LD state needed for the next
+dependent records and does not create an extra reader thread pool.
+
+`pgenlib.read_dosages()` returns effective dosage. On a fixture with hardcalls
+and no stored dosage track, it returns exact 0/1/2 values and its missing-value
+sentinel. This contradicts the original OpenSpec statement that `DS` is always
+null when no dosage is physically stored. The amended contract therefore uses:
+
+- `DS`: stored dosage when present, otherwise exact hardcall dosage, otherwise
+  null; and
+- optional `DS_STORED`: the source dosage only, null when fallback was used.
+
+### `snputils`
+
+Current `snputils` delegates PGEN payload decoding to `pgenlib`, so it is a
+performance and behavioral oracle, not an acceptable runtime dependency or
+architecture for this Apache-licensed Rust provider.
+
+For exactly `fields=["GT"]` with no sample/variant selector, `snputils` skips
+PVAR and PSAM and opens PGEN directly. Its phased fast path:
+
+- materializes compact `int8` output shaped as variants × samples × 2;
+- reads a whole temporary `int32` result only when it stays under 64 MiB;
+- otherwise uses chunks capped at about 16 MiB and 512 variants;
+- uses contiguous range calls for contiguous selections and list calls for
+  sparse selections; and
+- copies each `int32` chunk into the final `int8` array.
+
+Current `snputils` also has explicit chromosome-ploidy handling. The parity
+benchmark must use `chromosome_ploidy="autosomal"` because the initial Rust
+contract exposes PGEN's encoded two-allele representation and deliberately
+does not guess biological ploidy.
+
+## Draft PR #221 Correctness Status
+
+The draft has valuable coverage: all declared header modes, embedded/external
+indexes, dense/one-bit/difflist/LD hardcalls, phase, biallelic dosage/HDS,
+multiallelic hardcall patches, PVAR/PSAM companions, exact metadata filters,
+sample selection, and local/object-store range paths.
+
+Validation performed during this audit:
+
+- `cargo test -p datafusion-bio-format-pgen --all-targets --no-run`: passed;
+- 13 unit tests and 8 integration tests: passed; and
+- required external differential test with Python `pgenlib` 0.94.1: passed in
+  15.3 seconds.
+
+The differential fixture is intentionally small and does not demonstrate
+throughput, allocation behavior, catalog scalability, or all current oracle
+semantics. In particular, the draft's `DS` behavior is inconsistent: it may use
+hardcall fallback within a record carrying dosage while returning null for the
+same hardcall in a record without any dosage track.
+
+## Draft PR #221 Hot-Path Audit
+
+The following findings are release blockers, ordered by expected impact.
+
+1. `decode_record_and_main` constructs full-sample hardcall categories, full
+   `GT`, `PHASED`, `DS`, and `HDS` vectors for every row regardless of projected
+   genotype children. Projection currently avoids only some final copies, not
+   the dominant decode/allocation work.
+2. Decoded rows are retained as a second intermediate representation and then
+   copied into Arrow arrays at batch flush. Wide cohorts therefore pay for full
+   row materialization plus Arrow materialization.
+3. The dense path uses a generic per-sample packed-value reader that assembles a
+   word from several bytes. Dense two-bit decoding needs a specialized byte or
+   word kernel and a direct builder/gather path.
+4. LD bases are stored in a map, cloned before decode, and copied again by the
+   main decoder. The specification requires only the latest eligible base.
+5. Local coalesced reads open/seek and allocate per range instead of reusing one
+   partition-local handle and buffer.
+6. PVAR and PSAM are fully read into owned strings; compressed metadata can
+   exist in both compressed and decompressed buffers. Large catalogs need
+   streaming or compact interned storage.
+7. The complete PGEN record index is eagerly expanded into owned descriptors.
+   Block-lazy metadata is more scalable and can produce the first batch sooner.
+8. Partition weights are encoded bytes only. Decoded sample width, projected
+   fields, sparse representation work, and LD preludes can dominate bytes and
+   produce imbalance.
+9. The default genotype projection includes all children. The draft Criterion
+   benchmark selecting `genotypes` therefore does substantially more work than
+   the `snputils` `GT` benchmark.
+10. Conventional companion handling should explicitly cover the supported
+    compressed PVAR/PSAM suffix matrix and enforce official PVAR header rules.
+
+## Measured Baseline
+
+The audit generated a fully phased biallelic PGEN with the official Python
+writer: 16,384 variants × 1,024 samples with 0.5% missing calls. File sizes were
+5,296,184 bytes PGEN, 305,486 bytes PVAR, and 5,039 bytes PSAM.
+
+Host: Apple M3 Max, 16 physical cores. Rust 1.91.0, Python 3.11.9,
+`snputils` `482c6d1`, and `pgenlib` 0.94.1 were used. DataFusion target
+partitions and all Python/native numerical pools were constrained to one for
+the parity measurement. The page cache was warm.
+
+| Path | Time | Relative to Rust p1 |
+| --- | ---: | ---: |
+| `snputils` phased `GT`, median | 70.4 ms | 5.56x faster |
+| direct `pgenlib` list/read/cast, median | 79.4 ms | 4.93x faster |
+| draft Rust, 1 partition | 391.4 ms | 1.00x |
+| draft Rust, 2 partitions | 208.2 ms | 1.88x |
+| draft Rust, 4 partitions | 114.3 ms | 3.42x |
+| draft Rust, 8 partitions, fresh run | 105.2 ms | 3.72x |
+
+The Rust Arrow output estimate was 203,555,664 bytes versus 33,554,432 bytes
+for the compact `snputils` allele array. This is not a physically identical
+output-layout comparison; output bytes must always accompany the timing.
+Nevertheless, the Rust one-partition path is about 5.5 times slower, and even
+four partitions do not reach the one-thread oracle. The parity requirement is
+therefore unmet.
+
+The existing draft benchmark uses a 2,048 × 128 synthetic fixture, reuses an
+already-open context, selects the entire `genotypes` struct, and has no pinned
+external baseline or thread-pool controls. It is useful for local regression
+tracking but not for release qualification.
+
+## Target Architecture
+
+```text
+PVAR/PSAM + block index
+          |
+          v
+ projection/sample/filter plans (once)
+          |
+          v
+ contiguous cost-balanced DataFusion partitions
+          |
+          v
+ per-partition reader + reusable DecodeWorkspace
+          |
+          +--> skip/validate unprojected tracks
+          +--> specialized dense/one-bit/difflist kernels
+          +--> one in-place LD base
+          +--> selected samples in requested order
+          |
+          v
+ direct Arrow builders --> bounded RecordBatch stream
+```
+
+Key invariants:
+
+- no nested thread pool;
+- no full-cohort logical vector for an unprojected child;
+- no retained decoded-row copy after values enter Arrow builders;
+- no LD state proportional to the number of base records;
+- no metadata-only PGEN record reads;
+- memory bounded by projected output/batch budget plus one workspace per active
+  partition; and
+- partition weights include decode/output work as well as encoded bytes.
+
+Because PGEN exposes exactly two encoded allele slots in this initial contract,
+the inner Arrow value is a nullable `FixedSizeList<UInt16, 2>`, not a variable
+list. This removes a 32-bit offset per sample without changing allele order or
+missingness.
+
+## Implementation And Acceptance Sequence
+
+### Gate 0: Contract And Stack
+
+1. Approve this OpenSpec amendment.
+2. Rebase PR #221 onto current PR #217 without reverting core/BCF changes.
+3. Add the pinned benchmark fixture generator and oracle runner before changing
+   hot loops so every optimization has a comparable baseline.
+
+### Gate 1: Biallelic `GT` Parity
+
+1. Introduce `ProjectionPlan`, `SamplePlan`, and reusable partition workspaces.
+2. Add a dedicated `GT`-only path with no phase/dosage/HDS allocations.
+3. Decode dense two-bit data with byte/word lookup or measured portable SIMD and
+   append directly to Arrow builders.
+4. Reuse a local handle/range buffer and remove intermediate decoded rows.
+5. Pass all correctness tests and the hard one-thread no-slower-than-`snputils`
+   median gate.
+
+This gate is first because it is the user's explicit performance criterion and
+the least ambiguous like-for-like semantic path.
+
+### Gate 2: Compressed Representations And Selection
+
+1. Specialize one-bit and difflist paths for identity and sparse sample plans.
+2. Replace the LD map/clones with one in-place base workspace.
+3. Validate selected-sample ordering and representation-level differential
+   fixtures.
+4. Benchmark dense, sparse-sample, one-bit, difflist, and LD-heavy datasets.
+
+### Gate 3: Auxiliary Semantics
+
+1. Implement effective `DS` and optional stored-only `DS_STORED` exactly.
+2. Make phase, dosage, and HDS parsers allocation-free when unprojected.
+3. Validate missing dosage/hardcall coupling and HDS/DS quantization.
+4. Complete multiallelic hardcall and allele-width boundary suites; keep
+   non-finalized multiallelic dosage explicitly unsupported.
+
+### Gate 4: Catalog, Remote I/O, And Multicore Scale
+
+1. Make index metadata block-lazy and PVAR/PSAM storage compact/streaming.
+2. Validate local and object-store request/byte metrics.
+3. Balance partitions by estimated decode/output cost with valid LD preludes.
+4. Publish 1/2/4/8-partition throughput, efficiency, balance, duplicate prelude
+   work, output bytes, allocations, and peak RSS.
+5. Run workspace format, check, clippy, tests, conformance, fuzz/property, and
+   release gates before enabling the provider.
+
+## Gate 1 Implementation Result
+
+The approved Gate 1 work was implemented after this initial audit. PR #221 was
+restacked onto genotype-core `558503c`; a recoverable local backup preserves its
+old `d13ac8e` head. The exact `GT` path now uses a partition-local sample map and
+workspace, one LD base, direct Arrow buffers, nullable fixed-size allele pairs,
+and a dense lookup kernel that consumes four hardcalls and their phase bits at a
+time.
+
+The committed fixture generator parameters are 16,384 variants, 1,024 samples,
+0.5% missing calls, and seed `20260816`. On the audit host, ten measured
+post-warmup iterations gave:
+
+| Reader | Partitions | Median | Speedup vs Rust p1 |
+| --- | ---: | ---: | ---: |
+| pinned `snputils` | 1 | 71.60 ms | 0.46x |
+| Rust PGEN | 1 | 32.92 ms | 1.00x |
+| Rust PGEN | 2 | 18.26 ms | 1.80x |
+| Rust PGEN | 4 | 9.72 ms | 3.39x |
+| Rust PGEN | 8 | 7.03 ms | 4.68x |
+
+Rust and the oracle produced the identical digest
+`16692912:8342602:8347936:560154221234404`. Maximum RSS in the one-thread
+process runs was 163,889,152 bytes for Rust and 587,841,536 bytes for Python
+`snputils`. Gate 1 therefore passes even though Rust materializes a wider Arrow
+representation.
+
+## Auxiliary Semantics Implementation Result
+
+The first Gate 3 contract item is also implemented. `DS` now returns the
+physically stored biallelic dosage when present and exact hardcall dosage
+otherwise; `DS_STORED` exposes only the physical track. Hand-checked fixtures
+cover hardcall-only, sparse stored, dense stored, missing, and override cases.
+The decoder rejects the fixed-width `65535` dosage sentinel when its hardcall
+is present, as required by the format. Existing explicit and specification-
+defined implicit haplotype dosage behavior remains intact.
+
+## Release Decision
+
+The original draft should not be merged, but its restacked Gate 1 successor has
+resolved the explicit single-thread performance blocker. It can proceed through
+the compressed-representation, dosage/ploidy, catalog, remote-I/O, and full
+workspace release gates with the oracle harness kept independent from runtime
+code.

--- a/openspec/changes/add-genotype-format-providers/proposal.md
+++ b/openspec/changes/add-genotype-format-providers/proposal.md
@@ -31,7 +31,9 @@ when a query does not need them.
   ploidy, multiallelic variants, and optional biallelic dosage output.
 - Add a PLINK 2 PGEN/PVAR/PSAM provider supporting standard header modes,
   hardcalls, phase, biallelic dosage, phased dosage, multiallelic hardcalls,
-  PVAR pruning, and LD-dependency-aware partitioning.
+  PVAR pruning, and LD-dependency-aware partitioning. Require its one-thread
+  biallelic `GT` scan to meet or beat a pinned `snputils`/`pgenlib` baseline
+  before release, then scale through DataFusion-owned partitions.
 - Add a gated, read-only GRG mutation view with haplotype and fixed-ploidy
   individual output modes, mutation and sample pruning, graph-aware traversal,
   and an explicit local-file scope for the first implementation.
@@ -67,6 +69,9 @@ perform automatic format conversion, or add genotype association algorithms.
   - Remote SQLite BGI files require a bounded local cache.
   - Parallel scans do not guarantee global input order without an explicit
     DataFusion sort.
+  - PGEN release qualification requires a reproducible single-thread oracle
+    benchmark and bounded-memory scaling report, not only internal Criterion
+    timings.
 - Licensing:
   - Apache-2.0/MIT Rust libraries may be considered as runtime dependencies.
   - LGPL `pgenlib` and GPL `grgl` are test or behavioral references only unless

--- a/openspec/changes/add-genotype-format-providers/specs/genotype-provider-core/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/genotype-provider-core/spec.md
@@ -310,6 +310,11 @@ I/O, decompression, genotype decoding, and emitted rows.
 - **WHEN** a format partition reads internal dependency records
 - **THEN** metrics distinguish dependency reads from emitted variant rows.
 
+#### Scenario: Compressed companion input
+- **WHEN** a compressed companion object is fetched and decoded
+- **THEN** physical I/O metrics report the fetched compressed byte count
+- **AND** do not substitute the decoded in-memory size.
+
 ### Requirement: Contextual And Non-Lossy Errors
 
 The system SHALL distinguish malformed input, unsupported valid features,

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -196,8 +196,8 @@ counting PVAR alternate allele index one.
 ### Requirement: PGEN Phased Dosage Output
 
 The system SHALL decode valid phased dosage tracks into
-`HDS: List<List<Float32>>` in stored haplotype order and preserve their
-relationship to total dosage.
+`HDS: List<FixedSizeList<Float32, 2>>` in stored haplotype order and preserve
+their relationship to total dosage.
 
 #### Scenario: Complete phased dosage
 - **WHEN** both haplotype dosages are stored for a selected sample

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -189,6 +189,11 @@ counting PVAR alternate allele index one.
 - **AND** `DS_STORED` is null when projected
 - **AND** `GT` remains available when requested.
 
+#### Scenario: Multiallelic hardcall fallback
+- **WHEN** a multiallelic hardcall has no stored dosage
+- **THEN** `DS` counts only alleles equal to PVAR allele index one
+- **AND** higher alternate alleles do not contribute to `DS`.
+
 #### Scenario: Missing genotype and dosage
 - **WHEN** both hardcall and dosage are missing
 - **THEN** `DS`, `DS_STORED`, and `GT` are null when projected.

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -66,6 +66,11 @@ length and record order.
 - **WHEN** an index offset is out of bounds or not monotonic where required
 - **THEN** the fileset is rejected with index and variant context.
 
+#### Scenario: External-index data boundary
+- **WHEN** an external PGI declares a nonempty primary PGEN's first record
+  offset
+- **THEN** that offset is exactly byte 3, immediately after the primary magic.
+
 ### Requirement: PVAR Variant Semantics
 
 The system SHALL expose PVAR chromosome, site coordinates, variant ID,
@@ -311,6 +316,11 @@ predicates exactly against PVAR before PGEN payload planning.
 - **WHEN** a safe limit follows only exact PVAR predicates
 - **THEN** owned output record planning may stop after the required matches
 - **AND** required LD preludes are still included.
+
+#### Scenario: Exact PVAR rejection metric
+- **WHEN** exact PVAR predicates reject some or all catalog rows
+- **THEN** `ExactFilterRejections` reports the rejected count before any safe
+  limit truncation.
 
 ### Requirement: PGEN Projection And Sample Pushdown
 

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -446,7 +446,8 @@ PLINK 2 for supported features.
 #### Scenario: Empty embedded extension-mode fileset
 - **WHEN** an embedded extension-mode PGEN declares zero variants
 - **THEN** the provider parses the header and footer extension-flag varints
-- **AND** validates that the declared data boundary follows those varints.
+- **AND** validates that the declared data boundary follows the header extensions
+- **AND** does not fetch a declared footer while locating that boundary.
 
 #### Scenario: Differential fixture
 - **WHEN** a supported synthetic fileset is read by this provider and PLINK 2

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -278,6 +278,12 @@ dependency anchors required to decode LD-compressed records independently.
 - **THEN** only its owning partition emits it
 - **AND** dependency metrics record the duplicate internal read.
 
+#### Scenario: Dependency auxiliary-track validation
+- **WHEN** an unowned LD base declares patch, phase, dosage, or phased-dosage
+  tracks
+- **THEN** every declared track is consumed and validated without emitting the
+  dependency row.
+
 #### Scenario: Invalid LD chain
 - **WHEN** an LD record has no valid preceding base under the specification
 - **THEN** decoding fails with the dependent variant index.
@@ -450,6 +456,10 @@ storage using bounded header, index, record, PVAR, and PSAM reads.
 #### Scenario: Adjacent selected records
 - **WHEN** selected records and their dependencies occupy nearby ranges
 - **THEN** requests may be coalesced within configured thresholds.
+
+#### Scenario: Local partition range reuse
+- **WHEN** one local partition reads multiple coalesced ranges
+- **THEN** it reuses one open file handle and range buffer for those reads.
 
 ### Requirement: PGEN Integrity And Conformance
 

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -443,6 +443,11 @@ PLINK 2 for supported features.
 - **WHEN** a record ends during a varint, difflist, patch, or dosage track
 - **THEN** the stream fails with variant and byte-offset context.
 
+#### Scenario: Empty embedded extension-mode fileset
+- **WHEN** an embedded extension-mode PGEN declares zero variants
+- **THEN** the provider parses the header and footer extension-flag varints
+- **AND** validates that the declared data boundary follows those varints.
+
 #### Scenario: Differential fixture
 - **WHEN** a supported synthetic fileset is read by this provider and PLINK 2
   or external `pgenlib`

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -80,6 +80,15 @@ reference allele, and all alternate alleles without reducing multiallelic rows.
 - **THEN** required column interpretation follows that header
 - **AND** unsupported optional annotations do not alter allele indices.
 
+#### Scenario: Headerless PVAR
+- **WHEN** PVAR has no header line
+- **THEN** columns follow BIM order `CHROM, ID, CM, POS, ALT, REF`
+- **AND** a five-column row is interpreted as the same order with `CM` omitted.
+
+#### Scenario: Biallelic-only PGEN mode
+- **WHEN** a PLINK1 or fixed-width PGEN mode is paired with a multiallelic PVAR
+- **THEN** provider construction fails before metadata or genotype rows are exposed.
+
 #### Scenario: Invalid PVAR position
 - **WHEN** a PVAR row has an invalid one-based position or malformed allele list
 - **THEN** planning fails with the PVAR line number.

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -106,7 +106,7 @@ PGEN.
 ### Requirement: PGEN Raw Allele Output
 
 The system SHALL provide a raw allele mode with
-`GT: List<List<UInt16>>` containing PVAR allele indices and
+`GT: List<FixedSizeList<UInt16, 2>>` containing PVAR allele indices and
 `PHASED: List<Boolean>` describing whether allele order is phased for each
 selected sample.
 
@@ -165,8 +165,9 @@ eligible heterozygous hardcalls and SHALL reject inconsistent phase bits.
 
 ### Requirement: PGEN Biallelic Dosage Output
 
-The system SHALL decode stored biallelic dosage and dosage-presence tracks into
-`DS: List<Float32>` where values count PVAR alternate allele index one.
+The system SHALL expose effective biallelic dosage as `DS: List<Float32>` and
+optionally stored-only dosage as `DS_STORED: List<Float32>`, with both fields
+counting PVAR alternate allele index one.
 
 #### Scenario: Stored dosage
 - **WHEN** a selected sample has a stored dosage value
@@ -175,12 +176,18 @@ The system SHALL decode stored biallelic dosage and dosage-presence tracks into
 
 #### Scenario: No stored dosage
 - **WHEN** a selected sample has a hardcall but no stored dosage
-- **THEN** `DS` is null
+- **THEN** `DS` contains exact hardcall-derived dosage 0, 1, or 2
+- **AND** `DS_STORED` is null when projected
 - **AND** `GT` remains available when requested.
 
 #### Scenario: Missing genotype and dosage
 - **WHEN** both hardcall and dosage are missing
-- **THEN** their output values are null.
+- **THEN** `DS`, `DS_STORED`, and `GT` are null when projected.
+
+#### Scenario: Stored dosage overrides hardcall
+- **WHEN** a selected sample has a valid stored dosage value
+- **THEN** `DS` and `DS_STORED` contain that specification-scaled value
+- **AND** `DS` does not substitute the hardcall-derived integer.
 
 #### Scenario: Invalid dosage
 - **WHEN** a dosage integer or presence track violates bounds or record length
@@ -289,16 +296,114 @@ representation.
 
 #### Scenario: Hardcall-only projection
 - **WHEN** `GT` is requested but dosage fields are not
-- **THEN** dosage tracks are skipped by their declared lengths.
+- **THEN** dosage tracks are validated and skipped by their declared lengths
+- **AND** no dosage, phase, or phased-dosage logical vectors are allocated.
 
 #### Scenario: Dosage-only projection
 - **WHEN** `DS` is requested but phase and phased dosage are not
-- **THEN** unrequested phase tracks are not converted into Arrow arrays.
+- **THEN** unrequested phase tracks are not converted into Arrow arrays
+- **AND** only the minimum hardcall state needed for effective dosage fallback
+  is retained.
 
 #### Scenario: Sparse sample selection
 - **WHEN** a sample subset is selected
 - **THEN** dense and sparse record paths append only selected sample values
 - **AND** difflist membership tests preserve request order.
+
+#### Scenario: Direct batch construction
+- **WHEN** projected PGEN values are decoded
+- **THEN** they are appended directly to reusable Arrow builders
+- **AND** the provider does not retain a full-cohort decoded-row copy until
+  batch flush.
+
+### Requirement: Explicit PGEN Ploidy Semantics
+
+The system SHALL treat the initial PGEN raw allele representation as two
+encoded allele slots and SHALL NOT infer biological chromosome ploidy without
+an explicit future ploidy policy.
+
+#### Scenario: Encoded diploid output
+- **WHEN** a caller reads raw `GT` with the initial provider
+- **THEN** each called sample contains the two allele slots encoded by PGEN
+- **AND** schema metadata declares `ploidy_semantics=encoded_diploid`.
+
+#### Scenario: Oracle comparison
+- **WHEN** output is compared with `snputils` or `pgenlib`
+- **THEN** the oracle uses its autosomal/diploid mode
+- **AND** no chromosome-derived haploid rewrite is included in the comparison.
+
+#### Scenario: Biological ploidy request
+- **WHEN** a caller requests chromosome-aware biological ploidy without a
+  supported explicit genome-build and ploidy policy
+- **THEN** planning fails as unsupported rather than guessing PAR or sex rules.
+
+### Requirement: Bounded PGEN Decoder State
+
+The system SHALL reuse partition-local decode workspaces and SHALL bound
+intermediate state by selected sample width, projected fields, batch budget,
+range buffer limits, and one current LD base.
+
+#### Scenario: LD-heavy partition
+- **WHEN** a partition decodes many LD-compressed records
+- **THEN** only the most recent eligible base is retained
+- **AND** no full-cohort base vector is cloned per dependent record.
+
+#### Scenario: Wide cohort
+- **WHEN** the selected cohort makes one Arrow row large
+- **THEN** the row may be emitted alone under the documented soft budget
+- **AND** completed decoded rows are not duplicated in an intermediate batch.
+
+#### Scenario: Large variant catalog
+- **WHEN** a PGEN contains many `2^16`-variant index blocks
+- **THEN** record metadata is decoded blockwise or compactly
+- **AND** planning does not require an independently allocated descriptor for
+  every record before the first partition can scan.
+
+### Requirement: PGEN Single-Thread Performance Parity
+
+The system SHALL meet or beat the pinned `snputils` single-thread baseline for
+an equivalent full-cohort biallelic phased `GT` scan before PGEN is enabled in
+release artifacts.
+
+#### Scenario: Reproducible parity benchmark
+- **WHEN** the PGEN release benchmark is run
+- **THEN** Rust and the pinned oracle use the same official-writer fixture,
+  variant/sample selection, warm-cache policy, and release/native-code policy
+- **AND** DataFusion, Tokio, Python, BLAS, Rayon, and OpenMP concurrency are each
+  constrained to one thread
+- **AND** the Rust median decode-plus-materialize time over at least ten measured
+  iterations is no greater than the oracle median.
+
+#### Scenario: Transparent output cost
+- **WHEN** benchmark output layouts use different physical widths
+- **THEN** materialized bytes and peak RSS are reported beside wall time
+- **AND** the layout difference does not silently relax the parity gate.
+
+#### Scenario: Multicore scaling
+- **WHEN** the same scan uses two, four, or more DataFusion target partitions
+- **THEN** no nested decoder thread pool is created
+- **AND** throughput, efficiency, peak RSS, partition balance, and LD prelude
+  work are reported.
+
+### Requirement: Explicit PGEN Allele-Width Support
+
+The system SHALL publish and enforce the allele-index width supported by its
+Arrow schema independently of the narrower limits of a selected oracle.
+
+#### Scenario: Supported allele width
+- **WHEN** all PVAR allele indices fit in `UInt16`
+- **THEN** multiallelic hardcalls preserve those exact indices.
+
+#### Scenario: Unsupported allele width
+- **WHEN** a record requires an allele index not representable by `UInt16`
+- **THEN** planning or decoding fails with a distinct unsupported-width error
+- **AND** no index is truncated or wrapped.
+
+#### Scenario: Oracle-limited fixture
+- **WHEN** differential testing uses the current official `pgenlib` oracle
+- **THEN** fixtures respect that oracle's current allele-count limit
+- **AND** documentation does not claim that limit is imposed by the PGEN file
+  specification.
 
 ### Requirement: PGEN Object-Store Range Access
 

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -242,6 +242,11 @@ PVAR allele indices without collapsing alternate alleles.
 - **WHEN** both allele positions are patched
 - **THEN** both exact allele indices and stored phase order are preserved.
 
+#### Scenario: Declared higher alternate is unused
+- **WHEN** PVAR declares ALT2 or higher but all hardcalls use only REF and ALT1
+- **THEN** a record without a multiallelic patch track retains its main-track
+  calls.
+
 #### Scenario: Invalid patch allele
 - **WHEN** a patch references an allele outside the PVAR allele list
 - **THEN** decoding fails with variant and sample context.

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -39,6 +39,11 @@ PGEN specification.
 - **WHEN** required header fields, control bytes, or offsets are inconsistent
 - **THEN** planning fails before genotype record decoding.
 
+#### Scenario: Phased dosage without dosage
+- **WHEN** a variable-width record type declares phased dosage without a dosage
+  track
+- **THEN** provider construction fails before metadata-only rows are exposed.
+
 ### Requirement: PGEN Index Support
 
 The system SHALL use mode-appropriate embedded indexes and supported external
@@ -307,6 +312,12 @@ representation.
 - **THEN** no PGEN variant record payload bytes are read
 - **AND** minimal PGEN header/index bytes may still be read for fileset
   validation.
+
+#### Scenario: Explicit empty genotype child selection
+- **WHEN** the configured genotype-field selection is explicitly empty and the
+  zero-child `genotypes` struct is projected
+- **THEN** the struct preserves the selected variant row count
+- **AND** no PGEN variant record payload bytes are read.
 
 #### Scenario: Hardcall-only projection
 - **WHEN** `GT` is requested but dosage fields are not

--- a/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/pgen/spec.md
@@ -339,7 +339,9 @@ representation.
 - **WHEN** projected PGEN values are decoded
 - **THEN** they are appended directly to reusable Arrow builders
 - **AND** the provider does not retain a full-cohort decoded-row copy until
-  batch flush.
+  batch flush
+- **AND** initial builder capacity is bounded by both the row limit and the
+  configured soft byte limit.
 
 ### Requirement: Explicit PGEN Ploidy Semantics
 

--- a/openspec/changes/add-genotype-format-providers/tasks.md
+++ b/openspec/changes/add-genotype-format-providers/tasks.md
@@ -184,6 +184,24 @@
   allele patches, and dosage bounds.
 - [x] 6.22 Benchmark each record representation, sparse variants, sparse
   samples, LD-heavy files, dosage output, and parallel record blocks.
+- [x] 6.23 Build projection and sample plans once per scan and use reusable
+  partition-local decode workspaces.
+- [x] 6.24 Replace generic dense per-sample bit extraction with a specialized
+  packed-byte/word kernel and direct selected-sample gather path.
+- [ ] 6.25 Append decoded values directly to Arrow builders without retaining
+  full-cohort `DecodedRecord` and `DecodedRow` copies.
+- [ ] 6.26 Retain only the latest eligible LD base, update it in place, and add
+  allocation/copy assertions for LD-heavy scans.
+- [ ] 6.27 Reuse one local read handle and bounded range buffer per partition;
+  decode header indexes by block and compact or stream PVAR/PSAM catalogs.
+- [x] 6.28 Define effective `DS`, optional `DS_STORED`, missingness, and stored
+  dosage override behavior in oracle and hand-checked tests.
+- [ ] 6.29 Publish encoded-diploid ploidy metadata and reject unsupported
+  chromosome-aware requests instead of inferring genome-build/PAR rules.
+- [ ] 6.30 Enforce the public `UInt16` allele-width limit and maintain a separate
+  current-`pgenlib` oracle compatibility limit.
+- [x] 6.31 Rebase the PGEN implementation on the current genotype-core head and
+  verify that it does not revert intervening BCF/core changes.
 
 ## 7. GRG Provider
 
@@ -252,3 +270,11 @@
   sample/allele semantics, and benchmark results.
 - [ ] 9.12 Obtain per-format approval before enabling it in default release
   artifacts.
+- [x] 9.13 Add a pinned, official-writer PGEN parity harness that constrains all
+  runtime pools to one thread and compares at least ten post-warmup medians with
+  `snputils`/`pgenlib` on identical selections.
+- [x] 9.14 Require PGEN one-thread biallelic phased `GT` decode-plus-materialize
+  time to be no slower than the pinned `snputils` median; report provider-open,
+  full-fileset, output-byte, and peak-RSS results separately.
+- [ ] 9.15 Publish PGEN 1/2/4/8-partition scaling, balance, dependency-prelude,
+  decoded-value, allocation, and peak-memory metrics without nested pools.

--- a/openspec/changes/add-genotype-format-providers/tasks.md
+++ b/openspec/changes/add-genotype-format-providers/tasks.md
@@ -154,35 +154,35 @@
 
 ## 6. PGEN Provider
 
-- [ ] 6.1 Create the `bio-format-pgen` crate and allele/dosage output options.
-- [ ] 6.2 Resolve standard PGEN/PVAR/PSAM filesets and reject unsupported hybrid
+- [x] 6.1 Create the `bio-format-pgen` crate and allele/dosage output options.
+- [x] 6.2 Resolve standard PGEN/PVAR/PSAM filesets and reject unsupported hybrid
   companions explicitly.
-- [ ] 6.3 Parse PVAR variants, allele lists, IDs, positions, and optional metadata.
-- [ ] 6.4 Parse PSAM sample identifiers with an explicit documented ID policy.
-- [ ] 6.5 Parse and validate PGEN modes `0x01`, `0x02`, `0x03`, `0x04`, `0x10`,
+- [x] 6.3 Parse PVAR variants, allele lists, IDs, positions, and optional metadata.
+- [x] 6.4 Parse PSAM sample identifiers with an explicit documented ID policy.
+- [x] 6.5 Parse and validate PGEN modes `0x01`, `0x02`, `0x03`, `0x04`, `0x10`,
   `0x11`, `0x20`, and `0x21`.
-- [ ] 6.6 Parse embedded and external PGEN indexes and validate counts/offsets.
-- [ ] 6.7 Implement biallelic hardcall and missingness decoding.
-- [ ] 6.8 Implement difflist and one-bit genotype representations.
-- [ ] 6.9 Implement phase-present and phase-information decoding.
-- [ ] 6.10 Implement biallelic dosage and dosage-present decoding.
-- [ ] 6.11 Implement phased dosage decoding.
-- [ ] 6.12 Implement multiallelic hardcall patch decoding with PVAR allele indices.
-- [ ] 6.13 Reject unsupported multiallelic dosage portions with a distinct
+- [x] 6.6 Parse embedded and external PGEN indexes and validate counts/offsets.
+- [x] 6.7 Implement biallelic hardcall and missingness decoding.
+- [x] 6.8 Implement difflist and one-bit genotype representations.
+- [x] 6.9 Implement phase-present and phase-information decoding.
+- [x] 6.10 Implement biallelic dosage and dosage-present decoding.
+- [x] 6.11 Implement phased dosage decoding.
+- [x] 6.12 Implement multiallelic hardcall patch decoding with PVAR allele indices.
+- [x] 6.13 Reject unsupported multiallelic dosage portions with a distinct
   unsupported-feature error.
-- [ ] 6.14 Implement LD base tracking and dependency-prelude planning.
-- [ ] 6.15 Prove partitions emit owned variants once while dependency records
+- [x] 6.14 Implement LD base tracking and dependency-prelude planning.
+- [x] 6.15 Prove partitions emit owned variants once while dependency records
   remain internal.
-- [ ] 6.16 Apply exact PVAR filters and limits before PGEN payload reads.
-- [ ] 6.17 Apply sample selection within packed, sparse, and dosage paths.
-- [ ] 6.18 Skip PGEN variant record payloads for PVAR-only, exact count, and
+- [x] 6.16 Apply exact PVAR filters and limits before PGEN payload reads.
+- [x] 6.17 Apply sample selection within packed, sparse, and dosage paths.
+- [x] 6.18 Skip PGEN variant record payloads for PVAR-only, exact count, and
   empty-sample scans after minimal fileset validation.
-- [ ] 6.19 Support local and object-store range reads with index/header
+- [x] 6.19 Support local and object-store range reads with index/header
   coalescing.
-- [ ] 6.20 Add differential tests against PLINK 2 and external `pgenlib`.
-- [ ] 6.21 Add fuzz/property tests for varints, difflists, offsets, LD chains,
+- [x] 6.20 Add differential tests against PLINK 2 and external `pgenlib`.
+- [x] 6.21 Add fuzz/property tests for varints, difflists, offsets, LD chains,
   allele patches, and dosage bounds.
-- [ ] 6.22 Benchmark each record representation, sparse variants, sparse
+- [x] 6.22 Benchmark each record representation, sparse variants, sparse
   samples, LD-heavy files, dosage output, and parallel record blocks.
 
 ## 7. GRG Provider


### PR DESCRIPTION
## Summary

- add an independent Rust DataFusion provider for PLINK 2 PGEN/PVAR/PSAM filesets
- support standard fixed, variable, extension, and external-index storage modes; hardcalls, phase, biallelic dosage, phased dosage, multiallelic hardcalls, filters, sample selection, bounded range reads, and LD-aware partitioning
- expose raw `GT` as nullable `List<FixedSizeList<UInt16, 2>>` with explicit encoded-diploid semantics
- define effective `DS`, source-only `DS_STORED`, and specification-compatible explicit and implicit `HDS`
- add an exact-`GT` path that decodes packed calls directly into Arrow buffers with reusable partition-local state and no nested thread pool
- add a pinned official-writer/`pgenlib`/`snputils` correctness and performance harness, plus the OpenSpec audit and release gate

## Why

The original draft eagerly decoded every genotype child for every sample, retained decoded rows before copying them into Arrow, and used generic per-sample packed-bit extraction. That made the common full-cohort `GT` projection substantially slower and more allocation-heavy than the reference implementation.

The specialized path now performs projection-aware decoding, uses a four-call lookup kernel for dense records, appends directly to Arrow buffers, retains only the required GT LD base, and lets DataFusion partitions own multicore scaling.

## Performance

Official-`pgenlib` writer fixture: 16,384 fully phased biallelic variants by 1,024 samples, 0.5% missing, seed `20260816`, ten measured iterations after warmup on an Apple M3 Max.

| Reader | Threads/partitions | Median |
| --- | ---: | ---: |
| pinned `snputils` | 1 | 71.60 ms |
| Rust PGEN | 1 | 33.02 ms |
| Rust PGEN | 2 | 18.26 ms |
| Rust PGEN | 4 | 9.72 ms |
| Rust PGEN | 8 | 7.03 ms |

The one-partition Rust path is about 2.17x faster than the constrained one-thread oracle despite emitting a wider nullable Arrow representation. Both readers produced the exact digest:

```text
16692912:8342602:8347936:560154221234404
```

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy -p datafusion-bio-format-pgen --all-targets -- -D warnings`
- `cargo test -p datafusion-bio-format-pgen --all-targets`
- required external `pgenlib`/`snputils` differential test
- `openspec validate add-genotype-format-providers --strict`
- repository pre-commit hooks, including workspace Clippy

The committed `BENCHMARKS.md`, oracle harness, and `pgen-audit.md` contain the reproduction commands, pinned versions, architectural findings, and remaining non-gating optimization work.
