### PR TITLE
Speed up the BGEN probability path

### DIFF
--- a/datafusion/bio-format-bgen/benches/bgen_scan.rs
+++ b/datafusion/bio-format-bgen/benches/bgen_scan.rs
@@ -415,7 +415,7 @@ fn benchmarks(criterion: &mut Criterion) {
                 if output_mode == BgenOutputMode::Dosage && layout == BgenProbabilityLayout::Fixed {
                     continue;
                 }
-                for partitions in [1_usize, 8] {
+                for partitions in [1_usize, 2, 4, 8] {
                     let table = format!("real_{mode_name}_{layout_name}_p{partitions}");
                     let context = runtime.block_on(try_context(
                         &real_path,
@@ -423,6 +423,14 @@ fn benchmarks(criterion: &mut Criterion) {
                         BgenReadOptions {
                             output_mode,
                             probability_layout: layout,
+                            // Payload ranges are capped at one partition's byte
+                            // share, so a scan gets `target_partitions + 1`
+                            // indivisible chunks and cannot balance them. Set
+                            // this to explore finer range sizing.
+                            max_range_bytes: std::env::var("BGEN_BENCH_MAX_RANGE_BYTES")
+                                .ok()
+                                .and_then(|value| value.parse().ok())
+                                .unwrap_or(16 * 1024 * 1024),
                             ..Default::default()
                         },
                         partitions,

--- a/datafusion/bio-format-bgen/benches/bgen_scan.rs
+++ b/datafusion/bio-format-bgen/benches/bgen_scan.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion::prelude::{SessionConfig, SessionContext};
-use datafusion_bio_format_bgen::{BgenOutputMode, BgenReadOptions, BgenTableProvider};
+use datafusion_bio_format_bgen::{
+    BgenOutputMode, BgenProbabilityLayout, BgenReadOptions, BgenTableProvider,
+};
 use flate2::Compression as FlateCompression;
 use flate2::write::ZlibEncoder;
 use rusqlite::{Connection, params};
@@ -234,6 +236,35 @@ async fn context(
     context
 }
 
+/// Builds a context and proves its scan works.
+///
+/// Returns `None` for a combination the file does not support, so one
+/// unsupported case is skipped rather than panicking the whole run. A
+/// mixed-width file cannot use the fixed probability layout today; that is the
+/// case this exists for, and its disappearance is a deliverable.
+async fn try_context(
+    path: &str,
+    name: &str,
+    options: BgenReadOptions,
+    partitions: usize,
+) -> Option<SessionContext> {
+    let provider = BgenTableProvider::try_new(path, options).await.ok()?;
+    let context =
+        SessionContext::new_with_config(SessionConfig::new().with_target_partitions(partitions));
+    context.register_table(name, Arc::new(provider)).ok()?;
+    // A whole scan, not a LIMIT: the case this guards against is a variant
+    // whose width differs from variant 0's, and a limited scan reads variant 0.
+    // The cost is one extra scan per benched combination at setup.
+    context
+        .sql(&format!("SELECT genotypes FROM {name}"))
+        .await
+        .ok()?
+        .collect()
+        .await
+        .ok()?;
+    Some(context)
+}
+
 async fn execute(context: &SessionContext, sql: &str) -> usize {
     context
         .sql(sql)
@@ -347,6 +378,53 @@ fn benchmarks(criterion: &mut Criterion) {
             black_box(execute(&parallel, "SELECT genotypes FROM bgen_parallel").await)
         });
     });
+
+    // A real cohort file is the only fixture that can guide probability-path
+    // work; the synthetic one above is 2,048 x 256 and dominated by fixed
+    // costs. Opt in with BGEN_BENCH_PATH so CI, which has no such file, keeps
+    // running the synthetic benches alone.
+    if let Ok(real_path) = std::env::var("BGEN_BENCH_PATH") {
+        let mut contexts = Vec::new();
+        for (mode_name, output_mode) in [
+            ("probability", BgenOutputMode::Probability),
+            ("dosage", BgenOutputMode::Dosage),
+        ] {
+            for (layout_name, layout) in [
+                ("nested", BgenProbabilityLayout::Nested),
+                ("fixed", BgenProbabilityLayout::Fixed),
+            ] {
+                // The layout only applies to probability output.
+                if output_mode == BgenOutputMode::Dosage && layout == BgenProbabilityLayout::Fixed {
+                    continue;
+                }
+                for partitions in [1_usize, 8] {
+                    let table = format!("real_{mode_name}_{layout_name}_p{partitions}");
+                    let context = runtime.block_on(try_context(
+                        &real_path,
+                        &table,
+                        BgenReadOptions {
+                            output_mode,
+                            probability_layout: layout,
+                            ..Default::default()
+                        },
+                        partitions,
+                    ));
+                    match context {
+                        Some(context) => contexts.push((table, context)),
+                        None => eprintln!("skipping {table}: this file does not support it"),
+                    }
+                }
+            }
+        }
+        for (table, context) in &contexts {
+            let sql = format!("SELECT genotypes FROM {table}");
+            group.bench_function(table, |bencher| {
+                bencher
+                    .to_async(&runtime)
+                    .iter(|| async { black_box(execute(context, &sql).await) });
+            });
+        }
+    }
     group.finish();
 }
 

--- a/datafusion/bio-format-bgen/benches/bgen_scan.rs
+++ b/datafusion/bio-format-bgen/benches/bgen_scan.rs
@@ -384,6 +384,24 @@ fn benchmarks(criterion: &mut Criterion) {
     // costs. Opt in with BGEN_BENCH_PATH so CI, which has no such file, keeps
     // running the synthetic benches alone.
     if let Ok(real_path) = std::env::var("BGEN_BENCH_PATH") {
+        // Criterion saves a baseline per benchmark id, so two fixtures sharing
+        // an id would compare against each other and report the difference
+        // between the files as a change in the code.
+        let fixture = std::path::Path::new(&real_path)
+            .file_stem()
+            .map(|stem| {
+                stem.to_string_lossy()
+                    .chars()
+                    .map(|character| {
+                        if character.is_alphanumeric() {
+                            character
+                        } else {
+                            '_'
+                        }
+                    })
+                    .collect::<String>()
+            })
+            .unwrap_or_else(|| "fixture".to_string());
         let mut contexts = Vec::new();
         for (mode_name, output_mode) in [
             ("probability", BgenOutputMode::Probability),
@@ -410,15 +428,19 @@ fn benchmarks(criterion: &mut Criterion) {
                         partitions,
                     ));
                     match context {
-                        Some(context) => contexts.push((table, context)),
-                        None => eprintln!("skipping {table}: this file does not support it"),
+                        Some(context) => {
+                            let id =
+                                format!("real_{fixture}_{mode_name}_{layout_name}_p{partitions}");
+                            contexts.push((id, table, context));
+                        }
+                        None => eprintln!("skipping {table} on {fixture}: unsupported"),
                     }
                 }
             }
         }
-        for (table, context) in &contexts {
+        for (id, table, context) in &contexts {
             let sql = format!("SELECT genotypes FROM {table}");
-            group.bench_function(table, |bencher| {
+            group.bench_function(id, |bencher| {
                 bencher
                     .to_async(&runtime)
                     .iter(|| async { black_box(execute(context, &sql).await) });

--- a/datafusion/bio-format-bgen/benches/bgen_scan.rs
+++ b/datafusion/bio-format-bgen/benches/bgen_scan.rs
@@ -236,6 +236,23 @@ async fn context(
     context
 }
 
+/// Coalesced payload range cap for the real-file benches.
+///
+/// Payload ranges are otherwise capped at one partition's byte share, so a scan
+/// gets `target_partitions + 1` indivisible chunks and cannot balance them.
+/// Setting `BGEN_BENCH_MAX_RANGE_BYTES` explores finer range sizing. A value
+/// that does not parse aborts rather than silently measuring the default, which
+/// would report numbers the operator did not ask for.
+fn max_range_bytes() -> u64 {
+    const DEFAULT: u64 = 16 * 1024 * 1024;
+    match std::env::var("BGEN_BENCH_MAX_RANGE_BYTES") {
+        Ok(value) => value.parse().unwrap_or_else(|_| {
+            panic!("BGEN_BENCH_MAX_RANGE_BYTES must be a byte count, got {value:?}")
+        }),
+        Err(_) => DEFAULT,
+    }
+}
+
 /// Builds a context and proves its scan works.
 ///
 /// Returns `None` for a combination the file does not support, so one
@@ -427,10 +444,7 @@ fn benchmarks(criterion: &mut Criterion) {
                             // share, so a scan gets `target_partitions + 1`
                             // indivisible chunks and cannot balance them. Set
                             // this to explore finer range sizing.
-                            max_range_bytes: std::env::var("BGEN_BENCH_MAX_RANGE_BYTES")
-                                .ok()
-                                .and_then(|value| value.parse().ok())
-                                .unwrap_or(16 * 1024 * 1024),
+                            max_range_bytes: max_range_bytes(),
                             ..Default::default()
                         },
                         partitions,

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -1,0 +1,440 @@
+//! Arrow-shaped output buffers for one BGEN batch.
+//!
+//! A decoder that stages each variant in its own allocation pays for it three
+//! times: the allocation itself, the per-sample bookkeeping, and a copy into
+//! the batch's buffers. These buffers are written directly by the decoder and
+//! moved into Arrow arrays when the batch is emitted, so a probability makes
+//! one trip from the bitstream to the output.
+
+// Nothing calls this yet: the decoder is moved onto it in the next commit, and
+// this attribute goes with that move. It exists so this commit is one
+// reviewable unit rather than a rewrite of the decoder and its buffers at once.
+#![allow(dead_code)]
+
+use datafusion::arrow::array::BooleanBufferBuilder;
+use datafusion::arrow::buffer::NullBuffer;
+use datafusion::common::{DataFusionError, Result};
+
+/// How a batch's values are laid out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BufferLayout {
+    /// Probabilities padded to a fixed number of states per sample.
+    FixedProbability(usize),
+    /// Probabilities with one variable-length list per sample.
+    NestedProbability,
+    /// One dosage per sample.
+    Dosage,
+}
+
+/// Buffer lengths at a point in time, so one variant's writes can be undone.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BufferMark {
+    values: usize,
+    sample_offsets: usize,
+    samples: usize,
+    variant_offsets: usize,
+    ploidy: usize,
+    ploidy_offsets: usize,
+}
+
+/// Arrow buffers for the batch currently being built.
+#[derive(Debug)]
+pub(crate) struct GenotypeBuffers {
+    layout: BufferLayout,
+    values: Vec<f32>,
+    /// Empty unless `layout` is [`BufferLayout::NestedProbability`].
+    sample_offsets: Vec<i32>,
+    /// Materialized on the first missing sample and backfilled; a fully called
+    /// cohort writes no validity at all.
+    valid: Option<BooleanBufferBuilder>,
+    samples: usize,
+    /// Index into `values` where the sample being written began.
+    sample_start: usize,
+    variant_offsets: Vec<i32>,
+    ploidy: Vec<u8>,
+    ploidy_offsets: Vec<i32>,
+}
+
+/// One batch's buffers, moved out for Arrow construction.
+#[derive(Debug)]
+pub(crate) struct TakenBuffers {
+    pub(crate) values: Vec<f32>,
+    pub(crate) sample_offsets: Vec<i32>,
+    pub(crate) nulls: Option<NullBuffer>,
+    pub(crate) variant_offsets: Vec<i32>,
+    pub(crate) ploidy: Vec<u8>,
+    pub(crate) ploidy_offsets: Vec<i32>,
+}
+
+impl GenotypeBuffers {
+    pub(crate) fn new(layout: BufferLayout) -> Self {
+        Self {
+            layout,
+            values: Vec::new(),
+            sample_offsets: match layout {
+                BufferLayout::NestedProbability => vec![0],
+                _ => Vec::new(),
+            },
+            valid: None,
+            samples: 0,
+            sample_start: 0,
+            variant_offsets: vec![0],
+            ploidy: Vec::new(),
+            ploidy_offsets: vec![0],
+        }
+    }
+
+    pub(crate) fn rows(&self) -> usize {
+        self.variant_offsets.len() - 1
+    }
+
+    /// The values buffer, for a decoder that appends a whole sample at once.
+    #[inline]
+    pub(crate) fn values_mut(&mut self) -> &mut Vec<f32> {
+        &mut self.values
+    }
+
+    #[inline]
+    pub(crate) fn push_state(&mut self, value: f32) {
+        self.values.push(value);
+    }
+
+    #[inline]
+    pub(crate) fn extend_states(&mut self, values: impl IntoIterator<Item = f32>) {
+        self.values.extend(values);
+    }
+
+    /// Closes a called sample.
+    #[inline]
+    pub(crate) fn finish_sample(&mut self) -> Result<()> {
+        self.close_sample(true)
+    }
+
+    /// Closes a sample with no called genotype.
+    ///
+    /// A fixed layout still reserves the sample's slots, because Arrow sizes a
+    /// fixed-size list's values buffer from the entry count rather than from
+    /// offsets. Those slots are NaN so a consumer reading the values buffer
+    /// directly — which is the point of the fixed layout — does not see a real
+    /// 0.0 where there is no genotype.
+    #[inline]
+    pub(crate) fn finish_missing_sample(&mut self) -> Result<()> {
+        self.close_sample(false)
+    }
+
+    fn close_sample(&mut self, valid: bool) -> Result<()> {
+        match self.layout {
+            BufferLayout::FixedProbability(width) => {
+                let written = self.values.len() - self.sample_start;
+                if written > width {
+                    return Err(DataFusionError::Execution(format!(
+                        "BGEN fixed probability layout has {width} states per sample, but a \
+                         sample stores {written}; use the nested layout for this file"
+                    )));
+                }
+                self.values.resize(self.sample_start + width, f32::NAN);
+            }
+            BufferLayout::NestedProbability => {
+                let end = i32::try_from(self.values.len()).map_err(|_| {
+                    DataFusionError::Execution(
+                        "BGEN probability offsets exceed the 32-bit Arrow list limit".to_string(),
+                    )
+                })?;
+                self.sample_offsets.push(end);
+            }
+            BufferLayout::Dosage => {
+                debug_assert_eq!(
+                    self.values.len() - self.sample_start,
+                    usize::from(valid),
+                    "a dosage sample writes exactly one value when called and none when missing"
+                );
+                if !valid {
+                    self.values.push(f32::NAN);
+                }
+            }
+        }
+        if !valid && self.valid.is_none() {
+            let mut builder = BooleanBufferBuilder::new(self.samples + 1);
+            builder.append_n(self.samples, true);
+            self.valid = Some(builder);
+        }
+        if let Some(builder) = self.valid.as_mut() {
+            builder.append(valid);
+        }
+        self.samples += 1;
+        self.sample_start = self.values.len();
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn push_ploidy(&mut self, ploidy: u8) {
+        self.ploidy.push(ploidy);
+    }
+
+    /// Closes a variant's samples into one output row.
+    pub(crate) fn finish_variant(&mut self) -> Result<()> {
+        self.variant_offsets
+            .push(i32::try_from(self.samples).map_err(|_| {
+                DataFusionError::Execution(
+                    "BGEN sample offsets exceed the 32-bit Arrow list limit".to_string(),
+                )
+            })?);
+        self.ploidy_offsets
+            .push(i32::try_from(self.ploidy.len()).map_err(|_| {
+                DataFusionError::Execution(
+                    "BGEN ploidy offsets exceed the 32-bit Arrow list limit".to_string(),
+                )
+            })?);
+        Ok(())
+    }
+
+    pub(crate) fn mark(&self) -> BufferMark {
+        BufferMark {
+            values: self.values.len(),
+            sample_offsets: self.sample_offsets.len(),
+            samples: self.samples,
+            variant_offsets: self.variant_offsets.len(),
+            ploidy: self.ploidy.len(),
+            ploidy_offsets: self.ploidy_offsets.len(),
+        }
+    }
+
+    /// Undoes every write since `mark`, leaving a valid Arrow prefix.
+    ///
+    /// `valid` is a builder and cannot be truncated, so it is rebuilt. This runs
+    /// only when a variant fails to decode, which aborts the scan.
+    pub(crate) fn rollback(&mut self, mark: BufferMark) {
+        self.values.truncate(mark.values);
+        self.sample_offsets.truncate(mark.sample_offsets);
+        self.variant_offsets.truncate(mark.variant_offsets);
+        self.ploidy.truncate(mark.ploidy);
+        self.ploidy_offsets.truncate(mark.ploidy_offsets);
+        if let Some(mut builder) = self.valid.take() {
+            let buffer = builder.finish();
+            let mut rebuilt = BooleanBufferBuilder::new(mark.samples);
+            for index in 0..mark.samples {
+                rebuilt.append(buffer.value(index));
+            }
+            self.valid = Some(rebuilt);
+        }
+        self.samples = mark.samples;
+        self.sample_start = self.values.len();
+    }
+
+    /// Arrow bytes written since `mark`.
+    ///
+    /// Deliberately the same formula the staged `estimated_arrow_bytes` used —
+    /// values, ploidy, and one offset per ploidy entry — even though per-sample
+    /// offsets are now countable too. `GenotypeMetric::GenotypeBytes` is
+    /// reported from this, and three rounds of review on #220 were spent
+    /// settling what those counters mean.
+    pub(crate) fn bytes_since(&self, mark: BufferMark) -> usize {
+        let values = (self.values.len() - mark.values).saturating_mul(size_of::<f32>());
+        let ploidy = self.ploidy.len() - mark.ploidy;
+        values
+            .saturating_add(ploidy)
+            .saturating_add(ploidy.saturating_mul(size_of::<i32>()))
+    }
+
+    /// Moves the batch out, leaving empty buffers that keep their capacity.
+    pub(crate) fn take(&mut self) -> TakenBuffers {
+        let values = std::mem::take(&mut self.values);
+        let sample_offsets = std::mem::take(&mut self.sample_offsets);
+        let variant_offsets = std::mem::take(&mut self.variant_offsets);
+        let ploidy = std::mem::take(&mut self.ploidy);
+        let ploidy_offsets = std::mem::take(&mut self.ploidy_offsets);
+        let nulls = self
+            .valid
+            .take()
+            .map(|mut builder| NullBuffer::new(builder.finish()));
+
+        // A batch is very likely the same shape as the one before it, so the
+        // next batch starts at the previous batch's size. Without this the
+        // buffers reallocate their way up from zero on every batch, which is
+        // the allocator churn this design exists to remove.
+        self.values = Vec::with_capacity(values.len());
+        self.sample_offsets = match self.layout {
+            BufferLayout::NestedProbability => {
+                let mut offsets = Vec::with_capacity(sample_offsets.len());
+                offsets.push(0);
+                offsets
+            }
+            _ => Vec::new(),
+        };
+        self.variant_offsets = Vec::with_capacity(variant_offsets.len());
+        self.variant_offsets.push(0);
+        self.ploidy = Vec::with_capacity(ploidy.len());
+        self.ploidy_offsets = Vec::with_capacity(ploidy_offsets.len());
+        self.ploidy_offsets.push(0);
+        self.samples = 0;
+        self.sample_start = 0;
+
+        TakenBuffers {
+            values,
+            sample_offsets,
+            nulls,
+            variant_offsets,
+            ploidy,
+            ploidy_offsets,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fixed_layout_pads_a_short_sample_with_nan_and_writes_no_offsets() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(4));
+        buffers.extend_states([0.5, 0.25, 0.25]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+
+        let taken = buffers.take();
+        assert_eq!(taken.values.len(), 4, "the sample is padded to the width");
+        assert_eq!(&taken.values[..3], &[0.5, 0.25, 0.25]);
+        assert!(taken.values[3].is_nan(), "padding is NaN, not zero");
+        assert!(
+            taken.sample_offsets.is_empty(),
+            "a fixed-size list reads no per-sample offsets, so none are built"
+        );
+        assert_eq!(taken.variant_offsets, vec![0, 1]);
+        assert_eq!(taken.ploidy, vec![2]);
+        assert_eq!(taken.ploidy_offsets, vec![0, 1]);
+        assert!(taken.nulls.is_none(), "every sample was called");
+    }
+
+    #[test]
+    fn a_fixed_layout_rejects_a_sample_wider_than_its_width() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3));
+        buffers.extend_states([0.25, 0.25, 0.25, 0.25]);
+        let error = buffers.finish_sample().unwrap_err().to_string();
+        assert!(
+            error.contains("fixed probability layout") && error.contains("nested layout"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_fixed_layout_pads_a_missing_sample_to_the_full_width() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3));
+        buffers.finish_missing_sample().unwrap();
+        buffers.extend_states([1.0, 0.0, 0.0]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+
+        let taken = buffers.take();
+        assert_eq!(
+            taken.values.len(),
+            6,
+            "Arrow sizes the values buffer by entry count"
+        );
+        assert!(
+            taken.values[..3].iter().all(|value| value.is_nan()),
+            "a missing sample's slots read as NaN, not as a real 0.0"
+        );
+        let nulls = taken
+            .nulls
+            .expect("a missing sample needs a validity buffer");
+        assert!(nulls.is_null(0));
+        assert!(nulls.is_valid(1));
+    }
+
+    #[test]
+    fn a_nested_layout_writes_one_offset_per_sample_and_no_padding() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+        buffers.extend_states([0.5, 0.5]);
+        buffers.finish_sample().unwrap();
+        buffers.finish_missing_sample().unwrap();
+        buffers.extend_states([0.2, 0.3, 0.5]);
+        buffers.finish_sample().unwrap();
+        for _ in 0..3 {
+            buffers.push_ploidy(2);
+        }
+        buffers.finish_variant().unwrap();
+
+        let taken = buffers.take();
+        assert_eq!(taken.values, vec![0.5, 0.5, 0.2, 0.3, 0.5]);
+        assert_eq!(
+            taken.sample_offsets,
+            vec![0, 2, 2, 5],
+            "a missing sample occupies no states in the nested layout"
+        );
+        assert_eq!(taken.variant_offsets, vec![0, 3]);
+    }
+
+    #[test]
+    fn validity_appears_only_once_a_sample_is_missing() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage);
+        for value in [0.0_f32, 1.0, 2.0] {
+            buffers.push_state(value);
+            buffers.finish_sample().unwrap();
+        }
+        assert!(
+            buffers.take().nulls.is_none(),
+            "a fully called cohort must write no validity bytes at all"
+        );
+
+        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage);
+        buffers.push_state(0.0);
+        buffers.finish_sample().unwrap();
+        buffers.finish_missing_sample().unwrap();
+        buffers.push_state(2.0);
+        buffers.finish_sample().unwrap();
+        let nulls = buffers
+            .take()
+            .nulls
+            .expect("a missing dosage needs validity");
+        assert!(
+            nulls.is_valid(0),
+            "samples before the first missing one are backfilled"
+        );
+        assert!(nulls.is_null(1));
+        assert!(nulls.is_valid(2));
+    }
+
+    #[test]
+    fn rollback_restores_every_buffer_to_its_mark() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+        buffers.extend_states([1.0, 0.0]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+
+        let mark = buffers.mark();
+        buffers.extend_states([0.0, 1.0]);
+        buffers.finish_missing_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.rollback(mark);
+
+        let taken = buffers.take();
+        assert_eq!(taken.values, vec![1.0, 0.0]);
+        assert_eq!(taken.sample_offsets, vec![0, 2]);
+        assert_eq!(taken.variant_offsets, vec![0, 1]);
+        assert_eq!(taken.ploidy, vec![2]);
+    }
+
+    #[test]
+    fn take_resets_the_buffers_and_keeps_their_capacity() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(2));
+        buffers.extend_states([0.5, 0.5]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+        let taken = buffers.take();
+        assert_eq!(taken.values.len(), 2);
+
+        assert_eq!(buffers.rows(), 0, "take leaves an empty batch");
+        let second = buffers.take();
+        assert!(second.values.is_empty());
+        assert_eq!(
+            second.variant_offsets,
+            vec![0],
+            "a reset batch still carries its leading zero offset"
+        );
+    }
+}

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -219,6 +219,13 @@ impl GenotypeBuffers {
     /// offsets are now countable too. `GenotypeMetric::GenotypeBytes` is
     /// reported from this, and three rounds of review on #220 were spent
     /// settling what those counters mean.
+    ///
+    /// The consequence, unchanged from before but worth stating: a
+    /// [`BufferLayout::NestedProbability`] batch is undercounted by its
+    /// per-sample offsets, four bytes per sample per variant, so such a batch
+    /// can exceed `batch_soft_byte_limit` by roughly a quarter for a diploid
+    /// biallelic cohort. The fixed layout, which emits no per-sample offsets,
+    /// is counted exactly.
     pub(crate) fn bytes_since(&self, mark: BufferMark) -> usize {
         let values = (self.values.len() - mark.values).saturating_mul(size_of::<f32>());
         let ploidy = self.ploidy.len() - mark.ploidy;

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -6,11 +6,6 @@
 //! moved into Arrow arrays when the batch is emitted, so a probability makes
 //! one trip from the bitstream to the output.
 
-// Nothing calls this yet: the decoder is moved onto it in the next commit, and
-// this attribute goes with that move. It exists so this commit is one
-// reviewable unit rather than a rewrite of the decoder and its buffers at once.
-#![allow(dead_code)]
-
 use datafusion::arrow::array::BooleanBufferBuilder;
 use datafusion::arrow::buffer::NullBuffer;
 use datafusion::common::{DataFusionError, Result};
@@ -82,10 +77,6 @@ impl GenotypeBuffers {
             ploidy: Vec::new(),
             ploidy_offsets: vec![0],
         }
-    }
-
-    pub(crate) fn rows(&self) -> usize {
-        self.variant_offsets.len() - 1
     }
 
     /// The values buffer, for a decoder that appends a whole sample at once.
@@ -428,13 +419,12 @@ mod tests {
         let taken = buffers.take();
         assert_eq!(taken.values.len(), 2);
 
-        assert_eq!(buffers.rows(), 0, "take leaves an empty batch");
         let second = buffers.take();
         assert!(second.values.is_empty());
         assert_eq!(
             second.variant_offsets,
             vec![0],
-            "a reset batch still carries its leading zero offset"
+            "take leaves an empty batch that still carries its leading zero offset"
         );
     }
 }

--- a/datafusion/bio-format-bgen/src/decode.rs
+++ b/datafusion/bio-format-bgen/src/decode.rs
@@ -1,91 +1,22 @@
 use datafusion::common::{DataFusionError, Result};
 use datafusion_bio_format_core::companion::sanitize_location;
 
+use crate::buffers::GenotypeBuffers;
 use crate::catalog::BgenVariant;
 use crate::header::{BgenCompression, BgenHeader, BgenLayout};
-use crate::table_provider::{BgenOutputMode, BgenProbabilityLayout, BgenReadOptions};
+use crate::table_provider::{BgenOutputMode, BgenReadOptions};
 
+/// What a decoded variant reports beyond the values it wrote into the batch
+/// buffers.
 #[derive(Debug)]
 pub(crate) struct DecodedGenotypes {
     pub(crate) phased: bool,
     pub(crate) bits: u8,
-    pub(crate) ploidy: Vec<u8>,
-    pub(crate) values: DecodedValues,
     pub(crate) decompressed_bytes: usize,
     /// Probability states every sample of this variant stores, when the variant
     /// declares one ploidy. `None` for a variable-ploidy variant, whose samples
     /// do not share a width.
     pub(crate) state_width: Option<usize>,
-}
-
-/// One variant's per-sample probability vectors in a flat layout.
-///
-/// A vector per sample would allocate once per sample per variant, which
-/// dominates a whole-cohort probability scan. Values are concatenated instead,
-/// with one offset per sample; this is also the layout Arrow's list arrays use,
-/// so no per-value copy is needed when the batch is built.
-#[derive(Debug, Default)]
-pub(crate) struct ProbabilityValues {
-    /// Concatenated probabilities of every emitted sample.
-    pub(crate) values: Vec<f32>,
-    /// Start of each sample's states, with a trailing total length.
-    pub(crate) offsets: Vec<i32>,
-    /// False for a sample with no called genotype.
-    pub(crate) valid: Vec<bool>,
-}
-
-impl ProbabilityValues {
-    fn with_sample_capacity(samples: usize) -> Self {
-        let mut offsets = Vec::with_capacity(samples + 1);
-        offsets.push(0);
-        Self {
-            values: Vec::new(),
-            offsets,
-            valid: Vec::with_capacity(samples),
-        }
-    }
-
-    /// Records a sample with no called genotype.
-    ///
-    /// A fixed-width layout still reserves `pad` slots for a null sample,
-    /// because Arrow sizes its values buffer from the entry count rather than
-    /// from offsets. The padded values are never read.
-    fn finish_missing_sample(&mut self, pad: usize) -> Result<()> {
-        self.values.resize(self.values.len() + pad, 0.0);
-        self.finish_sample(false)
-    }
-
-    /// Records one sample whose probabilities are the tail of `values`.
-    fn finish_sample(&mut self, valid: bool) -> Result<()> {
-        let end = i32::try_from(self.values.len()).map_err(|_| {
-            DataFusionError::Execution(
-                "BGEN probability offsets exceed the 32-bit Arrow list limit".to_string(),
-            )
-        })?;
-        self.offsets.push(end);
-        self.valid.push(valid);
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum DecodedValues {
-    Probabilities(ProbabilityValues),
-    Dosages(Vec<Option<f32>>),
-}
-
-impl DecodedGenotypes {
-    pub(crate) fn estimated_arrow_bytes(&self) -> usize {
-        let value_bytes = match &self.values {
-            DecodedValues::Probabilities(samples) => {
-                samples.values.len().saturating_mul(size_of::<f32>())
-            }
-            DecodedValues::Dosages(samples) => samples.len().saturating_mul(size_of::<f32>()),
-        };
-        value_bytes
-            .saturating_add(self.ploidy.len())
-            .saturating_add(self.ploidy.len().saturating_mul(size_of::<i32>()))
-    }
 }
 
 /// Buffers reused across the variants decoded by one partition.
@@ -122,6 +53,7 @@ impl std::fmt::Debug for DecodeScratch {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn decode_variant(
     path: &str,
     variant: &BgenVariant,
@@ -130,6 +62,7 @@ pub(crate) fn decode_variant(
     selected_samples: &[usize],
     options: &BgenReadOptions,
     scratch: &mut DecodeScratch,
+    buffers: &mut GenotypeBuffers,
 ) -> Result<DecodedGenotypes> {
     match header.layout {
         BgenLayout::Layout1 => decode_layout1(
@@ -140,6 +73,7 @@ pub(crate) fn decode_variant(
             selected_samples,
             options,
             scratch,
+            buffers,
         ),
         BgenLayout::Layout2 => decode_layout2(
             path,
@@ -149,10 +83,12 @@ pub(crate) fn decode_variant(
             selected_samples,
             options,
             scratch,
+            buffers,
         ),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn decode_layout1(
     path: &str,
     variant: &BgenVariant,
@@ -161,6 +97,7 @@ fn decode_layout1(
     selected_samples: &[usize],
     options: &BgenReadOptions,
     scratch: &mut DecodeScratch,
+    buffers: &mut GenotypeBuffers,
 ) -> Result<DecodedGenotypes> {
     let DecodeScratch {
         zlib,
@@ -218,9 +155,6 @@ fn decode_layout1(
         }
     };
 
-    let fixed_layout = options.probability_layout == BgenProbabilityLayout::Fixed;
-    let mut probabilities = ProbabilityValues::with_sample_capacity(selected_samples.len());
-    let mut dosages = Vec::with_capacity(selected_samples.len());
     for &sample in selected_samples {
         let start = sample.checked_mul(6).ok_or_else(|| {
             execution_error(path, variant, "sample probability offset overflowed")
@@ -231,9 +165,11 @@ fn decode_layout1(
             read_u16(data, start + 4)? as u64,
         ];
         let sum: u64 = values.iter().sum();
+        // Layout 1 is always diploid, and ploidy is recorded for a missing
+        // sample too.
+        buffers.push_ploidy(2);
         if sum == 0 {
-            probabilities.finish_missing_sample(if fixed_layout { 3 } else { 0 })?;
-            dosages.push(None);
+            buffers.finish_missing_sample()?;
             continue;
         }
         // Layout 1 scales each called sample's three probabilities to 32768,
@@ -252,13 +188,12 @@ fn decode_layout1(
         }
         match options.output_mode {
             BgenOutputMode::Probability => {
-                probabilities
-                    .values
-                    .extend(values.iter().map(|value| *value as f32 / 32_768.0));
-                probabilities.finish_sample(true)?;
+                buffers.extend_states(values.iter().map(|value| *value as f32 / 32_768.0));
+                buffers.finish_sample()?;
             }
             BgenOutputMode::Dosage => {
-                dosages.push(Some((values[1] + 2 * values[2]) as f32 / 32_768.0));
+                buffers.push_state((values[1] + 2 * values[2]) as f32 / 32_768.0);
+                buffers.finish_sample()?;
             }
         }
     }
@@ -266,16 +201,12 @@ fn decode_layout1(
     Ok(DecodedGenotypes {
         phased: false,
         bits: 16,
-        ploidy: vec![2; selected_samples.len()],
-        values: match options.output_mode {
-            BgenOutputMode::Probability => DecodedValues::Probabilities(probabilities),
-            BgenOutputMode::Dosage => DecodedValues::Dosages(dosages),
-        },
         decompressed_bytes: data.len(),
         state_width: Some(3),
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn decode_layout2(
     path: &str,
     variant: &BgenVariant,
@@ -284,6 +215,7 @@ fn decode_layout2(
     selected_samples: &[usize],
     options: &BgenReadOptions,
     scratch: &mut DecodeScratch,
+    buffers: &mut GenotypeBuffers,
 ) -> Result<DecodedGenotypes> {
     let DecodeScratch {
         zlib,
@@ -366,6 +298,7 @@ fn decode_layout2(
         stored,
         complete,
         sample_bit_offsets,
+        buffers,
     )
 }
 
@@ -380,6 +313,7 @@ fn decode_layout2_block(
     stored: &mut Vec<u64>,
     complete: &mut Vec<u64>,
     sample_bit_offsets: &mut Vec<u64>,
+    buffers: &mut GenotypeBuffers,
 ) -> Result<DecodedGenotypes> {
     let sample_count = read_u32(block, 0)?;
     let allele_count = read_u16(block, 4)? as usize;
@@ -511,16 +445,6 @@ fn decode_layout2_block(
         .transpose()
         .map_err(|_| execution_error(path, variant, "state count does not fit usize"))?;
 
-    // A fixed-width layout reserves the same slots for a missing sample as for a
-    // called one.
-    let missing_pad = if options.output_mode == BgenOutputMode::Probability
-        && options.probability_layout == BgenProbabilityLayout::Fixed
-    {
-        uniform_state_width.unwrap_or(0)
-    } else {
-        0
-    };
-
     sample_bit_offsets.clear();
     if uniform_stride_bits.is_some() {
         for (sample, &ploidy_missing) in ploidy_bytes.iter().enumerate() {
@@ -623,9 +547,6 @@ fn decode_layout2_block(
     }
 
     let denominator = (1_u64 << bits) - 1;
-    let mut ploidies = Vec::with_capacity(selected_samples.len());
-    let mut probabilities = ProbabilityValues::with_sample_capacity(selected_samples.len());
-    let mut dosages = Vec::with_capacity(selected_samples.len());
 
     // Whole-cohort scans of biallelic 8-bit blocks with one declared ploidy are
     // the dominant workload, and there every sample occupies the same whole
@@ -636,7 +557,7 @@ fn decode_layout2_block(
         let stride = min_ploidy as usize;
         for &sample in selected_samples {
             let ploidy_missing = ploidy_bytes[sample];
-            ploidies.push(ploidy_missing & 0x3f);
+            buffers.push_ploidy(ploidy_missing & 0x3f);
             let start = sample * stride;
             let values = probability_bytes
                 .get(start..start + stride)
@@ -648,23 +569,13 @@ fn decode_layout2_block(
                 // undefined, so they are skipped rather than required to be
                 // zero. Writers differ here, and rejecting a non-zero slot
                 // would refuse files the specification allows.
-                match options.output_mode {
-                    BgenOutputMode::Probability => {
-                        probabilities.finish_missing_sample(missing_pad)?
-                    }
-                    BgenOutputMode::Dosage => dosages.push(None),
-                }
+                buffers.finish_missing_sample()?;
                 continue;
             }
             match options.output_mode {
                 BgenOutputMode::Probability => {
-                    byte_probabilities_into(
-                        &mut probabilities.values,
-                        values,
-                        denominator,
-                        phased,
-                    )
-                    .ok_or_else(|| {
+                    byte_probabilities_into(buffers.values_mut(), values, denominator, phased)
+                        .ok_or_else(|| {
                         let sum: u64 = values.iter().map(|&value| value as u64).sum();
                         execution_error(
                             path,
@@ -674,7 +585,7 @@ fn decode_layout2_block(
                             ),
                         )
                     })?;
-                    probabilities.finish_sample(true)?;
+                    buffers.finish_sample()?;
                 }
                 BgenOutputMode::Dosage => {
                     let numerator = byte_dosage_numerator(values, denominator, min_ploidy, phased)
@@ -688,7 +599,8 @@ fn decode_layout2_block(
                                 ),
                             )
                         })?;
-                    dosages.push(Some(numerator as f32 / denominator as f32));
+                    buffers.push_state(numerator as f32 / denominator as f32);
+                    buffers.finish_sample()?;
                 }
             }
         }
@@ -696,11 +608,6 @@ fn decode_layout2_block(
         return Ok(DecodedGenotypes {
             phased,
             bits,
-            ploidy: ploidies,
-            values: match options.output_mode {
-                BgenOutputMode::Probability => DecodedValues::Probabilities(probabilities),
-                BgenOutputMode::Dosage => DecodedValues::Dosages(dosages),
-            },
             decompressed_bytes: block.len(),
             state_width: uniform_state_width,
         });
@@ -710,7 +617,7 @@ fn decode_layout2_block(
         let ploidy_missing = ploidy_bytes[sample];
         let ploidy = ploidy_missing & 0x3f;
         let missing = ploidy_missing & 0x80 != 0;
-        ploidies.push(ploidy);
+        buffers.push_ploidy(ploidy);
         let offset = match uniform_stride_bits {
             Some(stride) => sample as u64 * stride,
             None => sample_bit_offsets[sample],
@@ -727,8 +634,7 @@ fn decode_layout2_block(
         )?;
         if missing {
             // See the fast path: a missing sample's stored bytes are undefined.
-            probabilities.finish_missing_sample(missing_pad)?;
-            dosages.push(None);
+            buffers.finish_missing_sample()?;
             continue;
         }
         let context = ProbabilityContext {
@@ -748,10 +654,8 @@ fn decode_layout2_block(
                     context,
                 )?;
                 let scale = denominator as f32;
-                probabilities
-                    .values
-                    .extend(complete.iter().map(|value| *value as f32 / scale));
-                probabilities.finish_sample(true)?;
+                buffers.extend_states(complete.iter().map(|value| *value as f32 / scale));
+                buffers.finish_sample()?;
             }
             BgenOutputMode::Dosage => {
                 // Dosage rejects multiallelic variants above, so the omitted
@@ -760,7 +664,8 @@ fn decode_layout2_block(
                 // complete probability vector.
                 let numerator =
                     biallelic_dosage_numerator(stored, denominator, ploidy, phased, context)?;
-                dosages.push(Some(numerator as f32 / denominator as f32));
+                buffers.push_state(numerator as f32 / denominator as f32);
+                buffers.finish_sample()?;
             }
         }
     }
@@ -768,11 +673,6 @@ fn decode_layout2_block(
     Ok(DecodedGenotypes {
         phased,
         bits,
-        ploidy: ploidies,
-        values: match options.output_mode {
-            BgenOutputMode::Probability => DecodedValues::Probabilities(probabilities),
-            BgenOutputMode::Dosage => DecodedValues::Dosages(dosages),
-        },
         decompressed_bytes: block.len(),
         state_width: uniform_state_width,
     })

--- a/datafusion/bio-format-bgen/src/decode.rs
+++ b/datafusion/bio-format-bgen/src/decode.rs
@@ -17,6 +17,12 @@ pub(crate) struct DecodedGenotypes {
     /// declares one ploidy. `None` for a variable-ploidy variant, whose samples
     /// do not share a width.
     pub(crate) state_width: Option<usize>,
+    /// The one ploidy every sample of this variant declares, or `None` when the
+    /// variant declares a range.
+    ///
+    /// The width probe reads this without selecting any sample, so it cannot
+    /// come from the per-sample ploidy the batch buffers hold.
+    pub(crate) declared_ploidy: Option<u8>,
 }
 
 /// Buffers reused across the variants decoded by one partition.
@@ -203,6 +209,7 @@ fn decode_layout1(
         bits: 16,
         decompressed_bytes: data.len(),
         state_width: Some(3),
+        declared_ploidy: Some(2),
     })
 }
 
@@ -610,6 +617,7 @@ fn decode_layout2_block(
             bits,
             decompressed_bytes: block.len(),
             state_width: uniform_state_width,
+            declared_ploidy: uniform_stride_bits.map(|_| min_ploidy),
         });
     }
 
@@ -675,6 +683,7 @@ fn decode_layout2_block(
         bits,
         decompressed_bytes: block.len(),
         state_width: uniform_state_width,
+        declared_ploidy: uniform_stride_bits.map(|_| min_ploidy),
     })
 }
 
@@ -686,7 +695,11 @@ fn stored_probability_count(ploidy: u8, allele_count: usize, phased: bool) -> Re
         })
 }
 
-fn complete_probability_count(ploidy: u8, allele_count: usize, phased: bool) -> Result<u64> {
+pub(crate) fn complete_probability_count(
+    ploidy: u8,
+    allele_count: usize,
+    phased: bool,
+) -> Result<u64> {
     if phased {
         (ploidy as u64)
             .checked_mul(allele_count as u64)

--- a/datafusion/bio-format-bgen/src/lib.rs
+++ b/datafusion/bio-format-bgen/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 
 mod bgi;
+mod buffers;
 mod catalog;
 mod decode;
 mod filter;

--- a/datafusion/bio-format-bgen/src/physical_exec.rs
+++ b/datafusion/bio-format-bgen/src/physical_exec.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, FixedSizeListArray, Float32Array, Float32Builder, ListArray,
-    ListBuilder, StringArray, StringBuilder, StructArray, UInt8Array, UInt8Builder, UInt64Array,
+    ArrayRef, BooleanArray, FixedSizeListArray, Float32Array, ListArray, ListBuilder, StringArray,
+    StringBuilder, StructArray, UInt8Array, UInt64Array,
 };
-use datafusion::arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use datafusion::arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use datafusion::arrow::datatypes::{DataType, Field, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::{DataFusionError, Result};
@@ -19,7 +19,8 @@ use datafusion_bio_format_core::genotype::{
 };
 use datafusion_bio_format_core::range_planning::ByteRange;
 
-use crate::decode::{DecodeScratch, DecodedGenotypes, DecodedValues, decode_variant};
+use crate::buffers::{BufferLayout, GenotypeBuffers, TakenBuffers};
+use crate::decode::{DecodeScratch, decode_variant};
 use crate::table_provider::{BgenFileset, BgenOutputMode};
 
 #[derive(Clone, Debug)]
@@ -34,10 +35,16 @@ pub(crate) struct BgenPartition {
     pub(crate) ranges: Vec<BgenReadRange>,
 }
 
+/// One emitted row's per-variant metadata.
+///
+/// The genotypes themselves are not here: the decoder writes them straight into
+/// the batch's [`GenotypeBuffers`], so a row carries only what the block header
+/// says about it.
 #[derive(Debug)]
 struct DecodedRow {
     variant_index: usize,
-    genotypes: Option<DecodedGenotypes>,
+    phased: bool,
+    bits: u8,
 }
 
 /// Physical execution plan for a BGEN scan.
@@ -130,9 +137,6 @@ impl ExecutionPlan for BgenExec {
         let max_rows = context.session_config().batch_size();
         let soft_bytes = self.batch_soft_byte_limit;
         let genotype_projected = schema.index_of("genotypes").is_ok();
-        let payload_derived_projected = genotype_projected
-            || schema.index_of("phased").is_ok()
-            || schema.index_of("bits").is_ok();
 
         let stream = try_stream! {
             let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
@@ -140,25 +144,37 @@ impl ExecutionPlan for BgenExec {
             // Decoding buffers live for the whole partition so per-variant work
             // reuses one decompressor and one set of probability buffers.
             let mut scratch = DecodeScratch::new();
+            // The decoder appends into these, and a finished batch moves them
+            // into its Arrow arrays.
+            let mut buffers = GenotypeBuffers::new(
+                match (fileset.options.output_mode, fileset.probability_width) {
+                    (BgenOutputMode::Dosage, _) => BufferLayout::Dosage,
+                    (BgenOutputMode::Probability, Some(width)) => {
+                        BufferLayout::FixedProbability(width)
+                    }
+                    (BgenOutputMode::Probability, None) => BufferLayout::NestedProbability,
+                },
+            );
 
             if assignment.ranges.is_empty() {
                 for variant_index in assignment.variants {
                     let estimated_row_bytes = 0;
                     if sizer.should_flush_before(estimated_row_bytes) {
                         let row_count = rows.len();
-                        let batch = build_batch(&fileset, schema.clone(), &rows)?;
+                        let batch = build_batch(&fileset, schema.clone(), &rows, buffers.take())?;
                         record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
                         yield batch;
                         rows.clear();
                         sizer.reset();
                     }
+                    // No payload was read, so the row has no samples and no
+                    // header-derived values; it still closes a variant, because
+                    // the batch's row count comes from the variant offsets.
+                    buffers.finish_variant()?;
                     rows.push(DecodedRow {
                         variant_index,
-                        genotypes: if genotype_projected {
-                            Some(empty_genotypes(fileset.options.output_mode))
-                        } else {
-                            None
-                        },
+                        phased: false,
+                        bits: 0,
                     });
                     sizer.push_row(estimated_row_bytes);
                 }
@@ -211,7 +227,8 @@ impl ExecutionPlan for BgenExec {
                         } else {
                             &[]
                         };
-                        let decoded = decode_variant(
+                        let mark = buffers.mark();
+                        let decoded = match decode_variant(
                             &fileset.path,
                             variant,
                             &fileset.header,
@@ -219,20 +236,19 @@ impl ExecutionPlan for BgenExec {
                             decode_samples,
                             &fileset.options,
                             &mut scratch,
-                        )?;
-                        let estimated_row_bytes = if genotype_projected {
-                            decoded.estimated_arrow_bytes()
-                        } else {
-                            0
+                            &mut buffers,
+                        ) {
+                            Ok(decoded) => decoded,
+                            Err(error) => {
+                                // A failed variant leaves a partial row behind;
+                                // drop it so the buffers stay a valid Arrow
+                                // prefix rather than a torn row.
+                                buffers.rollback(mark);
+                                Err(error)?
+                            }
                         };
-                        if sizer.should_flush_before(estimated_row_bytes) {
-                            let row_count = rows.len();
-                            let batch = build_batch(&fileset, schema.clone(), &rows)?;
-                            record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
-                            yield batch;
-                            rows.clear();
-                            sizer.reset();
-                        }
+                        buffers.finish_variant()?;
+                        let estimated_row_bytes = buffers.bytes_since(mark);
                         metrics.add(
                             GenotypeMetric::DecompressedBytes,
                             decoded.decompressed_bytes as u64,
@@ -249,15 +265,26 @@ impl ExecutionPlan for BgenExec {
                         );
                         rows.push(DecodedRow {
                             variant_index,
-                            genotypes: payload_derived_projected.then_some(decoded),
+                            phased: decoded.phased,
+                            bits: decoded.bits,
                         });
                         sizer.push_row(estimated_row_bytes);
+                        // The row is already in the buffers, so the flush
+                        // decision comes after it rather than before.
+                        if sizer.should_flush_after() {
+                            let row_count = rows.len();
+                            let batch = build_batch(&fileset, schema.clone(), &rows, buffers.take())?;
+                            record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                            yield batch;
+                            rows.clear();
+                            sizer.reset();
+                        }
                     }
                 }
             }
             if !rows.is_empty() {
                 let row_count = rows.len();
-                let batch = build_batch(&fileset, schema.clone(), &rows)?;
+                let batch = build_batch(&fileset, schema.clone(), &rows, buffers.take())?;
                 record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
                 yield batch;
             }
@@ -266,22 +293,6 @@ impl ExecutionPlan for BgenExec {
             stream_schema,
             stream,
         )))
-    }
-}
-
-fn empty_genotypes(mode: BgenOutputMode) -> DecodedGenotypes {
-    DecodedGenotypes {
-        state_width: None,
-        phased: false,
-        bits: 0,
-        ploidy: Vec::new(),
-        values: match mode {
-            BgenOutputMode::Probability => {
-                DecodedValues::Probabilities(crate::decode::ProbabilityValues::default())
-            }
-            BgenOutputMode::Dosage => DecodedValues::Dosages(Vec::new()),
-        },
-        decompressed_bytes: 0,
     }
 }
 
@@ -296,12 +307,16 @@ fn build_batch(
     fileset: &BgenFileset,
     schema: SchemaRef,
     rows: &[DecodedRow],
+    buffers: TakenBuffers,
 ) -> Result<RecordBatch> {
     if schema.fields().is_empty() {
         let options = RecordBatchOptions::new().with_row_count(Some(rows.len()));
         return RecordBatch::try_new_with_options(schema, Vec::new(), &options)
             .map_err(DataFusionError::from);
     }
+    // The genotype buffers can only be moved into one array, and a projection
+    // names each column at most once.
+    let mut buffers = Some(buffers);
     let arrays = schema
         .fields()
         .iter()
@@ -330,24 +345,20 @@ fn build_batch(
             )) as ArrayRef),
             "alleles" => build_alleles(fileset, rows),
             "phased" => Ok(Arc::new(BooleanArray::from(
-                rows.iter()
-                    .map(|row| {
-                        row.genotypes
-                            .as_ref()
-                            .map(|decoded| decoded.phased)
-                            .unwrap_or(false)
-                    })
-                    .collect::<Vec<_>>(),
+                rows.iter().map(|row| row.phased).collect::<Vec<_>>(),
             )) as ArrayRef),
-            "bits" => Ok(
-                Arc::new(UInt8Array::from_iter_values(rows.iter().map(|row| {
-                    row.genotypes
-                        .as_ref()
-                        .map(|decoded| decoded.bits)
-                        .unwrap_or(0)
-                }))) as ArrayRef,
+            "bits" => Ok(Arc::new(UInt8Array::from_iter_values(
+                rows.iter().map(|row| row.bits),
+            )) as ArrayRef),
+            "genotypes" => build_genotypes(
+                field.data_type(),
+                buffers.take().ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "BGEN genotype buffers were already consumed by this batch".to_string(),
+                    )
+                })?,
+                fileset.options.output_mode,
             ),
-            "genotypes" => build_genotypes(field.data_type(), rows, fileset.options.output_mode),
             name => Err(DataFusionError::Execution(format!(
                 "unsupported BGEN projected field {name}"
             ))),
@@ -387,7 +398,7 @@ fn fixed_probability_width(data_type: &DataType) -> Option<i32> {
 
 fn build_genotypes(
     data_type: &DataType,
-    rows: &[DecodedRow],
+    buffers: TakenBuffers,
     mode: BgenOutputMode,
 ) -> Result<ArrayRef> {
     let DataType::Struct(fields) = data_type else {
@@ -395,7 +406,17 @@ fn build_genotypes(
             "BGEN genotypes field is not a struct".to_string(),
         ));
     };
-    let values: ArrayRef = match mode {
+    // The decoder wrote Arrow's own layout as it went, so every buffer moves
+    // into its array here. Nothing in this function copies a probability.
+    let TakenBuffers {
+        values,
+        sample_offsets,
+        nulls,
+        variant_offsets,
+        ploidy,
+        ploidy_offsets,
+    } = buffers;
+    let genotype_values: ArrayRef = match mode {
         BgenOutputMode::Probability => {
             let width = fixed_probability_width(data_type);
             let state_field = Arc::new(Field::new("state", DataType::Float32, false));
@@ -407,77 +428,7 @@ fn build_genotypes(
                 },
                 true,
             ));
-            // The decoder already produced Arrow's own layout, so the states,
-            // sample offsets, and sample validity move into the arrays without
-            // being appended value by value.
-            let mut states: Vec<f32> = Vec::new();
-            let mut sample_offsets: Vec<i32> = vec![0];
-            let mut sample_valid: Vec<bool> = Vec::new();
-            let mut variant_offsets: Vec<i32> = vec![0];
-            for row in rows {
-                let decoded = row.genotypes.as_ref().ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "BGEN genotype projection has no decoded payload".to_string(),
-                    )
-                })?;
-                let DecodedValues::Probabilities(samples) = &decoded.values else {
-                    return Err(DataFusionError::Execution(
-                        "BGEN decoded dosage in probability mode".to_string(),
-                    ));
-                };
-                if let Some(width) = width {
-                    // The schema fixes the width, so a variant that stores a
-                    // different number of states cannot be represented and must
-                    // not be silently padded or truncated. A row that emits no
-                    // sample has no states to check, which is what an empty
-                    // sample selection produces without reading any payload.
-                    if !samples.valid.is_empty() && decoded.state_width != Some(width as usize) {
-                        return Err(DataFusionError::Execution(format!(
-                            "BGEN fixed probability layout expects {width} states per sample, \
-                             but a variant stores {}; use the nested layout for this file",
-                            decoded.state_width.map_or_else(
-                                || "a variable number".to_string(),
-                                |value| value.to_string()
-                            )
-                        )));
-                    }
-                } else {
-                    let base = i32::try_from(states.len()).map_err(|_| {
-                        DataFusionError::Execution(
-                            "BGEN probability offsets exceed the 32-bit Arrow list limit"
-                                .to_string(),
-                        )
-                    })?;
-                    // Each per-variant offset and the running base can both fit
-                    // in i32 while their sum does not, so the sum is what must
-                    // be checked; an unchecked add would wrap into a
-                    // non-monotonic Arrow offset in release builds.
-                    for offset in samples.offsets.iter().skip(1) {
-                        sample_offsets.push(offset.checked_add(base).ok_or_else(|| {
-                            DataFusionError::Execution(
-                                "BGEN probability offsets exceed the 32-bit Arrow list limit"
-                                    .to_string(),
-                            )
-                        })?);
-                    }
-                }
-                states.extend_from_slice(&samples.values);
-                sample_valid.extend_from_slice(&samples.valid);
-                variant_offsets.push(i32::try_from(sample_valid.len()).map_err(|_| {
-                    DataFusionError::Execution(
-                        "BGEN sample offsets exceed the 32-bit Arrow list limit".to_string(),
-                    )
-                })?);
-            }
-            let states = Arc::new(Float32Array::from(states)) as ArrayRef;
-            // Converting a bool per sample into a bitmap is a measurable share of
-            // a whole-cohort probability scan, and a file where every genotype is
-            // called needs no validity buffer at all.
-            let nulls = if sample_valid.iter().all(|valid| *valid) {
-                None
-            } else {
-                Some(NullBuffer::from(sample_valid))
-            };
+            let states = Arc::new(Float32Array::from(values)) as ArrayRef;
             let samples: ArrayRef = match width {
                 Some(width) => Arc::new(FixedSizeListArray::try_new(
                     state_field,
@@ -500,43 +451,27 @@ fn build_genotypes(
             )?)
         }
         BgenOutputMode::Dosage => {
-            let mut builder = ListBuilder::new(Float32Builder::new())
-                .with_field(Arc::new(Field::new("item", DataType::Float32, true)));
-            for row in rows {
-                let decoded = row.genotypes.as_ref().ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "BGEN genotype projection has no decoded payload".to_string(),
-                    )
-                })?;
-                let DecodedValues::Dosages(samples) = &decoded.values else {
-                    return Err(DataFusionError::Execution(
-                        "BGEN decoded probabilities in dosage mode".to_string(),
-                    ));
-                };
-                for dosage in samples {
-                    builder.values().append_option(*dosage);
-                }
-                builder.append(true);
-            }
-            Arc::new(builder.finish())
+            // A dosage is one value per sample, so the validity belongs to the
+            // values array rather than to a per-sample list.
+            let dosages = Arc::new(Float32Array::new(ScalarBuffer::from(values), nulls));
+            Arc::new(ListArray::try_new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                OffsetBuffer::new(ScalarBuffer::from(variant_offsets)),
+                dosages,
+                None,
+            )?)
         }
     };
-    let mut ploidy = ListBuilder::new(UInt8Builder::new()).with_field(Arc::new(Field::new(
-        "item",
-        DataType::UInt8,
-        false,
-    )));
-    for row in rows {
-        let decoded = row.genotypes.as_ref().ok_or_else(|| {
-            DataFusionError::Execution("BGEN genotype projection has no decoded ploidy".to_string())
-        })?;
-        // Declared ploidy is never null, so the whole row is one bulk append.
-        ploidy.values().append_slice(&decoded.ploidy);
-        ploidy.append(true);
-    }
+    // Declared ploidy is never null.
+    let ploidy = Arc::new(ListArray::try_new(
+        Arc::new(Field::new("item", DataType::UInt8, false)),
+        OffsetBuffer::new(ScalarBuffer::from(ploidy_offsets)),
+        Arc::new(UInt8Array::from(ploidy)),
+        None,
+    )?);
     Ok(Arc::new(StructArray::try_new(
         fields.clone(),
-        vec![values, Arc::new(ploidy.finish())],
+        vec![genotype_values, ploidy],
         None,
     )?))
 }

--- a/datafusion/bio-format-bgen/src/physical_exec.rs
+++ b/datafusion/bio-format-bgen/src/physical_exec.rs
@@ -147,10 +147,10 @@ impl ExecutionPlan for BgenExec {
             // The decoder appends into these, and a finished batch moves them
             // into its Arrow arrays.
             let mut buffers = GenotypeBuffers::new(
-                match (fileset.options.output_mode, fileset.probability_width) {
+                match (fileset.options.output_mode, fileset.probability_shape) {
                     (BgenOutputMode::Dosage, _) => BufferLayout::Dosage,
-                    (BgenOutputMode::Probability, Some(width)) => {
-                        BufferLayout::FixedProbability(width)
+                    (BgenOutputMode::Probability, Some(shape)) => {
+                        BufferLayout::FixedProbability(shape.width)
                     }
                     (BgenOutputMode::Probability, None) => BufferLayout::NestedProbability,
                 },

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -26,6 +26,7 @@ use datafusion_bio_format_core::range_planning::{
 use datafusion_bio_format_core::companion::sanitize_location;
 
 use crate::bgi::{BgiIndex, open_optional_bgi};
+use crate::buffers::{BufferLayout, GenotypeBuffers};
 use crate::catalog::{BgenCatalog, build_transient_catalog};
 use crate::decode::{DecodeScratch, decode_variant};
 use crate::filter::{evaluate_exact_filter, supports_exact_filter};
@@ -477,7 +478,18 @@ async fn probe_probability_width(
         .ok_or_else(|| DataFusionError::Plan("BGEN payload range overflowed".to_string()))?;
     let payload = source.read_range(path, variant.payload_offset..end).await?;
     let mut scratch = DecodeScratch::new();
-    let decoded = decode_variant(path, variant, header, &payload, &[], options, &mut scratch)?;
+    // The probe selects no sample, so nothing is written into these.
+    let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+    let decoded = decode_variant(
+        path,
+        variant,
+        header,
+        &payload,
+        &[],
+        options,
+        &mut scratch,
+        &mut buffers,
+    )?;
     if let Some(states) = decoded.state_width
         && states > options.max_states_per_sample
     {

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -219,7 +219,7 @@ impl BgenTableProvider {
                 // One width is in play from here on: the schema and the scan
                 // buffers both read `shape.width`, so neither has to know
                 // whether it came from the probe or from the catalog.
-                shape.width = derive_fixed_width(&catalog, shape)?;
+                shape.width = derive_fixed_width(&path, &catalog, shape, &options)?;
                 (Some(shape), bytes, decompressed)
             } else {
                 (None, 0, 0)
@@ -490,7 +490,18 @@ pub(crate) struct ProbeShape {
 /// constant across a file in practice, so the widest state count follows from
 /// the probe plus the catalog at no I/O cost. A sample that turns out to store
 /// more than this is rejected during the scan rather than silently truncated.
-fn derive_fixed_width(catalog: &BgenCatalog, shape: ProbeShape) -> Result<usize> {
+///
+/// The derived width is checked against `max_states_per_sample` here rather than
+/// only per decoded variant. Every emitted sample is padded to this width, so a
+/// query filtered to the narrow variants of a file that also holds a very wide
+/// one would allocate the padding without the widest variant ever being decoded
+/// — the per-variant check would never run.
+fn derive_fixed_width(
+    path: &str,
+    catalog: &BgenCatalog,
+    shape: ProbeShape,
+    options: &BgenReadOptions,
+) -> Result<usize> {
     let mut width = shape.width as u64;
     for variant in catalog.variants.iter() {
         width = width.max(complete_probability_count(
@@ -498,6 +509,14 @@ fn derive_fixed_width(catalog: &BgenCatalog, shape: ProbeShape) -> Result<usize>
             variant.alleles.len(),
             shape.phased,
         )?);
+    }
+    if width > options.max_states_per_sample as u64 {
+        return Err(DataFusionError::Plan(format!(
+            "BGEN {} needs a fixed probability width of {width} to cover its widest variant, \
+             exceeding max_states_per_sample {}; use the nested probability layout",
+            sanitize_location(path),
+            options.max_states_per_sample
+        )));
     }
     usize::try_from(width)
         .map_err(|_| DataFusionError::Plan("BGEN probability width does not fit usize".to_string()))

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -28,7 +28,7 @@ use datafusion_bio_format_core::companion::sanitize_location;
 use crate::bgi::{BgiIndex, open_optional_bgi};
 use crate::buffers::{BufferLayout, GenotypeBuffers};
 use crate::catalog::{BgenCatalog, build_transient_catalog};
-use crate::decode::{DecodeScratch, decode_variant};
+use crate::decode::{DecodeScratch, complete_probability_count, decode_variant};
 use crate::filter::{evaluate_exact_filter, supports_exact_filter};
 use crate::header::{BgenHeader, BgenLayout};
 use crate::physical_exec::{BgenExec, BgenPartition, BgenReadRange};
@@ -59,9 +59,15 @@ pub enum BgenProbabilityLayout {
     /// One fixed-width list per sample.
     ///
     /// Drops the per-sample list offsets, which are a quarter of the emitted
-    /// bytes for a diploid biallelic cohort. Requires every variant to store the
-    /// same number of states; a file that mixes widths is rejected rather than
-    /// silently padded.
+    /// bytes for a diploid biallelic cohort.
+    ///
+    /// The width covers the widest sample the catalog allows, and a narrower
+    /// sample is padded with NaN — including a missing sample, whose slots are
+    /// never read through Arrow but must exist because a fixed-size list sizes
+    /// its values buffer from the entry count. Padding is decided per sample,
+    /// so a file that mixes widths, and even a variant that declares a variable
+    /// ploidy, are both representable. A sample storing more states than the
+    /// width is rejected; use [`Self::Nested`] for such a file.
     Fixed,
 }
 
@@ -171,9 +177,9 @@ pub(crate) struct BgenFileset {
     pub(crate) bgi: Option<BgiIndex>,
     pub(crate) selected_samples: datafusion_bio_format_core::genotype::SampleSelection,
     pub(crate) options: BgenReadOptions,
-    /// States per sample when the fixed probability layout is in use.
-    pub(crate) probability_width: Option<usize>,
-    /// Payload bytes read to resolve [`Self::probability_width`].
+    /// Probability shape when the fixed layout is in use.
+    pub(crate) probability_shape: Option<ProbeShape>,
+    /// Payload bytes read to resolve [`Self::probability_shape`].
     pub(crate) probability_probe_bytes: u64,
     /// Bytes the width probe decompressed.
     pub(crate) probability_probe_decompressed: u64,
@@ -204,13 +210,17 @@ impl BgenTableProvider {
         // The fixed layout puts the state count in the schema, so it has to be
         // known before any batch is produced. One variant's block header carries
         // it; every other variant is checked against it while scanning.
-        let (probability_width, probability_probe_bytes, probability_probe_decompressed) =
+        let (probability_shape, probability_probe_bytes, probability_probe_decompressed) =
             if options.output_mode == BgenOutputMode::Probability
                 && options.probability_layout == BgenProbabilityLayout::Fixed
             {
-                let (width, bytes, decompressed) =
+                let (mut shape, bytes, decompressed) =
                     probe_probability_width(&path, &source, &header, &catalog, &options).await?;
-                (Some(width), bytes, decompressed)
+                // One width is in play from here on: the schema and the scan
+                // buffers both read `shape.width`, so neither has to know
+                // whether it came from the probe or from the catalog.
+                shape.width = derive_fixed_width(&catalog, shape)?;
+                (Some(shape), bytes, decompressed)
             } else {
                 (None, 0, 0)
             };
@@ -222,7 +232,7 @@ impl BgenTableProvider {
             bgi,
             selected_samples,
             options,
-            probability_width,
+            probability_shape,
             probability_probe_bytes,
             probability_probe_decompressed,
         });
@@ -459,13 +469,47 @@ fn validate_options(options: &BgenReadOptions) -> Result<()> {
 ///
 /// Decoding with an empty sample selection reads the block header without
 /// reconstructing any sample, so this costs one block, not one scan.
+/// What variant 0 says about the file's probability shape.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProbeShape {
+    /// States per sample the fixed layout emits.
+    ///
+    /// This starts as variant 0's own width and is widened by
+    /// [`derive_fixed_width`] to cover every catalog variant.
+    pub(crate) width: usize,
+    ploidy: u8,
+    phased: bool,
+}
+
+/// Widest sample any catalog variant can store, given the shape variant 0
+/// declares.
+///
+/// A Layout 2 block header lives inside the compressed payload, so learning
+/// every variant's exact width would mean decompressing the whole file at plan
+/// time. Allele counts are already in the catalog, and ploidy and phasing are
+/// constant across a file in practice, so the widest state count follows from
+/// the probe plus the catalog at no I/O cost. A sample that turns out to store
+/// more than this is rejected during the scan rather than silently truncated.
+fn derive_fixed_width(catalog: &BgenCatalog, shape: ProbeShape) -> Result<usize> {
+    let mut width = shape.width as u64;
+    for variant in catalog.variants.iter() {
+        width = width.max(complete_probability_count(
+            shape.ploidy,
+            variant.alleles.len(),
+            shape.phased,
+        )?);
+    }
+    usize::try_from(width)
+        .map_err(|_| DataFusionError::Plan("BGEN probability width does not fit usize".to_string()))
+}
+
 async fn probe_probability_width(
     path: &str,
     source: &ObjectAccess,
     header: &BgenHeader,
     catalog: &BgenCatalog,
     options: &BgenReadOptions,
-) -> Result<(usize, u64, u64)> {
+) -> Result<(ProbeShape, u64, u64)> {
     let variant = catalog.variants.first().ok_or_else(|| {
         DataFusionError::Plan(
             "BGEN fixed probability layout needs at least one variant to determine its width"
@@ -500,15 +544,20 @@ async fn probe_probability_width(
             options.max_states_per_sample
         )));
     }
-    let width = decoded.state_width.ok_or_else(|| {
+    let variable_ploidy = || {
         DataFusionError::Plan(format!(
             "BGEN {} variant 0 declares a variable ploidy, which has no single probability width; \
              use the nested probability layout",
             sanitize_location(path)
         ))
-    })?;
+    };
+    let shape = ProbeShape {
+        width: decoded.state_width.ok_or_else(variable_ploidy)?,
+        ploidy: decoded.declared_ploidy.ok_or_else(variable_ploidy)?,
+        phased: decoded.phased,
+    };
     Ok((
-        width,
+        shape,
         payload.len() as u64,
         decoded.decompressed_bytes as u64,
     ))
@@ -539,7 +588,7 @@ fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
             "GP",
             DataType::List(Arc::new(Field::new(
                 "sample",
-                match fileset.probability_width {
+                match fileset.probability_shape.map(|shape| shape.width) {
                     // A fixed-width sample list needs no per-sample offsets.
                     Some(width) => DataType::FixedSizeList(
                         Arc::new(Field::new("state", DataType::Float32, false)),

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -1483,6 +1483,33 @@ async fn the_fixed_width_covers_the_widest_catalog_variant() {
 }
 
 #[tokio::test]
+async fn the_derived_fixed_width_respects_max_states_per_sample() {
+    // The width covers the widest catalog variant, so it can exceed the
+    // per-sample state limit even when variant 0 is well inside it. Every
+    // selected sample is padded to that width whether or not the wide variant
+    // is ever decoded, so a filter that excludes it would otherwise allocate
+    // the padding without the limit ever being consulted.
+    let fixture = fixture(Codec::Zlib, true);
+    let error = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            // Variant 0 stores three states and passes; the triallelic variant
+            // pushes the derived width to six.
+            max_states_per_sample: 5,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("a derived width above the limit must fail planning")
+    .to_string();
+    assert!(
+        error.contains("max_states_per_sample") && error.contains("nested"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
 async fn fixed_probability_layout_pads_a_narrower_variant_with_nan() {
     // The fixture mixes widths on purpose: rs1 is unphased biallelic (three
     // states) and rs3 is triallelic (six for a diploid sample). The schema is

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -1428,25 +1428,175 @@ async fn fixed_probability_layout_matches_the_nested_layout() {
         .await
         .unwrap();
 
-    // Same values, different physical layout.
-    for variant in 0..1 {
-        for sample in 0..3 {
-            assert_eq!(
-                probability_values_any(&nested_rows[0], 0, variant)[sample],
-                probability_values_any(&fixed_rows[0], 0, variant)[sample],
-                "variant {variant} sample {sample}"
-            );
+    // Same values, different physical layout. The fixed layout pads every
+    // sample to the schema width, so the nested vector is the prefix and the
+    // remainder is padding.
+    let nested = probability_values_any(&nested_rows[0], 0, 0);
+    let fixed = probability_values_any(&fixed_rows[0], 0, 0);
+    for sample in 0..3 {
+        match (&nested[sample], &fixed[sample]) {
+            (None, None) => {}
+            (Some(nested), Some(fixed)) => {
+                assert_eq!(
+                    &fixed[..nested.len()],
+                    nested.as_slice(),
+                    "sample {sample} states differ between layouts"
+                );
+                assert!(
+                    fixed[nested.len()..].iter().all(|value| value.is_nan()),
+                    "sample {sample} padding must be NaN: {fixed:?}"
+                );
+            }
+            (nested, fixed) => panic!("sample {sample} validity differs: {nested:?} {fixed:?}"),
         }
     }
 }
 
 #[tokio::test]
-async fn fixed_probability_layout_rejects_a_mixed_width_file() {
-    // v3 is multiallelic, so it stores more states than the biallelic variants
-    // and cannot share one fixed width with them.
+async fn the_fixed_width_covers_the_widest_catalog_variant() {
+    // v1 is unphased biallelic diploid, so the probe reports ploidy 2 and
+    // unphased. v3 is triallelic, and an unphased triallelic diploid sample
+    // stores six states, so the schema has to be six wide rather than v1's
+    // three — the width follows from the catalog's allele counts, not from
+    // variant 0 alone.
     let fixture = fixture(Codec::Zlib, true);
     let provider = BgenTableProvider::try_new(
         path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let schema = TableProvider::schema(&provider);
+    let genotypes = schema.field_with_name("genotypes").unwrap();
+    let rendered = format!("{:?}", genotypes.data_type());
+    assert!(
+        rendered.contains("FixedSizeList"),
+        "the fixed layout must advertise a fixed-width sample list: {rendered}"
+    );
+    assert!(
+        rendered.contains(", 6)"),
+        "the width must cover the widest catalog variant, not just variant 0: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn fixed_probability_layout_pads_a_narrower_variant_with_nan() {
+    // The fixture mixes widths on purpose: rs1 is unphased biallelic (three
+    // states) and rs3 is triallelic (six for a diploid sample). The schema is
+    // six wide and every narrower sample pads rather than being rejected.
+    let fixture = fixture(Codec::Zlib, true);
+    let provider = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1024);
+    context.register_table("f", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM f WHERE rsid = 'rs1'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect("a mixed-width file is padded, not rejected");
+
+    let samples = probability_values_any(&batches[0], 0, 0);
+    let called = samples[0].as_ref().expect("sample 0 is called");
+    assert_eq!(called.len(), 6, "every sample is the schema width");
+    assert_eq!(&called[..3], &[1.0, 0.0, 0.0]);
+    assert!(
+        called[3..].iter().all(|value| value.is_nan()),
+        "padding is NaN: {called:?}"
+    );
+    assert!(
+        samples[2].is_none(),
+        "the third sample is missing and stays null"
+    );
+}
+
+#[tokio::test]
+async fn fixed_probability_layout_pads_a_variable_ploidy_variant() {
+    // rs3 declares ploidy 1..=2, so it has no single width and the old
+    // per-variant check rejected it outright. Padding is decided per sample, so
+    // its haploid samples pad to the schema width alongside its diploid one.
+    let fixture = fixture(Codec::Zlib, true);
+    let provider = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1024);
+    context.register_table("f", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM f WHERE rsid = 'rs3'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect("a variable-ploidy variant pads per sample");
+    let samples = probability_values_any(&batches[0], 0, 0);
+    let haploid = samples[0].as_ref().expect("sample 0 is called");
+    assert_eq!(haploid.len(), 6);
+    assert!(
+        haploid[3..].iter().all(|value| value.is_nan()),
+        "a haploid triallelic sample stores three states and pads to six: {haploid:?}"
+    );
+}
+
+#[tokio::test]
+async fn fixed_probability_layout_reports_a_sample_wider_than_the_schema() {
+    // The width is derived from variant 0's ploidy, so a later variant whose
+    // samples are triploid stores four states where the schema has three.
+    // Padding cannot represent that, and truncating would emit a distribution
+    // that is not the file's.
+    let dir = TempDir::new().unwrap();
+    let bgen = dir.path().join("wider.bgen");
+    let variants = vec![
+        Variant {
+            id: "v1",
+            rsid: "rs1",
+            chrom: "1",
+            position: 10,
+            alleles: vec!["A", "C"],
+            phased: false,
+            bits: 8,
+            samples: vec![
+                sample(2, false, &[255, 0]),
+                sample(2, false, &[0, 255]),
+                sample(2, false, &[0, 0]),
+            ],
+        },
+        Variant {
+            id: "v2",
+            rsid: "rs2",
+            chrom: "1",
+            position: 20,
+            alleles: vec!["A", "C"],
+            phased: false,
+            bits: 8,
+            samples: vec![
+                sample(3, false, &[255, 0, 0]),
+                sample(3, false, &[0, 255, 0]),
+                sample(3, false, &[0, 0, 255]),
+            ],
+        },
+    ];
+    let (bytes, _rows) = encode_layout2(Codec::Zlib, true, &variants);
+    fs::write(&bgen, bytes).unwrap();
+
+    let provider = BgenTableProvider::try_new(
+        path(&bgen),
         BgenReadOptions {
             probability_layout: BgenProbabilityLayout::Fixed,
             ..Default::default()

--- a/datafusion/bio-format-core/src/genotype.rs
+++ b/datafusion/bio-format-core/src/genotype.rs
@@ -410,6 +410,17 @@ impl GenotypeBatchSizer {
                 || self.estimated_bytes.saturating_add(estimated_row_bytes) > self.soft_byte_limit)
     }
 
+    /// Returns true when the current batch should be emitted now that its rows
+    /// are appended.
+    ///
+    /// A caller that writes a row directly into its output buffers cannot
+    /// consult [`Self::should_flush_before`], because the row's size is not
+    /// known until it is written. Such a batch can exceed `soft_byte_limit` by
+    /// one row, which is the same slack the first row of every batch has.
+    pub fn should_flush_after(&self) -> bool {
+        self.rows > 0 && (self.rows >= self.max_rows || self.estimated_bytes > self.soft_byte_limit)
+    }
+
     /// Records an appended row and its estimated genotype bytes.
     pub fn push_row(&mut self, estimated_row_bytes: usize) {
         self.rows = self.rows.saturating_add(1);
@@ -439,6 +450,26 @@ mod tests {
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn should_flush_after_reports_a_full_batch() {
+        let mut sizer = GenotypeBatchSizer::new(2, 100).unwrap();
+        assert!(!sizer.should_flush_after(), "an empty batch never flushes");
+
+        sizer.push_row(10);
+        assert!(!sizer.should_flush_after(), "one small row is not full");
+
+        sizer.push_row(10);
+        assert!(sizer.should_flush_after(), "max_rows reached");
+
+        let mut sizer = GenotypeBatchSizer::new(100, 50).unwrap();
+        sizer.push_row(60);
+        assert!(
+            sizer.should_flush_after(),
+            "a single row over the soft limit flushes after it is appended, \
+             because it is already in the buffers"
+        );
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-08-15-bgen-baseline.md
+++ b/docs/superpowers/plans/2026-08-15-bgen-baseline.md
@@ -22,28 +22,33 @@ Criterion reports `[lower median upper]`; the table carries the median.
 
 ### `chr22.first-25000.unphased.bgen` — 25,000 x 2,548, uniform width 3
 
-| Mode | Layout | Partitions | Baseline | After batch buffers | Change |
+| Mode | Layout | Partitions | Baseline | After | Change |
 | --- | --- | --- | --- | --- | --- |
-| probability | nested | 1 | 1.0190 s | 779.95 ms | **-23%** |
-| probability | nested | 8 | 329.72 ms | 220.25 ms | **-33%** |
-| probability | fixed | 1 | 925.68 ms | 743.84 ms | **-20%** |
-| probability | fixed | 8 | 253.04 ms | 206.86 ms | **-18%** |
-| dosage | nested | 1 | 630.90 ms | 592.11 ms | -6% |
-| dosage | nested | 8 | 165.64 ms | 159.10 ms | -4% |
+| probability | nested | 1 | 1.0190 s | 783.36 ms | **-23%** |
+| probability | nested | 8 | 329.72 ms | 220.02 ms | **-33%** |
+| probability | fixed | 1 | 925.68 ms | 746.23 ms | **-19%** |
+| probability | fixed | 8 | 253.04 ms | 203.17 ms | **-20%** |
+| dosage | nested | 1 | 630.90 ms | 590.69 ms | -6% |
+| dosage | nested | 8 | 165.64 ms | 158.16 ms | -5% |
 
 ### `chr22.first-25000.bgen` — 25,000 x 2,548, mixed widths 3/4
 
-| Mode | Layout | Partitions | Baseline | After batch buffers | Change |
+| Mode | Layout | Partitions | Baseline | After | Change |
 | --- | --- | --- | --- | --- | --- |
-| probability | nested | 1 | 1.1211 s | 881.83 ms | **-21%** |
-| probability | nested | 8 | 524.85 ms | 256.22 ms | **-51%** |
-| probability | fixed | 1 | **unsupported** | 787.54 ms | **now runs** |
-| probability | fixed | 8 | **unsupported** | 217.71 ms | **now runs** |
-| dosage | nested | 1 | 633.00 ms | 585.32 ms | -8% |
-| dosage | nested | 8 | 169.67 ms | 157.12 ms | -7% |
+| probability | nested | 1 | 1.1211 s | 891.06 ms | **-21%** |
+| probability | nested | 8 | 524.85 ms | 253.88 ms | **-52%** |
+| probability | fixed | 1 | **unsupported** | 787.63 ms | **now runs** |
+| probability | fixed | 8 | **unsupported** | 225.67 ms | **now runs** |
+| dosage | nested | 1 | 633.00 ms | 583.03 ms | -8% |
+| dosage | nested | 8 | 169.67 ms | 156.41 ms | -8% |
 
 Every row improved, and dosage — already 1.9x ahead of snputils and the thing
 this rework most risked spending — improved too.
+
+The headline for the phased fixture is the pair of rows together: its best
+available probability read went from 524.85 ms (nested, 8 partitions, the only
+option) to 225.67 ms (fixed, 8 partitions, newly possible). That is 2.3x, and
+it is the fixture the project was furthest behind snputils on.
 
 **The mixed-width file gained the fixed layout early.** The plan expected this
 at task 9; it arrived with the batch buffers, because moving padding into the

--- a/docs/superpowers/plans/2026-08-15-bgen-baseline.md
+++ b/docs/superpowers/plans/2026-08-15-bgen-baseline.md
@@ -1,0 +1,67 @@
+# BGEN scan benchmark, before and after
+
+Rust-level scan time only, from the opt-in `BGEN_BENCH_PATH` bench in
+`datafusion/bio-format-bgen/benches/bgen_scan.rs`. This deliberately excludes
+the Python round trip: the handover's stage split put the Rust scan at 0.27 s of
+a 0.393 s end-to-end probability read, and 253 ms below is the same quantity
+measured directly.
+
+Host: Apple M3 Max, 16 cores, 64 GiB, macOS 15.6 arm64.
+
+Command, identical for every column:
+
+```bash
+BGEN_BENCH_PATH=~/research/data/BGEN/<fixture>.bgen \
+  cargo bench -p datafusion-bio-format-bgen --bench bgen_scan -- real_ \
+  --sample-size 10 --warm-up-time 2 --measurement-time 10
+```
+
+Criterion reports `[lower median upper]`; the table carries the median.
+
+## Baseline — `2c06f23` plus tasks 1-2
+
+### `chr22.first-25000.unphased.bgen` — 25,000 x 2,548, uniform width 3
+
+| Mode | Layout | Partitions | Baseline | After tasks 4-5 | Change |
+| --- | --- | --- | --- | --- | --- |
+| probability | nested | 1 | 1.0190 s | | |
+| probability | nested | 8 | 329.72 ms | | |
+| probability | fixed | 1 | 925.68 ms | | |
+| probability | fixed | 8 | 253.04 ms | | |
+| dosage | nested | 1 | 630.90 ms | | |
+| dosage | nested | 8 | 165.64 ms | | |
+
+### `chr22.first-25000.bgen` — 25,000 x 2,548, mixed widths 3/4
+
+| Mode | Layout | Partitions | Baseline | After tasks 4-5 | Change |
+| --- | --- | --- | --- | --- | --- |
+| probability | nested | 1 | 1.1211 s | | |
+| probability | nested | 8 | 524.85 ms | | |
+| probability | fixed | 1 | **unsupported** | | |
+| probability | fixed | 8 | **unsupported** | | |
+| dosage | nested | 1 | 633.00 ms | | |
+| dosage | nested | 8 | 169.67 ms | | |
+
+**"unsupported" is a baseline result, not a gap in the measurement.** The fixed
+layout rejects a mixed-width file, so the bench harness skips those two cases
+and says so on stderr. Task 9 is what makes them run; when they appear in the
+"after" column, that is the deliverable landing.
+
+## Noise
+
+The 8-partition rows are noisy at this sample size — `real_probability_nested_p8`
+spans 297-413 ms on the unphased fixture and 355-879 ms on the phased one,
+against a 253-255 ms spread for `real_probability_fixed_p8`. Treat an 8-partition
+change under ~15% as unproven and re-run with a larger `--sample-size` before
+believing it. The 1-partition rows are tight (under 1%) and are the better
+signal for a decoder change.
+
+## Discipline
+
+- Every column in these tables uses the command above, unchanged.
+- Nothing else runs on the machine during a measurement. The first attempt at
+  this baseline was discarded because a `cargo test` and a `cargo clippy` ran
+  against the same target directory while the bench was sampling.
+- Fresh-process numbers compare only against fresh-process numbers, and
+  `datafusion.execution.batch_size` does not matter — an apparent win from
+  raising it was a cold-versus-warm artifact.

--- a/docs/superpowers/plans/2026-08-15-bgen-baseline.md
+++ b/docs/superpowers/plans/2026-08-15-bgen-baseline.md
@@ -97,6 +97,58 @@ Both readers came in about 3% slower than the published run, so the absolute
 shift is machine state rather than code; the ratio is what this row is for and
 it held. Dosage was the workload this rework most risked spending.
 
+## Partition scaling is capped by range granularity, not by the decoder
+
+Measured on `chr22.first-25000.unphased.bgen`, probability output, fixed layout,
+Rust scan only:
+
+| Partitions | Time | Speedup |
+| --- | --- | --- |
+| 1 | 743.97 ms | 1.00x |
+| 2 | 641.80 ms | **1.16x** |
+| 4 | 354.23 ms | 2.10x |
+| 8 | 204.37 ms | 3.64x |
+
+The 2-partition step is 1.16x, and it is 1.16-1.17x on every workload measured —
+dosage and probability, phased and unphased. That reproducibility is what makes
+it a plan property rather than noise.
+
+**Root cause.** `plan_payload_partitions` caps each coalesced range at
+`payload_bytes / target_partitions`, and a variant's payload cannot be split
+across ranges, so the scan gets `target_partitions + 1` indivisible chunks of
+roughly equal size. `target + 1` chunks never divide evenly into `target`
+partitions: one partition always takes two of them. The planned byte shares are
+
+| Target | Shares |
+| --- | --- |
+| 2 | **87.2%**, 12.8% |
+| 4 | 43.6%, 21.8%, 21.8%, 12.9% |
+| 8 | 21.8%, 10.9% x5, 21.8%, 2.0% |
+
+and 1 / 0.872 = 1.15, which is the measured 2-partition speedup. The decoder is
+not the limit; the largest partition is.
+
+**Confirmed by experiment.** Capping ranges at a fixed 128 KiB instead of one
+partition's share, changing nothing else:
+
+| Partitions | Default cap | 128 KiB cap | Speedup, 128 KiB |
+| --- | --- | --- | --- |
+| 1 | 743.97 ms | 752.56 ms | 1.00x |
+| 2 | 641.80 ms | **414.36 ms** | 1.82x |
+| 4 | 354.23 ms | **234.60 ms** | 3.21x |
+| 8 | 204.37 ms | **147.76 ms** | 5.09x |
+
+One partition is unchanged, so this is purely balance: 8 partitions gain another
+28%. Set `BGEN_BENCH_MAX_RANGE_BYTES` to reproduce.
+
+**Not fixed here, deliberately.** This is pre-existing behaviour on the base
+branch, unrelated to the decode path this work changed, and the fix is a
+trade-off rather than a constant: finer ranges mean more object-store requests,
+which is cheap locally and expensive against remote storage. A real fix wants a
+cap of `payload_bytes / (target_partitions * k)` with a floor, chosen with
+remote reads in mind, plus its own spec scenario and review. Worth its own
+change.
+
 ## The inner loop was not touched
 
 The plan gated a `byte_probabilities_into` rewrite (23% of the profile) on this

--- a/docs/superpowers/plans/2026-08-15-bgen-baseline.md
+++ b/docs/superpowers/plans/2026-08-15-bgen-baseline.md
@@ -22,30 +22,46 @@ Criterion reports `[lower median upper]`; the table carries the median.
 
 ### `chr22.first-25000.unphased.bgen` — 25,000 x 2,548, uniform width 3
 
-| Mode | Layout | Partitions | Baseline | After tasks 4-5 | Change |
+| Mode | Layout | Partitions | Baseline | After batch buffers | Change |
 | --- | --- | --- | --- | --- | --- |
-| probability | nested | 1 | 1.0190 s | | |
-| probability | nested | 8 | 329.72 ms | | |
-| probability | fixed | 1 | 925.68 ms | | |
-| probability | fixed | 8 | 253.04 ms | | |
-| dosage | nested | 1 | 630.90 ms | | |
-| dosage | nested | 8 | 165.64 ms | | |
+| probability | nested | 1 | 1.0190 s | 779.95 ms | **-23%** |
+| probability | nested | 8 | 329.72 ms | 220.25 ms | **-33%** |
+| probability | fixed | 1 | 925.68 ms | 743.84 ms | **-20%** |
+| probability | fixed | 8 | 253.04 ms | 206.86 ms | **-18%** |
+| dosage | nested | 1 | 630.90 ms | 592.11 ms | -6% |
+| dosage | nested | 8 | 165.64 ms | 159.10 ms | -4% |
 
 ### `chr22.first-25000.bgen` — 25,000 x 2,548, mixed widths 3/4
 
-| Mode | Layout | Partitions | Baseline | After tasks 4-5 | Change |
+| Mode | Layout | Partitions | Baseline | After batch buffers | Change |
 | --- | --- | --- | --- | --- | --- |
-| probability | nested | 1 | 1.1211 s | | |
-| probability | nested | 8 | 524.85 ms | | |
-| probability | fixed | 1 | **unsupported** | | |
-| probability | fixed | 8 | **unsupported** | | |
-| dosage | nested | 1 | 633.00 ms | | |
-| dosage | nested | 8 | 169.67 ms | | |
+| probability | nested | 1 | 1.1211 s | 881.83 ms | **-21%** |
+| probability | nested | 8 | 524.85 ms | 256.22 ms | **-51%** |
+| probability | fixed | 1 | **unsupported** | 787.54 ms | **now runs** |
+| probability | fixed | 8 | **unsupported** | 217.71 ms | **now runs** |
+| dosage | nested | 1 | 633.00 ms | 585.32 ms | -8% |
+| dosage | nested | 8 | 169.67 ms | 157.12 ms | -7% |
 
-**"unsupported" is a baseline result, not a gap in the measurement.** The fixed
-layout rejects a mixed-width file, so the bench harness skips those two cases
-and says so on stderr. Task 9 is what makes them run; when they appear in the
-"after" column, that is the deliverable landing.
+Every row improved, and dosage — already 1.9x ahead of snputils and the thing
+this rework most risked spending — improved too.
+
+**The mixed-width file gained the fixed layout early.** The plan expected this
+at task 9; it arrived with the batch buffers, because moving padding into the
+buffers replaced the per-variant width equality check with a per-sample bound.
+Variant 0 of this fixture is phased and four states wide, which happens to be
+the file's widest, so the probed width already covers every sample and the
+narrower unphased variants pad to it. Task 8's catalog-derived width is still
+needed for the general case — a file whose variant 0 is *not* the widest.
+
+## A measurement bug found and fixed here
+
+The first run of this comparison reported the phased fixture as *regressed* by
+4-16%. It had not. Criterion saves a baseline per benchmark id, and the ids did
+not include the fixture, so the phased run compared itself against the unphased
+run's saved numbers — reporting the difference between two files as a change in
+the code. Ids are now `real_<fixture>_<mode>_<layout>_p<n>`. The absolute
+numbers above are unaffected; the change column is computed against the recorded
+baseline medians, not against criterion's `change:` line.
 
 ## Noise
 

--- a/docs/superpowers/plans/2026-08-15-bgen-baseline.md
+++ b/docs/superpowers/plans/2026-08-15-bgen-baseline.md
@@ -58,6 +58,52 @@ the file's widest, so the probed width already covers every sample and the
 narrower unphased variants pad to it. Task 8's catalog-derived width is still
 needed for the general case — a file whose variant 0 is *not* the widest.
 
+## End to end, against snputils
+
+`run_bgen_benchmarks.py --runs 3`, fresh process per reader, polars-bio through
+the fixed probability layout at 8 partitions. This is the comparison the goal is
+stated in; the tables above are the Rust scan inside it.
+
+### Probabilities, 25,000-variant slices
+
+| Fixture | Reader | Before | After |
+| --- | --- | --- | --- |
+| unphased | **polars-bio, 8 partitions** | 0.393 s | **0.292 s** |
+| unphased | snputils | 0.361 s | 0.363 s |
+| unphased | bgen | — | 0.319 s |
+| phased, mixed width | **polars-bio, 8 partitions** | 0.660 s | **0.340 s** |
+| phased, mixed width | snputils | 0.386 s | 0.397 s |
+| phased, mixed width | bgen | — | 0.332 s |
+
+Both goals are met. The unphased slice went from 9% behind snputils to **1.24x
+ahead**; the phased slice from 71% behind to **1.17x ahead**. Every reader
+produced the same `value_sha256` on each fixture.
+
+polars-bio is still marginally behind the `bgen` package on the phased fixture
+(0.340 s against 0.332 s) and ahead of it on the unphased one. `bgen` is the
+oracle, not the target, but it is the honest bound on what is left.
+
+### Dosage, full chromosome 22 — the number that must not move
+
+993,881 variants x 2,548 samples.
+
+| Reader | Published | Now |
+| --- | --- | --- |
+| polars-bio, 8 partitions | 7.073 s | 7.334 s |
+| snputils | 13.403 s | 13.665 s |
+| ratio | 1.895x | **1.86x** |
+
+Both readers came in about 3% slower than the published run, so the absolute
+shift is machine state rather than code; the ratio is what this row is for and
+it held. Dosage was the workload this rework most risked spending.
+
+## The inner loop was not touched
+
+The plan gated a `byte_probabilities_into` rewrite (23% of the profile) on this
+measurement: run it only if a fixture was still behind snputils. Neither is, so
+it was not run. That work remains available if the gap to the `bgen` package on
+the phased fixture is ever worth closing.
+
 ## A measurement bug found and fixed here
 
 The first run of this comparison reported the phased fixture as *regressed* by

--- a/docs/superpowers/plans/2026-08-15-bgen-probability-performance.md
+++ b/docs/superpowers/plans/2026-08-15-bgen-probability-performance.md
@@ -1,0 +1,1693 @@
+# BGEN Probability Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a BGEN probability scan faster than snputils on both the uniform-width and the mixed-width fixture, by decoding straight into batch-level Arrow buffers and by letting the fixed layout NaN-pad a mixed-width file.
+
+**Architecture:** Today `decode_variant` stages each variant in a freshly allocated `ProbabilityValues` and `build_genotypes` copies every staged variant into batch-level buffers. That single decision accounts for three profile frames — `memmove` 12%, `finish_sample` 9.5%, allocator churn ~10%. A new `GenotypeBuffers` (in a new `src/buffers.rs`) becomes the only place probabilities, dosages, ploidy, and offsets are written; the decoder appends into it and `build_batch` moves its `Vec`s into Arrow arrays with no copy. On top of that, the fixed layout gains per-sample NaN padding to a catalog-derived width, so the phased chr22 fixture can use the fixed layout at all.
+
+**Tech Stack:** Rust 1.88, DataFusion 52.1, arrow-rs (via `datafusion::arrow`), criterion, tokio. Python side: NumPy, PyArrow, polars-bio's venv.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-15-bgen-probability-performance-design.md`. Read it before task 1.
+- Branch `agent/bgen-probability-perf` in `~/CLionProjects/datafusion-bio-formats-bgen-perf`, off `agent/add-bgen-provider` (`2c06f23`). Do not commit to `agent/add-bgen-provider`; `~/CLionProjects/datafusion-bio-formats-bgen` stays pinned to `2c06f23` as the A/B baseline.
+- Every task ends green on: `cargo test -p datafusion-bio-format-bgen --all-targets` and `cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings`. Tasks touching `bio-format-core` add `-p datafusion-bio-format-core` to both.
+- Values already emitted must not change, with exactly one exception: task 9 (NaN padding, NaN for missing samples in the fixed layout). A value diff anywhere else is a bug, not a trade-off.
+- Never claim an edit landed without re-reading the file. On PR #220 a `checked_add` fix was silently reverted by a later edit to the same block and the build gave no signal.
+- Benchmarks: measure interleaved with a warm-up; compare fresh-process numbers only against fresh-process numbers. `datafusion.execution.batch_size` makes no difference — an apparent win from raising it was a cold-versus-warm artifact.
+- Fixtures live in `~/research/data/BGEN/`: `chr22.full.bgen` and `chr22.first-25000.bgen` (993,881 / 25,000 variants x 2,548 samples, mixed widths 3/4), plus `.unphased.` counterparts (uniform width 3). Python is `~/CLionProjects/polars-bio/.venv/bin/python`.
+
+---
+
+### Task 1: Real-file benchmark harness
+
+Without this the loop is a `maturin develop --release` rebuild per change. The existing bench fixture is a synthetic 2,048 x 256 file — a fine regression guard, useless for guiding this work.
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/benches/bgen_scan.rs:250-354`
+
+**Interfaces:**
+- Produces: a criterion group `bgen_real_file` with benches named `real_<mode>_<layout>_p<partitions>`, active only when `BGEN_BENCH_PATH` is set.
+
+- [ ] **Step 1: Add the opt-in group**
+
+Append to `benchmarks()` in `benches/bgen_scan.rs`, immediately before `group.finish();`:
+
+```rust
+    // A real cohort file is the only fixture that can guide probability-path
+    // work; the synthetic one above is 2,048 x 256 and dominated by fixed
+    // costs. Opt in with BGEN_BENCH_PATH so CI, which has no such file, keeps
+    // running the synthetic benches alone.
+    if let Ok(real_path) = std::env::var("BGEN_BENCH_PATH") {
+        for (mode_name, output_mode) in [
+            ("probability", BgenOutputMode::Probability),
+            ("dosage", BgenOutputMode::Dosage),
+        ] {
+            for (layout_name, layout) in [
+                ("nested", BgenProbabilityLayout::Nested),
+                ("fixed", BgenProbabilityLayout::Fixed),
+            ] {
+                if output_mode == BgenOutputMode::Dosage
+                    && layout == BgenProbabilityLayout::Fixed
+                {
+                    continue;
+                }
+                for partitions in [1_usize, 8] {
+                    let table = format!("real_{mode_name}_{layout_name}_p{partitions}");
+                    let context = runtime.block_on(context(
+                        &real_path,
+                        &table,
+                        BgenReadOptions {
+                            output_mode,
+                            probability_layout: layout,
+                            ..Default::default()
+                        },
+                        partitions,
+                    ));
+                    let sql = format!("SELECT genotypes FROM {table}");
+                    group.bench_function(&table, |bencher| {
+                        bencher
+                            .to_async(&runtime)
+                            .iter(|| async { black_box(execute(&context, &sql).await) });
+                    });
+                }
+            }
+        }
+    }
+```
+
+Add `BgenProbabilityLayout` to the `datafusion_bio_format_bgen` import at line 8.
+
+- [ ] **Step 2: Verify the bench still compiles and skips without the variable**
+
+Run: `cargo bench -p datafusion-bio-format-bgen -- --list`
+Expected: the synthetic bench names are listed and no `real_` name appears.
+
+- [ ] **Step 3: Verify the opt-in path runs**
+
+Run: `BGEN_BENCH_PATH=~/research/data/BGEN/chr22.first-25000.unphased.bgen cargo bench -p datafusion-bio-format-bgen -- --list`
+Expected: names including `real_probability_fixed_p8` appear.
+
+- [ ] **Step 4: Record the baseline**
+
+Run each of these to completion and paste the criterion medians into `docs/superpowers/plans/2026-08-15-bgen-baseline.md`, one table with columns fixture / mode / layout / partitions / median:
+
+```bash
+cd ~/CLionProjects/datafusion-bio-formats-bgen-perf
+for f in chr22.first-25000.unphased chr22.first-25000; do
+  BGEN_BENCH_PATH=~/research/data/BGEN/$f.bgen \
+    cargo bench -p datafusion-bio-format-bgen -- real_
+done
+```
+
+Note in that file which fixture is which: `chr22.first-25000.unphased` is uniform width 3, `chr22.first-25000` is mixed 3/4 and therefore **cannot** run the `fixed` benches yet — expect those to error, and record that they error. That error disappearing is task 9's deliverable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-format-bgen/benches/bgen_scan.rs docs/superpowers/plans/2026-08-15-bgen-baseline.md
+git commit -m "bench(bgen): add an opt-in real-file scan benchmark and record the baseline"
+```
+
+---
+
+### Task 2: `should_flush_after` on the batch sizer
+
+Decoding into batch buffers inverts the flush decision: the row is already in the buffers by the time its size is known, so the sizer must answer "flush now?" after the append rather than before it.
+
+**Files:**
+- Modify: `datafusion/bio-format-core/src/genotype.rs:405-433`
+- Test: `datafusion/bio-format-core/src/genotype.rs` (the existing `#[cfg(test)] mod tests` at line 436)
+
+**Interfaces:**
+- Produces: `GenotypeBatchSizer::should_flush_after(&self) -> bool` — true when the batch is non-empty and has reached `max_rows` or exceeded `soft_byte_limit`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `datafusion/bio-format-core/src/genotype.rs`:
+
+```rust
+    #[test]
+    fn should_flush_after_reports_a_full_batch() {
+        let mut sizer = GenotypeBatchSizer::new(2, 100).unwrap();
+        assert!(!sizer.should_flush_after(), "an empty batch never flushes");
+
+        sizer.push_row(10);
+        assert!(!sizer.should_flush_after(), "one small row is not full");
+
+        sizer.push_row(10);
+        assert!(sizer.should_flush_after(), "max_rows reached");
+
+        let mut sizer = GenotypeBatchSizer::new(100, 50).unwrap();
+        sizer.push_row(60);
+        assert!(
+            sizer.should_flush_after(),
+            "a single row over the soft limit flushes after it is appended, \
+             because it is already in the buffers"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-format-core should_flush_after_reports_a_full_batch`
+Expected: FAIL, `no method named should_flush_after`.
+
+- [ ] **Step 3: Implement**
+
+Add to `impl GenotypeBatchSizer`, directly after `should_flush_before`:
+
+```rust
+    /// Returns true when the current batch should be emitted now that its rows
+    /// are appended.
+    ///
+    /// A caller that writes a row directly into its output buffers cannot
+    /// consult [`Self::should_flush_before`], because the row's size is not
+    /// known until it is written. Such a batch can exceed `soft_byte_limit` by
+    /// one row, which is the same slack the first row of every batch has.
+    pub fn should_flush_after(&self) -> bool {
+        self.rows > 0
+            && (self.rows >= self.max_rows || self.estimated_bytes > self.soft_byte_limit)
+    }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p datafusion-bio-format-core && cargo clippy -p datafusion-bio-format-core --all-targets -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-format-core/src/genotype.rs
+git commit -m "feat(core): let a genotype batch sizer decide after a row is appended"
+```
+
+---
+
+### Task 3: `GenotypeBuffers` — the batch-level Arrow buffers
+
+Pure data structure, no wiring. Tasks 4-6 move callers onto it.
+
+`decode.rs` is already 1,527 lines, so this goes in its own file.
+
+**Files:**
+- Create: `datafusion/bio-format-bgen/src/buffers.rs`
+- Modify: `datafusion/bio-format-bgen/src/lib.rs` (add `mod buffers;`)
+
+**Interfaces:**
+- Produces:
+  - `pub(crate) enum BufferLayout { FixedProbability(usize), NestedProbability, Dosage }`
+  - `pub(crate) struct GenotypeBuffers`
+  - `GenotypeBuffers::new(layout: BufferLayout) -> Self`
+  - `GenotypeBuffers::layout(&self) -> BufferLayout`
+  - `GenotypeBuffers::push_state(&mut self, value: f32)`
+  - `GenotypeBuffers::extend_states(&mut self, values: impl IntoIterator<Item = f32>)`
+  - `GenotypeBuffers::reserve_states(&mut self, additional: usize)`
+  - `GenotypeBuffers::finish_sample(&mut self) -> Result<()>`
+  - `GenotypeBuffers::finish_missing_sample(&mut self) -> Result<()>`
+  - `GenotypeBuffers::push_ploidy(&mut self, ploidy: u8)`
+  - `GenotypeBuffers::finish_variant(&mut self) -> Result<()>`
+  - `GenotypeBuffers::mark(&self) -> BufferMark` / `rollback(&mut self, mark: BufferMark)` / `bytes_since(&self, mark: BufferMark) -> usize`
+  - `GenotypeBuffers::rows(&self) -> usize`
+  - `GenotypeBuffers::take(&mut self) -> TakenBuffers`
+  - `pub(crate) struct TakenBuffers { pub values: Vec<f32>, pub sample_offsets: Vec<i32>, pub nulls: Option<NullBuffer>, pub variant_offsets: Vec<i32>, pub ploidy: Vec<u8>, pub ploidy_offsets: Vec<i32> }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `datafusion/bio-format-bgen/src/buffers.rs` containing only this test module for now:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fixed_layout_pads_a_short_sample_with_nan_and_writes_no_offsets() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(4));
+        buffers.extend_states([0.5, 0.25, 0.25]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+
+        let taken = buffers.take();
+        assert_eq!(taken.values.len(), 4, "the sample is padded to the width");
+        assert_eq!(&taken.values[..3], &[0.5, 0.25, 0.25]);
+        assert!(taken.values[3].is_nan(), "padding is NaN, not zero");
+        assert!(
+            taken.sample_offsets.is_empty(),
+            "a fixed-size list reads no per-sample offsets, so none are built"
+        );
+        assert_eq!(taken.variant_offsets, vec![0, 1]);
+        assert_eq!(taken.ploidy, vec![2]);
+        assert_eq!(taken.ploidy_offsets, vec![0, 1]);
+        assert!(taken.nulls.is_none(), "every sample was called");
+    }
+
+    #[test]
+    fn a_fixed_layout_rejects_a_sample_wider_than_its_width() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3));
+        buffers.extend_states([0.25, 0.25, 0.25, 0.25]);
+        let error = buffers.finish_sample().unwrap_err().to_string();
+        assert!(
+            error.contains("fixed probability layout") && error.contains("nested layout"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_fixed_layout_pads_a_missing_sample_to_the_full_width() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3));
+        buffers.finish_missing_sample().unwrap();
+        buffers.extend_states([1.0, 0.0, 0.0]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+
+        let taken = buffers.take();
+        assert_eq!(taken.values.len(), 6, "Arrow sizes the values buffer by entry count");
+        assert!(
+            taken.values[..3].iter().all(|value| value.is_nan()),
+            "a missing sample's slots read as NaN, not as a real 0.0"
+        );
+        let nulls = taken.nulls.expect("a missing sample needs a validity buffer");
+        assert!(nulls.is_null(0));
+        assert!(nulls.is_valid(1));
+    }
+
+    #[test]
+    fn a_nested_layout_writes_one_offset_per_sample_and_no_padding() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+        buffers.extend_states([0.5, 0.5]);
+        buffers.finish_sample().unwrap();
+        buffers.finish_missing_sample().unwrap();
+        buffers.extend_states([0.2, 0.3, 0.5]);
+        buffers.finish_sample().unwrap();
+        for _ in 0..3 {
+            buffers.push_ploidy(2);
+        }
+        buffers.finish_variant().unwrap();
+
+        let taken = buffers.take();
+        assert_eq!(taken.values, vec![0.5, 0.5, 0.2, 0.3, 0.5]);
+        assert_eq!(
+            taken.sample_offsets,
+            vec![0, 2, 2, 5],
+            "a missing sample occupies no states in the nested layout"
+        );
+        assert_eq!(taken.variant_offsets, vec![0, 3]);
+    }
+
+    #[test]
+    fn validity_appears_only_once_a_sample_is_missing() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage);
+        for value in [0.0_f32, 1.0, 2.0] {
+            buffers.push_state(value);
+            buffers.finish_sample().unwrap();
+        }
+        assert!(
+            buffers.take().nulls.is_none(),
+            "a fully called cohort must write no validity bytes at all"
+        );
+
+        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage);
+        buffers.push_state(0.0);
+        buffers.finish_sample().unwrap();
+        buffers.finish_missing_sample().unwrap();
+        buffers.push_state(2.0);
+        buffers.finish_sample().unwrap();
+        let nulls = buffers.take().nulls.expect("a missing dosage needs validity");
+        assert!(nulls.is_valid(0), "samples before the first missing one are backfilled");
+        assert!(nulls.is_null(1));
+        assert!(nulls.is_valid(2));
+    }
+
+    #[test]
+    fn rollback_restores_every_buffer_to_its_mark() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+        buffers.extend_states([1.0, 0.0]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+
+        let mark = buffers.mark();
+        buffers.extend_states([0.0, 1.0]);
+        buffers.finish_missing_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.rollback(mark);
+
+        let taken = buffers.take();
+        assert_eq!(taken.values, vec![1.0, 0.0]);
+        assert_eq!(taken.sample_offsets, vec![0, 2]);
+        assert_eq!(taken.variant_offsets, vec![0, 1]);
+        assert_eq!(taken.ploidy, vec![2]);
+    }
+
+    #[test]
+    fn take_resets_the_buffers_and_keeps_their_capacity() {
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(2));
+        buffers.extend_states([0.5, 0.5]);
+        buffers.finish_sample().unwrap();
+        buffers.push_ploidy(2);
+        buffers.finish_variant().unwrap();
+        let taken = buffers.take();
+        assert_eq!(taken.values.len(), 2);
+
+        assert_eq!(buffers.rows(), 0, "take leaves an empty batch");
+        let second = buffers.take();
+        assert!(second.values.is_empty());
+        assert_eq!(
+            second.variant_offsets,
+            vec![0],
+            "a reset batch still carries its leading zero offset"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p datafusion-bio-format-bgen --lib buffers`
+Expected: FAIL to compile — `cannot find type GenotypeBuffers`. (Add `mod buffers;` to `src/lib.rs` first if the module is not compiled at all.)
+
+- [ ] **Step 3: Implement**
+
+Prepend to `datafusion/bio-format-bgen/src/buffers.rs`:
+
+```rust
+//! Arrow-shaped output buffers for one BGEN batch.
+//!
+//! A decoder that stages each variant in its own allocation pays for it three
+//! times: the allocation itself, the per-sample bookkeeping, and a copy into
+//! the batch's buffers. These buffers are written directly by the decoder and
+//! moved into Arrow arrays when the batch is emitted, so a probability makes
+//! one trip from the bitstream to the output.
+
+use datafusion::arrow::array::BooleanBufferBuilder;
+use datafusion::arrow::buffer::NullBuffer;
+use datafusion::common::{DataFusionError, Result};
+
+/// How a batch's values are laid out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BufferLayout {
+    /// Probabilities padded to a fixed number of states per sample.
+    FixedProbability(usize),
+    /// Probabilities with one variable-length list per sample.
+    NestedProbability,
+    /// One dosage per sample.
+    Dosage,
+}
+
+/// Buffer lengths at a point in time, so one variant's writes can be undone.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BufferMark {
+    values: usize,
+    sample_offsets: usize,
+    samples: usize,
+    variant_offsets: usize,
+    ploidy: usize,
+    ploidy_offsets: usize,
+}
+
+/// Arrow buffers for the batch currently being built.
+#[derive(Debug)]
+pub(crate) struct GenotypeBuffers {
+    layout: BufferLayout,
+    values: Vec<f32>,
+    /// Empty unless `layout` is [`BufferLayout::NestedProbability`].
+    sample_offsets: Vec<i32>,
+    /// Materialized on the first missing sample and backfilled; a fully called
+    /// cohort writes no validity at all.
+    valid: Option<BooleanBufferBuilder>,
+    samples: usize,
+    /// Index into `values` where the sample being written began.
+    sample_start: usize,
+    variant_offsets: Vec<i32>,
+    ploidy: Vec<u8>,
+    ploidy_offsets: Vec<i32>,
+}
+
+/// One batch's buffers, moved out for Arrow construction.
+#[derive(Debug)]
+pub(crate) struct TakenBuffers {
+    pub(crate) values: Vec<f32>,
+    pub(crate) sample_offsets: Vec<i32>,
+    pub(crate) nulls: Option<NullBuffer>,
+    pub(crate) variant_offsets: Vec<i32>,
+    pub(crate) ploidy: Vec<u8>,
+    pub(crate) ploidy_offsets: Vec<i32>,
+}
+
+impl GenotypeBuffers {
+    pub(crate) fn new(layout: BufferLayout) -> Self {
+        Self {
+            layout,
+            values: Vec::new(),
+            sample_offsets: match layout {
+                BufferLayout::NestedProbability => vec![0],
+                _ => Vec::new(),
+            },
+            valid: None,
+            samples: 0,
+            sample_start: 0,
+            variant_offsets: vec![0],
+            ploidy: Vec::new(),
+            ploidy_offsets: vec![0],
+        }
+    }
+
+    pub(crate) fn layout(&self) -> BufferLayout {
+        self.layout
+    }
+
+    pub(crate) fn rows(&self) -> usize {
+        self.variant_offsets.len() - 1
+    }
+
+    pub(crate) fn reserve_states(&mut self, additional: usize) {
+        self.values.reserve(additional);
+    }
+
+    #[inline]
+    pub(crate) fn push_state(&mut self, value: f32) {
+        self.values.push(value);
+    }
+
+    #[inline]
+    pub(crate) fn extend_states(&mut self, values: impl IntoIterator<Item = f32>) {
+        self.values.extend(values);
+    }
+
+    /// Closes a called sample.
+    #[inline]
+    pub(crate) fn finish_sample(&mut self) -> Result<()> {
+        self.close_sample(true)
+    }
+
+    /// Closes a sample with no called genotype.
+    ///
+    /// A fixed layout still reserves the sample's slots, because Arrow sizes a
+    /// fixed-size list's values buffer from the entry count rather than from
+    /// offsets. Those slots are NaN so a consumer reading the values buffer
+    /// directly — which is the point of the fixed layout — does not see a real
+    /// 0.0 where there is no genotype.
+    #[inline]
+    pub(crate) fn finish_missing_sample(&mut self) -> Result<()> {
+        self.close_sample(false)
+    }
+
+    fn close_sample(&mut self, valid: bool) -> Result<()> {
+        match self.layout {
+            BufferLayout::FixedProbability(width) => {
+                let written = self.values.len() - self.sample_start;
+                if written > width {
+                    return Err(DataFusionError::Execution(format!(
+                        "BGEN fixed probability layout has {width} states per sample, but a \
+                         sample stores {written}; use the nested layout for this file"
+                    )));
+                }
+                self.values.resize(self.sample_start + width, f32::NAN);
+            }
+            BufferLayout::NestedProbability => {
+                let end = i32::try_from(self.values.len()).map_err(|_| {
+                    DataFusionError::Execution(
+                        "BGEN probability offsets exceed the 32-bit Arrow list limit".to_string(),
+                    )
+                })?;
+                self.sample_offsets.push(end);
+            }
+            BufferLayout::Dosage => {
+                debug_assert_eq!(
+                    self.values.len() - self.sample_start,
+                    usize::from(valid),
+                    "a dosage sample writes exactly one value when called and none when missing"
+                );
+                if !valid {
+                    self.values.push(f32::NAN);
+                }
+            }
+        }
+        if !valid && self.valid.is_none() {
+            let mut builder = BooleanBufferBuilder::new(self.samples + 1);
+            builder.append_n(self.samples, true);
+            self.valid = Some(builder);
+        }
+        if let Some(builder) = self.valid.as_mut() {
+            builder.append(valid);
+        }
+        self.samples += 1;
+        self.sample_start = self.values.len();
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn push_ploidy(&mut self, ploidy: u8) {
+        self.ploidy.push(ploidy);
+    }
+
+    /// Closes a variant's samples into one output row.
+    pub(crate) fn finish_variant(&mut self) -> Result<()> {
+        self.variant_offsets
+            .push(i32::try_from(self.samples).map_err(|_| {
+                DataFusionError::Execution(
+                    "BGEN sample offsets exceed the 32-bit Arrow list limit".to_string(),
+                )
+            })?);
+        self.ploidy_offsets
+            .push(i32::try_from(self.ploidy.len()).map_err(|_| {
+                DataFusionError::Execution(
+                    "BGEN ploidy offsets exceed the 32-bit Arrow list limit".to_string(),
+                )
+            })?);
+        Ok(())
+    }
+
+    pub(crate) fn mark(&self) -> BufferMark {
+        BufferMark {
+            values: self.values.len(),
+            sample_offsets: self.sample_offsets.len(),
+            samples: self.samples,
+            variant_offsets: self.variant_offsets.len(),
+            ploidy: self.ploidy.len(),
+            ploidy_offsets: self.ploidy_offsets.len(),
+        }
+    }
+
+    /// Undoes every write since `mark`, leaving a valid Arrow prefix.
+    ///
+    /// `valid` is a builder and cannot be truncated, so it is rebuilt. This runs
+    /// only when a variant fails to decode, which aborts the scan.
+    pub(crate) fn rollback(&mut self, mark: BufferMark) {
+        self.values.truncate(mark.values);
+        self.sample_offsets.truncate(mark.sample_offsets);
+        self.variant_offsets.truncate(mark.variant_offsets);
+        self.ploidy.truncate(mark.ploidy);
+        self.ploidy_offsets.truncate(mark.ploidy_offsets);
+        if let Some(builder) = self.valid.take() {
+            let buffer = builder.finish();
+            let mut rebuilt = BooleanBufferBuilder::new(mark.samples);
+            for index in 0..mark.samples {
+                rebuilt.append(buffer.value(index));
+            }
+            self.valid = Some(rebuilt);
+        }
+        self.samples = mark.samples;
+        self.sample_start = self.values.len();
+    }
+
+    /// Arrow bytes written since `mark`.
+    ///
+    /// Deliberately the same formula the staged `estimated_arrow_bytes` used —
+    /// values, ploidy, and one offset per ploidy entry — even though per-sample
+    /// offsets are now countable too. `GenotypeMetric::GenotypeBytes` is
+    /// reported from this, and three rounds of review on #220 were spent
+    /// settling what those counters mean.
+    pub(crate) fn bytes_since(&self, mark: BufferMark) -> usize {
+        let values = (self.values.len() - mark.values).saturating_mul(size_of::<f32>());
+        let ploidy = self.ploidy.len() - mark.ploidy;
+        values
+            .saturating_add(ploidy)
+            .saturating_add(ploidy.saturating_mul(size_of::<i32>()))
+    }
+
+    /// Moves the batch out, leaving empty buffers that keep their capacity.
+    pub(crate) fn take(&mut self) -> TakenBuffers {
+        let values = std::mem::take(&mut self.values);
+        let sample_offsets = std::mem::take(&mut self.sample_offsets);
+        let variant_offsets = std::mem::take(&mut self.variant_offsets);
+        let ploidy = std::mem::take(&mut self.ploidy);
+        let ploidy_offsets = std::mem::take(&mut self.ploidy_offsets);
+        let nulls = self
+            .valid
+            .take()
+            .map(|mut builder| NullBuffer::new(builder.finish()));
+
+        // A batch is very likely the same shape as the one before it, so the
+        // next batch starts at the previous batch's size. Without this the
+        // buffers reallocate their way up from zero on every batch, which is
+        // the allocator churn this design exists to remove.
+        self.values = Vec::with_capacity(values.len());
+        self.sample_offsets = match self.layout {
+            BufferLayout::NestedProbability => {
+                let mut offsets = Vec::with_capacity(sample_offsets.len());
+                offsets.push(0);
+                offsets
+            }
+            _ => Vec::new(),
+        };
+        self.variant_offsets = Vec::with_capacity(variant_offsets.len());
+        self.variant_offsets.push(0);
+        self.ploidy = Vec::with_capacity(ploidy.len());
+        self.ploidy_offsets = Vec::with_capacity(ploidy_offsets.len());
+        self.ploidy_offsets.push(0);
+        self.samples = 0;
+        self.sample_start = 0;
+
+        TakenBuffers {
+            values,
+            sample_offsets,
+            nulls,
+            variant_offsets,
+            ploidy,
+            ploidy_offsets,
+        }
+    }
+}
+```
+
+Add to `datafusion/bio-format-bgen/src/lib.rs`, next to the other module declarations:
+
+```rust
+mod buffers;
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p datafusion-bio-format-bgen --lib buffers`
+Expected: 7 passing tests.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings
+git add datafusion/bio-format-bgen/src/buffers.rs datafusion/bio-format-bgen/src/lib.rs
+git commit -m "feat(bgen): add batch-level Arrow genotype buffers"
+```
+
+---
+
+### Task 4: Decode probabilities into the buffers
+
+`decode_variant` stops returning staged values and appends to the buffers instead. Dosage keeps its `Vec<Option<f32>>` for one more task so this change stays reviewable.
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/src/decode.rs:8-89` (`DecodedGenotypes`, delete `ProbabilityValues`, delete `DecodedValues::Probabilities`)
+- Modify: `datafusion/bio-format-bgen/src/decode.rs:125-154` (`decode_variant` signature)
+- Modify: `datafusion/bio-format-bgen/src/decode.rs:221-277` (layout 1)
+- Modify: `datafusion/bio-format-bgen/src/decode.rs:625-779` (layout 2, both the fast path and the general path)
+- Modify: `datafusion/bio-format-bgen/src/physical_exec.rs:137-357` (stream and `build_batch`)
+- Modify: `datafusion/bio-format-bgen/src/table_provider.rs:461-503` (`probe_probability_width`)
+
+**Interfaces:**
+- Consumes: `GenotypeBuffers`, `BufferLayout`, `TakenBuffers`, `BufferMark` from task 3; `should_flush_after` from task 2.
+- Produces:
+  - `decode_variant(path: &str, variant: &BgenVariant, header: &BgenHeader, payload: &[u8], selected_samples: &[usize], options: &BgenReadOptions, scratch: &mut DecodeScratch, buffers: &mut GenotypeBuffers) -> Result<DecodedGenotypes>`
+  - `DecodedGenotypes { phased: bool, bits: u8, decompressed_bytes: usize, state_width: Option<usize> }` — `ploidy` and `values` are gone; both now live in the buffers.
+
+- [ ] **Step 1: Run the existing tests to capture the green baseline**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: PASS. These integration tests are the specification for this task — every one of them must still pass at step 4 without being edited. If a test needs editing to pass, stop: that is a behavior change, and only task 9 is allowed one.
+
+- [ ] **Step 2: Change the shape**
+
+In `decode.rs`:
+
+1. Delete `struct ProbabilityValues` and its `impl` (lines 21-69), and delete `enum DecodedValues` (lines 71-75).
+2. Reduce `DecodedGenotypes` to:
+
+```rust
+/// What a decoded variant reports beyond the values it wrote into the batch
+/// buffers.
+#[derive(Debug)]
+pub(crate) struct DecodedGenotypes {
+    pub(crate) phased: bool,
+    pub(crate) bits: u8,
+    pub(crate) decompressed_bytes: usize,
+    /// Probability states every sample of this variant stores, when the variant
+    /// declares one ploidy. `None` for a variable-ploidy variant.
+    pub(crate) state_width: Option<usize>,
+}
+```
+
+3. Delete `estimated_arrow_bytes` — `GenotypeBuffers::bytes_since` replaces it.
+4. Add `buffers: &mut GenotypeBuffers` as the last parameter of `decode_variant`, `decode_layout1`, `decode_layout2`, and `decode_layout2_block`, and thread it through.
+
+In layout 1 (lines 221-264), replace the `probabilities`/`dosages` locals so the probability arm writes to the buffers and the dosage arm keeps its `Vec<Option<f32>>`:
+
+```rust
+    let mut dosages = Vec::with_capacity(selected_samples.len());
+    for &sample in selected_samples {
+        // ... unchanged offset, values, and sum validation ...
+        if sum == 0 {
+            match options.output_mode {
+                BgenOutputMode::Probability => buffers.finish_missing_sample()?,
+                BgenOutputMode::Dosage => dosages.push(None),
+            }
+            buffers.push_ploidy(2);
+            continue;
+        }
+        // ... unchanged 32767..=32769 check ...
+        match options.output_mode {
+            BgenOutputMode::Probability => {
+                buffers.extend_states(values.iter().map(|value| *value as f32 / 32_768.0));
+                buffers.finish_sample()?;
+            }
+            BgenOutputMode::Dosage => {
+                dosages.push(Some((values[1] + 2 * values[2]) as f32 / 32_768.0));
+            }
+        }
+        buffers.push_ploidy(2);
+    }
+```
+
+Note the ploidy move: `ploidy: vec![2; selected_samples.len()]` in the returned struct becomes a `push_ploidy(2)` on **every** path through the loop, missing samples included. Layout 1 is always diploid.
+
+In layout 2, apply the same transformation at all three sites — the fast path (lines 646-694), the general path's missing branch (line 728-733), and the general path's probability arm (lines 739-755) — replacing `probabilities.finish_missing_sample(missing_pad)` with `buffers.finish_missing_sample()`, `probabilities.values.extend(...)` with `buffers.extend_states(...)`, `probabilities.finish_sample(true)` with `buffers.finish_sample()`, and `ploidies.push(x)` with `buffers.push_ploidy(x)`. Delete the `missing_pad` local (lines 514-522) and the `fixed_layout` local in layout 1 (line 221): the buffers own padding now. In the fast path, keep `byte_probabilities_into` writing into a `&mut Vec<f32>` by passing `buffers.values_mut()` — add that accessor to `GenotypeBuffers`:
+
+```rust
+    /// The values buffer, for a decoder that appends a whole sample at once.
+    #[inline]
+    pub(crate) fn values_mut(&mut self) -> &mut Vec<f32> {
+        &mut self.values
+    }
+```
+
+`byte_probabilities_into` already truncates its own partial write when it returns `None`, so a rejected sample leaves the buffer as it found it.
+
+- [ ] **Step 3: Rewire the stream and the batch builder**
+
+In `physical_exec.rs`:
+
+1. `struct DecodedRow` becomes metadata only:
+
+```rust
+#[derive(Debug)]
+struct DecodedRow {
+    variant_index: usize,
+    phased: bool,
+    bits: u8,
+}
+```
+
+2. In `execute`, build the buffers once per partition, before the loop:
+
+```rust
+            let layout = match (fileset.options.output_mode, fileset.probability_width) {
+                (BgenOutputMode::Dosage, _) => BufferLayout::Dosage,
+                (BgenOutputMode::Probability, Some(width)) => {
+                    BufferLayout::FixedProbability(width)
+                }
+                (BgenOutputMode::Probability, None) => BufferLayout::NestedProbability,
+            };
+            let mut buffers = GenotypeBuffers::new(layout);
+```
+
+3. Replace the decode-then-flush block with mark, decode, rollback-on-error, finish, flush-after:
+
+```rust
+                        let mark = buffers.mark();
+                        let decoded = match decode_variant(
+                            &fileset.path,
+                            variant,
+                            &fileset.header,
+                            payload,
+                            decode_samples,
+                            &fileset.options,
+                            &mut scratch,
+                            &mut buffers,
+                        ) {
+                            Ok(decoded) => decoded,
+                            Err(error) => {
+                                // A failed variant leaves a partial row behind;
+                                // drop it so the buffers stay a valid Arrow
+                                // prefix rather than a torn row.
+                                buffers.rollback(mark);
+                                Err(error)?
+                            }
+                        };
+                        buffers.finish_variant()?;
+                        let row_bytes = buffers.bytes_since(mark);
+                        metrics.add(
+                            GenotypeMetric::DecompressedBytes,
+                            decoded.decompressed_bytes as u64,
+                        );
+                        metrics.add(GenotypeMetric::SamplesDecoded, decode_samples.len() as u64);
+                        metrics.add(
+                            GenotypeMetric::SampleValuesSkipped,
+                            (fileset.header.sample_count as usize)
+                                .saturating_sub(decode_samples.len()) as u64,
+                        );
+                        rows.push(DecodedRow {
+                            variant_index,
+                            phased: decoded.phased,
+                            bits: decoded.bits,
+                        });
+                        sizer.push_row(row_bytes);
+                        if sizer.should_flush_after() {
+                            let row_count = rows.len();
+                            let batch =
+                                build_batch(&fileset, schema.clone(), &rows, buffers.take())?;
+                            record_batch_metrics(&metrics, row_count, sizer.estimated_bytes());
+                            yield batch;
+                            rows.clear();
+                            sizer.reset();
+                        }
+```
+
+The metadata-only branch (`assignment.ranges.is_empty()`, lines 144-164) keeps `should_flush_before` — it decodes nothing and writes nothing to the buffers — but must still call `buffers.finish_variant()?` per row so the row count matches, and must pass `buffers.take()` to `build_batch`. Delete `empty_genotypes` (lines 272-286); an empty row is now just a `finish_variant` with no samples.
+
+4. `build_batch` and `build_genotypes` take the taken buffers and stop copying:
+
+```rust
+fn build_batch(
+    fileset: &BgenFileset,
+    schema: SchemaRef,
+    rows: &[DecodedRow],
+    buffers: TakenBuffers,
+) -> Result<RecordBatch>
+```
+
+`build_genotypes(data_type, buffers, mode)` becomes construction only — every loop over `rows` in it disappears:
+
+```rust
+fn build_genotypes(
+    data_type: &DataType,
+    buffers: TakenBuffers,
+    mode: BgenOutputMode,
+) -> Result<ArrayRef> {
+    let DataType::Struct(fields) = data_type else {
+        return Err(DataFusionError::Execution(
+            "BGEN genotypes field is not a struct".to_string(),
+        ));
+    };
+    let TakenBuffers {
+        values,
+        sample_offsets,
+        nulls,
+        variant_offsets,
+        ploidy,
+        ploidy_offsets,
+    } = buffers;
+    let states = Arc::new(Float32Array::from(values)) as ArrayRef;
+    let genotype_values: ArrayRef = match mode {
+        BgenOutputMode::Probability => {
+            let state_field = Arc::new(Field::new("state", DataType::Float32, false));
+            let samples: ArrayRef = match fixed_probability_width(data_type) {
+                Some(width) => Arc::new(FixedSizeListArray::try_new(
+                    state_field.clone(),
+                    width,
+                    states,
+                    nulls,
+                )?),
+                None => Arc::new(ListArray::try_new(
+                    state_field.clone(),
+                    OffsetBuffer::new(ScalarBuffer::from(sample_offsets)),
+                    states,
+                    nulls,
+                )?),
+            };
+            let sample_field = Arc::new(Field::new("sample", samples.data_type().clone(), true));
+            Arc::new(ListArray::try_new(
+                sample_field,
+                OffsetBuffer::new(ScalarBuffer::from(variant_offsets)),
+                samples,
+                None,
+            )?)
+        }
+        BgenOutputMode::Dosage => unreachable!("dosage still stages its own values"),
+    };
+    let ploidy_values = Arc::new(UInt8Array::from(ploidy)) as ArrayRef;
+    let ploidy_array = Arc::new(ListArray::try_new(
+        Arc::new(Field::new("item", DataType::UInt8, false)),
+        OffsetBuffer::new(ScalarBuffer::from(ploidy_offsets)),
+        ploidy_values,
+        None,
+    )?);
+    Ok(Arc::new(StructArray::try_new(
+        fields.clone(),
+        vec![genotype_values, ploidy_array],
+        None,
+    )?))
+}
+```
+
+Keep the dosage arm working by leaving the old dosage code path in place for now — pass `rows` alongside the buffers and branch on `mode` at the call site. Task 5 deletes it.
+
+The `phased` and `bits` columns now read `row.phased` / `row.bits` instead of `row.genotypes.as_ref().map(...)`. Delete the `payload_derived_projected` local: those two values are always present on the row now.
+
+5. In `table_provider.rs`, `probe_probability_width` passes a throwaway buffer:
+
+```rust
+    let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+    let decoded = decode_variant(
+        path, variant, header, &payload, &[], options, &mut scratch, &mut buffers,
+    )?;
+```
+
+The probe selects no samples, so nothing is written to it.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: PASS, with no test file edited. Pay attention to `honors_row_and_soft_byte_batch_limits` — it is the test that pins the flush behavior this task inverts. If it fails on batch boundaries, the fix is in how `should_flush_after` is called, not in the test.
+
+- [ ] **Step 5: Confirm the metrics did not drift**
+
+Run: `cargo test -p datafusion-bio-format-bgen exact_filters_limits_and_metadata_projection_skip_payloads empty_sample_selection_emits_empty_values_without_payload_reads`
+Expected: PASS. `GenotypeBytes` is now exact rather than estimated; these tests assert on counters and will catch a formula that drifted.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings
+git add datafusion/bio-format-bgen/src
+git commit -m "perf(bgen): decode probabilities straight into the batch buffers"
+```
+
+---
+
+### Task 5: Decode dosages into the buffers
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/src/decode.rs` (both layouts' dosage arms)
+- Modify: `datafusion/bio-format-bgen/src/physical_exec.rs` (`build_genotypes` dosage arm)
+
+**Interfaces:**
+- Consumes: `GenotypeBuffers` in `BufferLayout::Dosage` from task 3.
+- Produces: `DecodedValues` and the last `Vec<Option<f32>>` staging are gone from `decode.rs`.
+
+- [ ] **Step 1: Replace the dosage staging in the decoder**
+
+In `decode.rs`, at every `dosages.push(...)` site (layout 1 lines ~236 and ~261; layout 2 lines ~655, ~680-691, ~731, ~756-763), replace:
+
+```rust
+                    dosages.push(None);
+```
+
+with:
+
+```rust
+                    buffers.finish_missing_sample()?;
+```
+
+and:
+
+```rust
+                    dosages.push(Some(numerator as f32 / denominator as f32));
+```
+
+with:
+
+```rust
+                    buffers.push_state(numerator as f32 / denominator as f32);
+                    buffers.finish_sample()?;
+```
+
+Delete every `let mut dosages = Vec::with_capacity(...)` and the `DecodedValues` construction in the returned `DecodedGenotypes`.
+
+- [ ] **Step 2: Replace the dosage arm of `build_genotypes`**
+
+```rust
+        BgenOutputMode::Dosage => Arc::new(ListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            OffsetBuffer::new(ScalarBuffer::from(variant_offsets)),
+            states,
+            None,
+        )?),
+```
+
+The item field stays `Float32` and **nullable**, and the null buffer belongs to the values array, not the list — `Float32Array::from(values)` must be rebuilt with `nulls`:
+
+```rust
+    let states = Arc::new(Float32Array::new(
+        ScalarBuffer::from(values),
+        nulls,
+    )) as ArrayRef;
+```
+
+Move that construction into each arm so probability keeps putting `nulls` on the sample list and dosage puts them on the values. Getting this backwards produces a schema that no longer matches `build_schema`, so `RecordBatch::try_new` will reject it — the tests will say so immediately.
+
+Remove the `rows` parameter from `build_genotypes`; it no longer reads any row.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: PASS with no test edited. `emits_biallelic_dosage_and_rejects_multiallelic_selection` and `decodes_layout1_uncompressed_and_zlib` are the ones that pin dosage nullability.
+
+- [ ] **Step 4: Check the dosage benchmark did not regress**
+
+Run:
+```bash
+BGEN_BENCH_PATH=~/research/data/BGEN/chr22.first-25000.unphased.bgen \
+  cargo bench -p datafusion-bio-format-bgen -- real_dosage
+```
+Expected: within noise of, or faster than, the task 1 baseline. Dosage is 1.9x ahead of snputils today; this refactor must not spend that.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings
+git add datafusion/bio-format-bgen/src
+git commit -m "perf(bgen): decode dosages straight into the batch buffers"
+```
+
+---
+
+### Task 6: Measure the refactor
+
+A checkpoint, not a code change. Phase 3 of the spec is conditional on this number.
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-15-bgen-baseline.md`
+
+- [ ] **Step 1: Re-run the benchmark**
+
+```bash
+cd ~/CLionProjects/datafusion-bio-formats-bgen-perf
+BGEN_BENCH_PATH=~/research/data/BGEN/chr22.first-25000.unphased.bgen \
+  cargo bench -p datafusion-bio-format-bgen -- real_
+```
+
+- [ ] **Step 2: Record before/after**
+
+Add an "after tasks 4-5" column to the table in `docs/superpowers/plans/2026-08-15-bgen-baseline.md`. State the percentage change per row. If any row got slower, say so in the file — a benchmark that only records wins is not a benchmark.
+
+- [ ] **Step 3: Re-profile**
+
+```bash
+cargo bench -p datafusion-bio-format-bgen --no-run
+# then sample the bench binary with your profiler of choice, e.g.
+# samply record ./target/release/deps/bgen_scan-<hash> --bench real_probability_fixed_p8
+```
+
+Record the new frame shares next to the spec's table (`byte_probabilities_into` 23%, libdeflate 23%, `decode_variant` 16%, `memmove` 12%, `finish_sample` 9.5%, allocator ~10%, `build_genotypes` 2%). `finish_sample` and `memmove` should have collapsed; whatever is now on top decides whether task 12 happens.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-08-15-bgen-baseline.md
+git commit -m "docs(bgen): record the batch-buffer benchmark and profile"
+```
+
+---
+
+### Task 7: Report the probed variant's ploidy and phasing
+
+Task 8 derives the schema width from the probe plus the catalog, and needs more from the probe than a width.
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/src/decode.rs` (`DecodedGenotypes`, both layouts' return values)
+- Modify: `datafusion/bio-format-bgen/src/table_provider.rs:461-503`
+- Test: `datafusion/bio-format-bgen/tests/provider_test.rs`
+
+**Interfaces:**
+- Produces: `DecodedGenotypes.declared_ploidy: Option<u8>` — the single ploidy every sample of the variant declares, or `None` when the variant declares a range.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/provider_test.rs`:
+
+```rust
+#[tokio::test]
+async fn the_width_probe_reports_the_first_variants_shape() {
+    // v1 is unphased biallelic diploid, so a fixed-layout schema for this
+    // fixture is derived from ploidy 2, unphased. v3 is triallelic, and an
+    // unphased triallelic diploid sample stores six states, so the schema has
+    // to be six wide rather than v1's three.
+    let fixture = fixture(Codec::Zlib, true);
+    let provider = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let schema = TableProvider::schema(&provider);
+    let genotypes = schema.field_with_name("genotypes").unwrap();
+    assert!(
+        format!("{:?}", genotypes.data_type()).contains("FixedSizeList(Field { name: \"state\""),
+        "{:?}",
+        genotypes.data_type()
+    );
+    assert!(
+        format!("{:?}", genotypes.data_type()).contains(", 6)"),
+        "the width must cover the widest catalog variant, not just variant 0: {:?}",
+        genotypes.data_type()
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p datafusion-bio-format-bgen the_width_probe_reports_the_first_variants_shape`
+Expected: FAIL — the schema is 3 wide, because the width comes from variant 0 alone.
+
+- [ ] **Step 3: Add `declared_ploidy`**
+
+In `decode.rs`, add the field to `DecodedGenotypes` with this doc comment:
+
+```rust
+    /// The one ploidy every sample of this variant declares, or `None` when the
+    /// variant declares a range. The probe reads this without selecting any
+    /// sample, so it cannot come from the per-sample ploidy the buffers hold.
+    pub(crate) declared_ploidy: Option<u8>,
+```
+
+Set it in every `DecodedGenotypes` construction: `Some(2)` in layout 1 (always diploid), and in layout 2 `uniform_stride_bits.map(|_| min_ploidy)` — the same condition that produces `uniform_state_width`, so a variable-ploidy variant reports `None` for both.
+
+- [ ] **Step 4: Widen the probe's return**
+
+In `table_provider.rs`, change `probe_probability_width` to return `(ProbeShape, u64, u64)` where:
+
+```rust
+/// What variant 0 says about the file's probability shape.
+#[derive(Debug, Clone, Copy)]
+struct ProbeShape {
+    width: usize,
+    ploidy: u8,
+    phased: bool,
+}
+```
+
+Keep the existing `max_states_per_sample` check and the existing "declares a variable ploidy" error for `state_width == None`; add the same `ok_or_else` for `declared_ploidy`, reusing that message. Store the shape on `BgenFileset` as `probability_shape: Option<ProbeShape>`, replacing `probability_width`, and have `build_schema` read `fileset.probability_shape.map(|shape| shape.width)` for now — task 8 changes what that width is.
+
+`probability_width` has a second reader: the `BufferLayout` selection added to `physical_exec.rs` in task 4. Update it in the same commit:
+
+```rust
+                (BgenOutputMode::Probability, Some(shape)) => {
+                    BufferLayout::FixedProbability(shape.width)
+                }
+```
+
+matching on `fileset.probability_shape`. `ProbeShape` therefore needs `pub(crate)` visibility, not private.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: everything passes except `the_width_probe_reports_the_first_variants_shape`, which still fails on the width being 3. That is task 8.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add datafusion/bio-format-bgen/src
+git commit -m "refactor(bgen): report the probed variant's ploidy and phasing"
+```
+
+---
+
+### Task 8: Derive the fixed width from the catalog
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/src/decode.rs` (make `complete_probability_count` visible)
+- Modify: `datafusion/bio-format-bgen/src/table_provider.rs:203-215`
+- Test: `datafusion/bio-format-bgen/tests/provider_test.rs` (task 7's test)
+
+**Interfaces:**
+- Consumes: `ProbeShape` from task 7.
+- Produces: `pub(crate) fn complete_probability_count(ploidy: u8, allele_count: usize, phased: bool) -> Result<u64>` — already exists at `decode.rs:789`, needs `pub(crate)`.
+
+- [ ] **Step 1: Implement the derivation**
+
+In `table_provider.rs`, after the probe:
+
+```rust
+/// Widest sample any catalog variant can store, given the shape variant 0
+/// declares.
+///
+/// A Layout 2 block header lives inside the compressed payload, so learning
+/// every variant's exact width would mean decompressing the whole file at plan
+/// time. Allele counts are already in the catalog, and ploidy and phasing are
+/// constant across a file in practice, so the widest state count follows from
+/// the probe plus the catalog at no I/O cost. A variant that turns out to store
+/// more than this is rejected during the scan rather than silently truncated.
+fn derive_fixed_width(catalog: &BgenCatalog, shape: ProbeShape) -> Result<usize> {
+    let mut width = shape.width as u64;
+    for variant in &catalog.variants {
+        width = width.max(complete_probability_count(
+            shape.ploidy,
+            variant.alleles.len(),
+            shape.phased,
+        )?);
+    }
+    usize::try_from(width).map_err(|_| {
+        DataFusionError::Plan("BGEN probability width does not fit usize".to_string())
+    })
+}
+```
+
+Call it where the probe result is stored, and **overwrite `ProbeShape::width` with the derived width** before the shape goes onto the `BgenFileset`:
+
+```rust
+                let (mut shape, bytes, decompressed) =
+                    probe_probability_width(&path, &source, &header, &catalog, &options).await?;
+                shape.width = derive_fixed_width(&catalog, shape)?;
+                (Some(shape), bytes, decompressed)
+```
+
+That keeps one width in play. `build_schema` and the `BufferLayout` selection both read `shape.width` and both get the derived one, so neither has to know which is which. Keep `ProbeShape`'s `ploidy`/`phased` — the scan does not need them, but the error message in task 9 is clearer with them and a future exact-width pass will.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p datafusion-bio-format-bgen the_width_probe_reports_the_first_variants_shape`
+Expected: PASS — the schema is now 6 wide.
+
+- [ ] **Step 3: Run the whole suite**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: `fixed_probability_layout_rejects_a_mixed_width_file` now fails differently — the schema is wide enough, so the scan gets further before rejecting. Leave it failing; task 9 rewrites it. Every other test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add datafusion/bio-format-bgen/src
+git commit -m "feat(bgen): derive the fixed probability width from the catalog"
+```
+
+---
+
+### Task 9: NaN-pad the fixed layout
+
+The one task in this plan that changes emitted values.
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/src/physical_exec.rs` (delete the per-variant `state_width` check, lines 428-443 of the original)
+- Modify: `datafusion/bio-format-bgen/src/table_provider.rs:58-64` (the `Fixed` doc comment)
+- Test: `datafusion/bio-format-bgen/tests/provider_test.rs:1443-1471`
+
+**Interfaces:**
+- Consumes: per-sample padding from `GenotypeBuffers::close_sample` (task 3), catalog width (task 8).
+
+- [ ] **Step 1: Rewrite the mixed-width test to assert padding**
+
+Replace `fixed_probability_layout_rejects_a_mixed_width_file` in `tests/provider_test.rs` with:
+
+```rust
+#[tokio::test]
+async fn fixed_probability_layout_pads_a_narrower_variant_with_nan() {
+    // The fixture mixes widths on purpose: rs1 is unphased biallelic (three
+    // states), rs3 is triallelic (six for a diploid sample, three for a
+    // haploid one). The schema is six wide and every narrower sample pads.
+    let fixture = fixture(Codec::Zlib, true);
+    let provider = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1024);
+    context.register_table("f", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM f WHERE rsid = 'rs1'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect("a mixed-width file is padded, not rejected");
+
+    let samples = probability_values_any(&batches[0], 0, 0);
+    let called = samples[0].as_ref().expect("sample 0 is called");
+    assert_eq!(called.len(), 6, "every sample is the schema width");
+    assert_eq!(&called[..3], &[1.0, 0.0, 0.0]);
+    assert!(
+        called[3..].iter().all(|value| value.is_nan()),
+        "padding is NaN: {called:?}"
+    );
+    assert!(
+        samples[2].is_none(),
+        "the third sample is missing and stays null"
+    );
+}
+
+#[tokio::test]
+async fn fixed_probability_layout_reports_a_sample_wider_than_the_schema() {
+    // The width is derived from variant 0's ploidy, so a later variant whose
+    // samples are triploid stores four states where the schema has three.
+    // Padding cannot represent that, and truncating would emit a distribution
+    // that is not the file's.
+    let dir = TempDir::new().unwrap();
+    let bgen = dir.path().join("wider.bgen");
+    let variants = vec![
+        Variant {
+            id: "v1",
+            rsid: "rs1",
+            chrom: "1",
+            position: 10,
+            alleles: vec!["A", "C"],
+            phased: false,
+            bits: 8,
+            samples: vec![
+                sample(2, false, &[255, 0]),
+                sample(2, false, &[0, 255]),
+                sample(2, false, &[0, 0]),
+            ],
+        },
+        Variant {
+            id: "v2",
+            rsid: "rs2",
+            chrom: "1",
+            position: 20,
+            alleles: vec!["A", "C"],
+            phased: false,
+            bits: 8,
+            samples: vec![
+                sample(3, false, &[255, 0, 0]),
+                sample(3, false, &[0, 255, 0]),
+                sample(3, false, &[0, 0, 255]),
+            ],
+        },
+    ];
+    let (bytes, _rows) = encode_layout2(Codec::Zlib, true, &variants);
+    fs::write(&bgen, bytes).unwrap();
+
+    let provider = BgenTableProvider::try_new(
+        path(&bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1024);
+    context.register_table("b", Arc::new(provider)).unwrap();
+    let error = context
+        .sql("SELECT genotypes FROM b")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("fixed probability layout") && error.contains("nested layout"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn fixed_probability_layout_pads_a_variable_ploidy_variant() {
+    // rs3 declares ploidy 1..=2, so it has no single width and the old
+    // per-variant check rejected it outright. Per-sample padding represents it:
+    // the haploid samples pad to the schema width alongside the diploid one.
+    let fixture = fixture(Codec::Zlib, true);
+    let provider = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1024);
+    context.register_table("f", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM f WHERE rsid = 'rs3'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect("a variable-ploidy variant pads per sample");
+    let samples = probability_values_any(&batches[0], 0, 0);
+    let haploid = samples[0].as_ref().expect("sample 0 is called");
+    assert_eq!(haploid.len(), 6);
+    assert!(
+        haploid[3..].iter().all(|value| value.is_nan()),
+        "a haploid sample pads to the schema width: {haploid:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run them to see which fail**
+
+Run: `cargo test -p datafusion-bio-format-bgen fixed_probability_layout`
+Expected: the padding tests FAIL with the "expects N states per sample" error from `build_genotypes`; the wider-sample test may already pass for the wrong reason. Read the failure text before proceeding.
+
+- [ ] **Step 3: Delete the per-variant width check**
+
+In `physical_exec.rs`, delete the whole `if let Some(width) = width { ... }` block that compares `decoded.state_width` to the schema width (original lines 428-443). `GenotypeBuffers` already enforces the bound per sample, with the message these tests assert on. The `else` branch that accumulated nested offsets is already gone as of task 4.
+
+- [ ] **Step 4: Update the contract documentation**
+
+In `table_provider.rs`, replace the `Fixed` variant's doc comment:
+
+```rust
+    /// One fixed-width list per sample.
+    ///
+    /// Drops the per-sample list offsets, which are a quarter of the emitted
+    /// bytes for a diploid biallelic cohort. The width covers the widest sample
+    /// the catalog allows, and a narrower sample is padded with NaN — including
+    /// a missing sample, whose slots are never read but must exist because
+    /// Arrow sizes the values buffer from the entry count. A sample storing
+    /// more states than the width is rejected; use [`Self::Nested`] for such a
+    /// file.
+    Fixed,
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: PASS, all of it.
+
+- [ ] **Step 6: Verify the padded fixed layout still equals the nested one**
+
+Run: `cargo test -p datafusion-bio-format-bgen fixed_probability_layout_matches_the_nested_layout`
+Expected: PASS. This test compares the two layouts value by value on rs1, which is now padded — if it passes, padding did not disturb the real states.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings
+git add datafusion/bio-format-bgen
+git commit -m "feat(bgen): NaN-pad the fixed probability layout instead of rejecting mixed widths"
+```
+
+---
+
+### Task 10: Verify against the oracle
+
+Correctness gate. The provider's whole claim is being bit-identical to the `bgen` package where snputils is not.
+
+**Files:**
+- Modify: `~/CLionProjects/bioformats-benchmark/benchmarks/bgen_matrix.py:58-61` (stale comment)
+- Modify: `~/CLionProjects/polars-bio/Cargo.toml` (repin the provider rev)
+
+- [ ] **Step 1: Push and repin**
+
+```bash
+cd ~/CLionProjects/datafusion-bio-formats-bgen-perf
+git push -u origin agent/bgen-probability-perf
+git rev-parse HEAD    # the SHA to pin
+```
+
+In `~/CLionProjects/polars-bio/Cargo.toml`, repin **every** `datafusion-bio-format-*` dependency to that SHA — they share a workspace and a partial repin compiles two copies of the core crate.
+
+```bash
+cd ~/CLionProjects/polars-bio
+unset CONDA_PREFIX; source .venv/bin/activate
+RUSTFLAGS="-C target-cpu=native" maturin develop --release
+```
+
+- [ ] **Step 2: Fix the stale comment**
+
+In `~/CLionProjects/bioformats-benchmark/benchmarks/bgen_matrix.py`, replace the comment at lines 58-61:
+
+```python
+    # The fixed layout drops the per-sample offsets and NaN-pads a narrower
+    # sample to the file's widest, so it applies to mixed-width files too. It is
+    # still chosen explicitly rather than attempted and retried: a failed
+    # attempt costs a whole scan.
+```
+
+- [ ] **Step 3: Verify every fixture, both layouts, zero tolerance**
+
+```bash
+cd ~/CLionProjects/bioformats-benchmark
+PY=~/CLionProjects/polars-bio/.venv/bin/python
+for f in chr22.first-25000.unphased chr22.first-25000; do
+  for layout in fixed nested; do
+    BGEN_PROBABILITY_LAYOUT=$layout BGEN_READER=bgen BGEN_MODE=probabilities \
+    BGEN_VERIFY_LEFT=polars-bio BGEN_VERIFY_RIGHT=bgen \
+    BGEN_PATH=~/research/data/BGEN/$f.bgen \
+    BGEN_EXPECTED_ROWS=25000 BGEN_EXPECTED_SAMPLES=2548 \
+    THREAD_NUM=8 POLARS_MAX_THREADS=8 TQDM_DISABLE=1 \
+    $PY -m benchmarks.bgen_verify
+  done
+done
+```
+
+Expected: `"value_differences": 0` on all four runs. `chr22.first-25000` with `fixed` is the new capability — it errored before task 9.
+
+Check `bitwise_differences` too. `value_differences` excludes cells where both sides are NaN, `bitwise_differences` does not; a nonzero bitwise count with a zero value count means the NaN payloads differ, which is worth understanding before it is dismissed.
+
+- [ ] **Step 4: Verify across partition counts**
+
+Repeat step 3 for `THREAD_NUM` and `POLARS_MAX_THREADS` of 1, 2, and 4 on `chr22.first-25000.unphased.bgen` with `fixed`. Expected: `value_differences` 0 every time. Row order is not stable above one partition, which is why `bgen_verify` sorts by position — do not remove that sort.
+
+- [ ] **Step 5: Verify dosage did not move**
+
+```bash
+BGEN_READER=bgen BGEN_MODE=dosage \
+BGEN_VERIFY_LEFT=polars-bio BGEN_VERIFY_RIGHT=bgen \
+BGEN_PATH=~/research/data/BGEN/chr22.first-25000.bgen \
+BGEN_EXPECTED_ROWS=25000 BGEN_EXPECTED_SAMPLES=2548 \
+THREAD_NUM=8 POLARS_MAX_THREADS=8 TQDM_DISABLE=1 \
+$PY -m benchmarks.bgen_verify
+```
+
+Expected: `"value_differences": 0`.
+
+- [ ] **Step 6: Commit the benchmark repo**
+
+```bash
+cd ~/CLionProjects/bioformats-benchmark
+git add benchmarks/bgen_matrix.py
+git commit -m "docs(bgen): the fixed layout now pads mixed widths"
+```
+
+---
+
+### Task 11: End-to-end benchmark against snputils
+
+**Files:**
+- Modify: `~/CLionProjects/bioformats-benchmark/GENOTYPE_READER_BENCHMARK.md`
+
+- [ ] **Step 1: Run the suite, fresh process, three runs**
+
+```bash
+cd ~/CLionProjects/bioformats-benchmark
+PY=~/CLionProjects/polars-bio/.venv/bin/python
+for f in chr22.first-25000.unphased chr22.first-25000; do
+  $PY run_bgen_benchmarks.py --runs 3 \
+    --workloads dosage probabilities \
+    --polars-bio-partitions 1 2 4 8 \
+    --bgen ~/research/data/BGEN/$f.bgen \
+    --output results/bgen_reader_${f}.json
+done
+```
+
+`results/` is gitignored by design; published numbers live in the markdown.
+
+- [ ] **Step 2: Compare against the goal**
+
+The targets from the spec, 25,000-variant slice at 8 partitions, fresh process: unphased was 0.393 s against snputils' 0.361 s; phased was 0.660 s against 0.386 s. Write the new numbers into `GENOTYPE_READER_BENCHMARK.md` next to snputils'.
+
+- [ ] **Step 3: Record the outcome honestly**
+
+If either fixture is still behind, say so in the markdown in the same sentence as the win. The benchmark already reports polars-bio losing at one partition; that credibility is worth more than a closed gap.
+
+- [ ] **Step 4: Decide on task 12**
+
+Task 12 is conditional. Run it only if a fixture is still behind snputils after this measurement. If both are ahead, skip to task 13 and note in `GENOTYPE_READER_BENCHMARK.md` that the inner loop was left alone deliberately.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GENOTYPE_READER_BENCHMARK.md
+git commit -m "bench(bgen): record probability results after the batch-buffer rework"
+```
+
+---
+
+### Task 12 (conditional): The inner loop
+
+Run only if task 11 step 4 says so. `byte_probabilities_into` was 23% of the profile before this plan and nothing so far has touched it.
+
+**Files:**
+- Modify: `datafusion/bio-format-bgen/src/decode.rs:893-926` (`byte_probabilities_into`)
+- Modify: `datafusion/bio-format-bgen/src/decode.rs:635-694` (the fast path's sample loop)
+
+- [ ] **Step 1: Confirm the target with the task 6 profile**
+
+Re-read the profile recorded in task 6 step 3. Implement whichever of these the profile actually supports, in this order, measuring after each — a change that does not move the benchmark gets reverted, not kept:
+
+1. Write through reserved capacity instead of `push` per state: `out.resize(out.len() + n, 0.0)` then indexed stores into the tail slice, so the inner loop carries no length update.
+2. When `selected_samples` is the whole cohort in order, walk `probability_bytes.chunks_exact(stride)` instead of indexing through `selected_samples`. Detect it once per variant with `selected_samples.len() == sample_count as usize && selected_samples.first() == Some(&0) && selected_samples.last() == Some(&(sample_count as usize - 1))` plus a `windows(2).all(|pair| pair[1] == pair[0] + 1)` check hoisted to the fileset, not recomputed per variant.
+3. Fuse the per-sample ploidy validation (the `uniform_stride_bits.is_some()` loop over `ploidy_bytes`) into the decode loop so the ploidy bytes are read once.
+
+- [ ] **Step 2: Keep the exactness property**
+
+`EIGHT_BIT_PROBABILITY` exists so the fast path produces exactly `numerator as f32 / 255.0`, identical to the general path rather than merely close. Any rewrite keeps the table lookup. Do not introduce a reciprocal multiply.
+
+- [ ] **Step 3: Test after each change**
+
+Run: `cargo test -p datafusion-bio-format-bgen`
+Expected: PASS. Then re-run task 10 steps 3-5 before committing: this is the code path that produces every probability, and a unit test suite of three samples will not catch a rounding change that 191 million cells will.
+
+- [ ] **Step 4: Commit each accepted change separately**
+
+```bash
+git add datafusion/bio-format-bgen/src/decode.rs
+git commit -m "perf(bgen): <the specific change>, <the measured delta>"
+```
+
+---
+
+### Task 13: Open the follow-up PR
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-15-bgen-baseline.md` (final numbers)
+
+- [ ] **Step 1: Full verification, one more time**
+
+```bash
+cd ~/CLionProjects/datafusion-bio-formats-bgen-perf
+cargo test -p datafusion-bio-format-bgen --all-targets
+cargo test -p datafusion-bio-format-core
+cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings
+cargo clippy -p datafusion-bio-format-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all green. Paste the actual output into the PR body rather than asserting it.
+
+- [ ] **Step 2: Confirm every edit is really in the tree**
+
+```bash
+git diff agent/add-bgen-provider --stat
+```
+
+Read the diff, not just the stat. On #220 a `checked_add` fix was reported as landed when a later edit to the same block had reverted it and the build gave no signal.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --base agent/add-bgen-provider --head agent/bgen-probability-perf \
+  --title "Speed up the BGEN probability path" --body "$(cat <<'EOF'
+Stacked on #220. Decodes probabilities and dosages straight into batch-level
+Arrow buffers instead of staging each variant, and lets the fixed probability
+layout NaN-pad a mixed-width file so the phased fixture can use it at all.
+
+## Numbers
+
+<before/after table from docs/superpowers/plans/2026-08-15-bgen-baseline.md>
+
+## Correctness
+
+Element-wise against the `bgen` package, zero tolerance, both fixtures, both
+layouts, 1/2/4/8 partitions: <value_differences per run>.
+
+## Behavior change
+
+The fixed layout pads a narrower sample with NaN rather than rejecting the
+file, and a missing sample's reserved slots are NaN rather than 0.0. Validity
+remains authoritative. Everything else is byte-identical.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01DJHDeWngFTP4GnRWNP2RTq
+EOF
+)"
+```
+
+- [ ] **Step 4: Request both bots**
+
+Comment `@claude review` and `@codex review` on the new PR. Both are needed; #220 took nine rounds and rounds 3-5 were all second-order breakage from performance work exactly like this.
+
+---
+
+## Notes for the implementer
+
+**Why the flush inverted.** Task 2 exists because of task 4. Once the decoder writes into the batch buffers, the row's size is not known until it is already in them, so `should_flush_before` cannot be asked. The consequence is that a batch may exceed `batch_soft_byte_limit` by one variant. That is deliberate and matches the slack the first row of every batch already had.
+
+**Why padding is per sample.** It could have been per variant, matching the old `state_width` check. Per sample falls out of `close_sample` having to know the width anyway, and it buys the variable-ploidy case for free — a variant that declares ploidy 1..=2 has no single width and was rejected outright, but each of its samples can pad to the schema width.
+
+**What must not change.** Everything except task 9. If a test needs editing in tasks 4, 5, 7, or 8, that is a signal the refactor changed behavior, not a signal the test was wrong.

--- a/docs/superpowers/specs/2026-08-15-bgen-probability-performance-design.md
+++ b/docs/superpowers/specs/2026-08-15-bgen-probability-performance-design.md
@@ -1,0 +1,247 @@
+# BGEN probability-path performance
+
+Date: 2026-08-15
+Branch: `agent/bgen-probability-perf`, off `agent/add-bgen-provider` (PR #220, commit `2c06f23`)
+
+## Goal
+
+Make a BGEN probability scan faster than snputils on both fixtures. Every
+probability a scan already emits keeps its exact value; the one deliberate
+output change is phase 2, which fills slots that are unreadable today — padding
+in a mixed-width file, and the never-read bytes of a missing sample.
+
+Two measured gaps, 25,000-variant slice, 8 partitions, fresh process:
+
+| Fixture | polars-bio | snputils | Behind by |
+| --- | --- | --- | --- |
+| unphased, uniform width | 0.393 s | 0.361 s | 9% |
+| phased, mixed width | 0.660 s | 0.386 s | 71% |
+
+Dosage is already 1.9x ahead on the full chromosome and must not regress.
+
+## Non-goals
+
+- Decompression. libdeflate plus its decode table is 23% of the profile and is
+  the floor of this design; nothing here touches it.
+- The single-partition decoder deficit (0.546x snputils on dosage at one
+  partition). Real, separately scoped.
+- The open BGI cache decision (a normal remote index is downloaded in full
+  before the cache hit is detected). Stays open for a human call.
+
+## Where the time goes
+
+Profile of the current probability path, full unphased file, 8 partitions,
+sampled:
+
+| Frame | Share |
+| --- | --- |
+| `byte_probabilities_into` | 23% |
+| libdeflate + decode table | 23% |
+| `decode_variant` | 16% |
+| `memmove` | 12% |
+| `ProbabilityValues::finish_sample` | 9.5% |
+| allocator churn | ~10% |
+| `build_genotypes` | 2% |
+
+Stage split for the same slice, warm, in process: Rust scan 0.27 s (~69%),
+Arrow to Polars ~0.03 s, Polars to Arrow 0.003 s, `combine_chunks`
+0.015-0.09 s, NumPy ~0 s. The scan is the target; the Python round trip is not.
+
+Three of those frames — `memmove`, `finish_sample`, and most of the allocator
+churn — are one design decision seen three ways: `decode_variant` stages each
+variant in a freshly allocated `ProbabilityValues`, and `build_genotypes` then
+copies every staged variant into batch-level buffers. Removing the staging
+struct removes all three at once.
+
+## Design
+
+### Phase 0 — measurement harness, before any edit
+
+The current criterion bench builds a synthetic 2,048 x 256 fixture. That is a
+fine regression guard and useless for guiding this work, and the alternative —
+re-running `maturin develop --release` for every Rust change — makes the loop
+minutes long.
+
+Add an opt-in bench to `datafusion/bio-format-bgen/benches/bgen_scan.rs`: when
+`BGEN_BENCH_PATH` names a file it is scanned directly; when the variable is
+unset the bench is skipped, so CI is unaffected. Parameterise over output mode,
+probability layout, and partition count.
+
+Baseline before touching anything, and keep the numbers in the PR body:
+all four `~/research/data/BGEN/` fixtures, {1, 8} partitions, {fixed, nested}.
+
+Two traps the handover already paid for, restated because this phase is where
+they bite:
+
+- Measure interleaved, with a warm-up. An apparent 0.368 s to 0.283 s win from
+  raising `datafusion.execution.batch_size` was a cold-versus-warm artifact and
+  collapsed when re-run interleaved. `batch_size` makes no difference.
+- Compare fresh-process numbers only against fresh-process numbers.
+
+### Phase 1 — decode into batch-level buffers
+
+Replace the per-variant `ProbabilityValues`, `ploidies`, and `dosages` with a
+`GenotypeBuffers` struct owned by the partition stream and reused across
+batches. `decode_variant` takes `&mut GenotypeBuffers` and appends into it
+directly; `build_batch` takes the buffers with `mem::take` and moves the `Vec`s
+into Arrow arrays.
+
+`GenotypeBuffers` holds:
+
+- `states: Vec<f32>` — every emitted probability of the batch.
+- `sample_offsets: Vec<i32>` — **only populated in the nested layout.** A
+  `FixedSizeList` never reads them. This is the 9.5%.
+- `sample_valid: Option<BooleanBufferBuilder>` — `None` until the first missing
+  sample appears, then backfilled with `true` for the samples already emitted.
+  A fully-called cohort writes no validity bytes and does no per-batch
+  `extend_from_slice`.
+- `variant_offsets: Vec<i32>`, `ploidy: Vec<u8>`, `ploidy_offsets: Vec<i32>`.
+- `dosages: Vec<f32>` plus the same optional validity, for dosage mode.
+
+Per-row metadata that is not a buffer (`variant_index`, `phased`, `bits`) stays
+in a small `Vec<RowMeta>`, which is what `DecodedRow` degenerates into.
+
+Consequences to get right:
+
+- **Flush ordering.** Today the row is decoded, its size estimated, and the
+  batch flushed *before* the row is appended. Decoding straight into the batch
+  buffers inverts that: append, then decide. Add `should_flush_after()` to
+  `GenotypeBatchSizer`. BGEN is its only consumer today, so no other provider's
+  batching shifts. A batch may now exceed the soft byte limit by one variant —
+  the same slack the first row of every batch already has.
+- **Torn rows.** Record each buffer's length before decoding a variant and
+  truncate back to those marks if decoding fails. A decode error aborts the
+  scan today, so this is defensive rather than load-bearing; it costs six
+  `usize` copies per variant and keeps the buffers a valid Arrow prefix.
+- **Capacity reuse.** `mem::take` leaves an empty `Vec`. Re-reserve the
+  previous batch's length so allocation is amortised per batch, not per
+  variant. This is the allocator-churn half of the win, and it is easy to write
+  the version that silently reallocates per batch instead.
+- **Dosage.** Dosage moves onto the same buffers, replacing the per-sample
+  `ListBuilder::append_option`. Not to chase dosage — it is 1.9x ahead — but
+  because it is the same function and the 1.9x must survive the refactor.
+- **Metrics.** `estimated_arrow_bytes()` currently reads the staged struct. It
+  becomes a function of the buffer growth across the row (end marks minus start
+  marks), which is exact rather than estimated. Rounds 6-9 of review were
+  metrics accounting; keep the counters meaning what they meant.
+
+### Phase 2 — NaN-padded fixed layout for mixed widths
+
+Today `BgenProbabilityLayout::Fixed` requires every variant to store the same
+number of states and rejects a file that mixes widths. That is why the phased
+chr22 fixture — where plink2 left 461 of 25,000 variants unphased, so widths
+mix 3 and 4 — cannot use the fixed layout at all, and why it is the furthest
+behind.
+
+**Contract change:** a variant narrower than the schema width is padded with
+NaN to that width. A variant wider than the schema width still errors, with the
+existing "use the nested layout for this file" message.
+
+**Deriving the width without a full pre-scan.** A Layout 2 block header is
+inside the compressed payload, so learning each variant's exact width would
+mean decompressing every block at plan time. Instead:
+
+1. Probe variant 0 as today, and return `(phased, ploidy, width)` rather than
+   just `width`. This needs a `declared_ploidy: Option<u8>` on
+   `DecodedGenotypes` — the probe selects no samples, so the existing `ploidy`
+   vector is empty and carries nothing.
+2. Schema width = `max` over every catalog variant of
+   `complete_probability_count(probed_ploidy, variant.alleles.len(), probed_phased)`.
+   That function already exists in `decode.rs`, and allele counts are already in
+   the catalog, so this costs no I/O.
+
+The result is exact whenever ploidy and phasedness are uniform across the file,
+which covers every fixture here including the phased one with its 461
+stragglers, and it handles multiallelic width variation exactly. It is computed
+over all catalog variants rather than the filtered subset, because the schema is
+built in `try_new`, before any `scan`. A filter that selects only narrow
+variants therefore gets a slightly over-wide schema; the alternative is a schema
+that changes per query, which is worse.
+
+The perverse case that still errors: a file whose variant 0 is unphased but
+which contains phased variants. The message tells the caller to use the nested
+layout, which is correct and always available.
+
+**Missing samples pad with NaN, not 0.0.** The fixed layout exists so a
+consumer can read the values buffer zero-copy; under that access pattern a
+missing sample currently reads as a real 0.0. NaN matches the `bgen` oracle and
+matches the new width padding. The validity buffer stays authoritative for
+anyone reading Arrow properly. This changes emitted bytes for files with
+missing genotypes, so existing fixed-layout tests need review, not just reruns.
+
+**Documentation to update:** the `BgenProbabilityLayout::Fixed` doc comment
+promises a mixed file "is rejected rather than silently padded". That promise is
+what this phase deletes; the replacement must say the padding is NaN and that
+the width comes from the catalog rather than from variant 0 alone.
+
+### Phase 3 — inner loop, only if the numbers demand it
+
+`byte_probabilities_into` is 23% and untouched by phases 1 and 2. Candidates,
+in order of risk:
+
+- Write through reserved spare capacity (`resize` then indexed stores) instead
+  of `push` per state, dropping the length bookkeeping from the inner loop.
+- Special-case a contiguous full-cohort selection so the loop walks
+  `probability_bytes.chunks_exact(stride)` instead of indirecting through
+  `selected_samples`, which today blocks vectorisation.
+- Fuse the per-sample ploidy validation pass into that same loop; it is
+  currently a separate full pass over the ploidy bytes of every variant.
+
+**This phase is conditional.** Re-profile after phase 1 and 2 land. The
+handover's estimate that the offset and copy removals take the scan from 0.27 s
+toward 0.21 s is explicitly unverified; if the measured result already clears
+snputils on both fixtures, phase 3 is a separate decision made on its own
+merits, not a foregone conclusion. Rounds 3-5 of review on #220 were entirely
+second-order breakage caused by performance work, and this is the phase most
+likely to repeat that.
+
+## Verification
+
+Correctness first, and correctness is not negotiable here: the value of this
+provider is that it is bit-identical to the `bgen` oracle where snputils is not
+(126,259,603 differing cells on phased dosage).
+
+- `cargo test -p datafusion-bio-format-bgen --all-targets`
+- `cargo clippy -p datafusion-bio-format-bgen --all-targets -- -D warnings`
+- `benchmarks.bgen_verify`, zero tolerance, element-wise against the `bgen`
+  package: all four fixtures x {1, 2, 4, 8} partitions x {dosage,
+  probabilities} x {fixed, nested}.
+- **The verifier needs NaN-aware equality.** NaN != NaN, so every padded slot
+  this design introduces reads as a mismatch against itself under the current
+  comparison. Fix the comparison before trusting a single verification run, or
+  phase 2 will look broken when it is right — and, worse, could look right
+  later for the wrong reason.
+- Row order is not stable above one partition. Sort by variant position before
+  hashing or comparing across partition counts.
+- Re-run `run_bgen_benchmarks.py --runs 3` fresh-process on all four fixtures,
+  and publish before/after in the PR body.
+
+Verify each edit is actually in the tree before reporting it landed. Twice on
+#220 a fix was reported as done when a later edit to the same block had
+silently reverted it and the build gave no signal.
+
+## Risks
+
+- **Phase 1 is a refactor of the code all nine review rounds concentrated on.**
+  The offsets, the validity buffer, and the metrics counters each carry a fix
+  from a specific round. Re-read those commits before rewriting the block they
+  touched.
+- **Phase 2 changes emitted values** for missing genotypes and for mixed-width
+  files. It is the only part of this design that does; everything else must be
+  byte-identical, and any diff elsewhere is a bug, not a trade-off.
+- **The gap may not close.** libdeflate is 23% and out of scope. If phases 1-3
+  land and the unphased scan is still behind, the honest outcome is a benchmark
+  that says so — the same way it already reports polars-bio losing at one
+  partition.
+
+## Reproducing
+
+Fixtures persist in `~/research/data/BGEN/`; plink2 does not and must be
+re-fetched from cog-genomics before regenerating any of them. The Python
+environment is polars-bio's own venv,
+`~/CLionProjects/polars-bio/.venv/bin/python`, which already holds `snputils`,
+`bgen`, and `pysnptools[bgen]`.
+
+Baseline A/B is easy here: `~/CLionProjects/datafusion-bio-formats-bgen` stays
+pinned to `2c06f23`, and this work happens in
+`~/CLionProjects/datafusion-bio-formats-bgen-perf`.

--- a/docs/superpowers/specs/2026-08-15-bgen-probability-performance-design.md
+++ b/docs/superpowers/specs/2026-08-15-bgen-probability-performance-design.md
@@ -133,9 +133,19 @@ chr22 fixture — where plink2 left 461 of 25,000 variants unphased, so widths
 mix 3 and 4 — cannot use the fixed layout at all, and why it is the furthest
 behind.
 
-**Contract change:** a variant narrower than the schema width is padded with
-NaN to that width. A variant wider than the schema width still errors, with the
-existing "use the nested layout for this file" message.
+**Contract change:** padding is decided **per sample**, not per variant. A
+sample storing fewer states than the schema width is padded with NaN to that
+width; a sample storing more still errors, with the existing "use the nested
+layout for this file" message. Per-sample rather than per-variant falls out of
+where the padding has to happen anyway, and it comes with a bonus: a
+variable-ploidy variant, which today has no single width and is rejected
+outright, becomes representable because each of its samples pads to the same
+schema width.
+
+This retires the per-variant `state_width` equality check in
+`build_genotypes`. `fixed_probability_layout_rejects_a_mixed_width_file` is
+therefore testing a contract that no longer exists and must be rewritten to
+assert padding, with a new test covering the case that still errors.
 
 **Deriving the width without a full pre-scan.** A Layout 2 block header is
 inside the compressed payload, so learning each variant's exact width would
@@ -206,11 +216,20 @@ provider is that it is bit-identical to the `bgen` oracle where snputils is not
 - `benchmarks.bgen_verify`, zero tolerance, element-wise against the `bgen`
   package: all four fixtures x {1, 2, 4, 8} partitions x {dosage,
   probabilities} x {fixed, nested}.
-- **The verifier needs NaN-aware equality.** NaN != NaN, so every padded slot
-  this design introduces reads as a mismatch against itself under the current
-  comparison. Fix the comparison before trusting a single verification run, or
-  phase 2 will look broken when it is right — and, worse, could look right
-  later for the wrong reason.
+- **NaN comparison is already handled, in one of the two counters.**
+  `bgen_verify.py` excludes `isnan(left) & isnan(right)` from
+  `value_differences`, so padded slots compare equal there. `bitwise_differences`
+  does not: it compares raw `uint32` bit patterns, so it stays zero only while
+  every NaN this design emits carries the same payload as the oracle's
+  (`f32::NAN` and NumPy's float32 `nan` are both `0x7FC00000`, so it should —
+  but check the counter rather than assuming it).
+- **The Python side needs almost nothing.** `bgen_matrix.py` already takes a
+  zero-copy path for `FixedSizeList` and already NaN-pads mixed widths by hand
+  for the nested layout; phase 2 moves that padding into Rust. The change is to
+  run the phased fixture with `BGEN_PROBABILITY_LAYOUT=fixed`, which is already
+  an environment variable, and to update the now-false comment at
+  `benchmarks/bgen_matrix.py:58-61` claiming the fixed layout "requires every
+  variant to store the same number of states".
 - Row order is not stable above one partition. Sort by variant position before
   hashing or comparing across partition counts.
 - Re-run `run_bgen_benchmarks.py --runs 3` fresh-process on all four fixtures,

--- a/openspec/changes/add-genotype-format-providers/specs/bgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/bgen/spec.md
@@ -274,8 +274,8 @@ or dosage values only for selected samples.
 ### Requirement: BGEN Probability Output Layout
 
 The system SHALL emit probability states as a variable-length list per sample by
-default, and SHALL offer a fixed-width layout for files whose variants all store
-the same number of states.
+default, and SHALL offer a fixed-width layout whose width covers the widest
+sample the file's catalog allows.
 
 #### Scenario: Default variable-length layout
 - **WHEN** probability output is requested without selecting a layout
@@ -289,11 +289,42 @@ the same number of states.
 - **AND** a sample with no called genotype is null while still occupying its
   declared width.
 
-#### Scenario: Fixed-width layout rejects a differing variant
-- **WHEN** the fixed probability layout is selected and a variant stores a
-  number of states other than the declared width
-- **THEN** the scan fails naming both counts
+#### Scenario: Fixed-width layout derives its width from the catalog
+- **WHEN** the fixed probability layout is selected
+- **THEN** the width is the widest state count implied by the first variant's
+  declared ploidy and phasing together with every catalog variant's allele count
+- **AND** no probability payload beyond the first variant is read to determine
+  it.
+
+#### Scenario: Fixed-width layout pads a narrower sample
+- **WHEN** the fixed probability layout is selected and a sample stores fewer
+  states than the declared width
+- **THEN** its remaining states are emitted as NaN
+- **AND** the sample's own states are unchanged
+- **AND** a variant declaring a variable ploidy is representable, because
+  padding is decided per sample rather than per variant.
+
+#### Scenario: A missing sample's reserved states read as NaN
+- **WHEN** the fixed probability layout is selected and a sample has no called
+  genotype
+- **THEN** the sample is null
+- **AND** the states it reserves are NaN rather than zero, so a consumer reading
+  the values buffer directly does not observe a probability of zero where there
+  is no genotype.
+
+#### Scenario: Fixed-width layout rejects a wider sample
+- **WHEN** the fixed probability layout is selected and a sample stores more
+  states than the declared width
+- **THEN** the scan fails naming both counts and directs the caller to the
+  default layout
 - **AND** the values are neither padded nor truncated to fit.
+
+#### Scenario: A derived width honours the per-sample state limit
+- **WHEN** the fixed probability layout is selected and the width the catalog
+  implies exceeds the configured maximum states per sample
+- **THEN** planning fails naming both counts and directs the caller to the
+  default layout, because every emitted sample is padded to that width whether
+  or not the widest variant is selected by a filter.
 
 #### Scenario: Fixed-width layout needs a determinable width
 - **WHEN** the fixed probability layout is selected and the first variant

--- a/openspec/changes/add-genotype-format-providers/tasks.md
+++ b/openspec/changes/add-genotype-format-providers/tasks.md
@@ -120,7 +120,8 @@
   missingness, multiallelic states, and source bit precision.
 - [x] 5.7 Implement Layout 1 compatibility for its biallelic diploid encoding.
 - [x] 5.8 Preserve ordered alleles and publish the exact probability-state order.
-- [x] 5.9 Implement probability output without padding variable state vectors.
+- [x] 5.9 Implement default-layout probability output without padding variable
+  state vectors.
 - [x] 5.10 Implement biallelic dosage output and reject selected multiallelic
   variants in dosage mode.
 - [x] 5.11 Apply sample selection while unpacking probability bits and skip
@@ -139,6 +140,11 @@
   decompression bomb, truncation, and invalid probability total tests.
 - [x] 5.20 Benchmark Layout 1/2, compression codecs, sparse BGI filters, sparse
   samples, probability/dosage modes, and parallel range reads.
+- [x] 5.21 Decode genotypes directly into batch-level Arrow buffers instead of
+  staging each variant, and decide the batch flush after the row is written.
+- [x] 5.22 Derive the fixed probability width from the catalog, NaN-pad narrower
+  and missing samples per sample, and bound the derived width by
+  `max_states_per_sample`.
 
 ## 6. PGEN Provider
 


### PR DESCRIPTION
Stacked on #220. Decodes genotypes straight into batch-level Arrow buffers
instead of staging each variant, and lets the fixed probability layout NaN-pad a
mixed-width file so a phased export can use it at all.

Spec and plan are in the diff: `docs/superpowers/specs/2026-08-15-bgen-probability-performance-design.md`
and `docs/superpowers/plans/2026-08-15-bgen-probability-performance.md`. Full
measurements in `docs/superpowers/plans/2026-08-15-bgen-baseline.md`.

## Why

Three frames of the probability profile — `memmove` 12%, `finish_sample` 9.5%,
allocator churn ~10% — were one design decision seen three ways: `decode_variant`
staged each variant in a fresh `ProbabilityValues`, and `build_genotypes` then
copied every staged variant into batch-level buffers. Removing the staging
struct removes all three.

## End to end, against snputils

`run_bgen_benchmarks.py --runs 3`, fresh process per reader, polars-bio through
the fixed layout at 8 partitions.

| Fixture | Before | After | vs snputils |
| --- | --- | --- | --- |
| unphased, uniform width | 0.393 s | **0.292 s** | 9% behind → **1.24x ahead** |
| phased, mixed width | 0.660 s | **0.340 s** | 71% behind → **1.17x ahead** |

Full-chromosome dosage, the workload this most risked spending: 7.334 s against
snputils' 13.665 s, a ratio of 1.86x where the published figure is 1.895x. Both
readers ran about 3% slower this session, so the absolute shift is machine state
and the ratio is what held.

polars-bio is still marginally behind the `bgen` package on the phased fixture
(0.340 s against 0.332 s) and ahead of it on the unphased one. `bgen` is the
oracle rather than the target, but it is the honest bound on what is left.

## Rust scan time

| Fixture | Workload | Before | After |
| --- | --- | --- | --- |
| unphased | probability fixed, 8 partitions | 253.04 ms | 203.17 ms |
| unphased | probability nested, 8 partitions | 329.72 ms | 220.02 ms |
| phased | probability nested, 8 partitions | 524.85 ms | 253.88 ms |
| phased | probability **fixed**, 8 partitions | *rejected the file* | 225.67 ms |

The phased fixture's best available probability read went 524.85 → 225.67 ms,
2.3x, and it was the workload furthest behind.

## Correctness

Element-wise against the `bgen` package, no tolerance, in one process:

| Comparison | Cells | Differing |
| --- | --- | --- |
| unphased, fixed and nested | 191,100,000 each | 0 |
| phased mixed width, fixed and nested | 254,800,000 each | 0 |
| dosage, phased fixture | 63,700,000 | 0 |

Zero at 1, 2, 4 and 8 partitions. `bitwise_differences` is also 0 everywhere,
so the padding NaNs carry the same bit pattern as the oracle's rather than
merely comparing equal. All 30 polars-bio BGEN tests pass against this branch.

## Behavior change

One, deliberate, in the fixed layout only:

- A sample narrower than the schema width is padded with NaN instead of the file
  being rejected. Padding is decided **per sample**, which also makes a
  variable-ploidy variant representable for the first time.
- A missing sample's reserved slots are NaN rather than 0.0, so a consumer
  reading the values buffer zero-copy — the point of that layout — does not see a
  real zero where there is no genotype. Validity remains authoritative.
- The width now covers the widest sample the catalog allows, derived from the
  probe's ploidy and phasing plus every variant's allele count, at no I/O cost. A
  sample wider than that is still rejected, pointing at the nested layout.

Everything else is byte-identical, and the table above is the evidence.

## Notes for review

- The flush decision moved *after* the row (`GenotypeBatchSizer::should_flush_after`,
  new; BGEN is its only consumer). A row written straight into the batch buffers
  has no size until it is written, so a batch can exceed its soft byte limit by
  one variant — the slack the first row of every batch already had.
- The old builder rebased per-variant offsets with `checked_add`, a guard from
  round 1 of #220's review. Offsets are now written at batch scale directly, so
  there is nothing to rebase and the overflow class is gone rather than guarded.
  Every remaining offset conversion still goes through `i32::try_from`.
- `byte_probabilities_into` is untouched and still 23% of the profile. The plan
  gated that rewrite on the measurement above — run it only if a fixture were
  still behind snputils — and neither is.
- `GENOTYPE_READER_BENCHMARK.md` in bioformats-benchmark is deliberately not
  updated yet: it documents merged behavior, and these numbers come from this
  branch. It should be updated when this lands.

## Verification

```
cargo test -p datafusion-bio-format-bgen --all-targets    45 passed
cargo test -p datafusion-bio-format-core                 130 passed
cargo clippy … --all-targets -- -D warnings              clean
cargo fmt --all -- --check                               clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJHDeWngFTP4GnRWNP2RTq