### PR TITLE
Size BGEN payload ranges for several per partition (replay of #227)

### DIFF
--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -37,6 +37,25 @@ use crate::source::ObjectAccess;
 /// Schema metadata marking generated ordinal sample names.
 pub const BGEN_SAMPLE_NAMES_SYNTHETIC_KEY: &str = "bio.bgen.sample_names.synthetic";
 
+/// Coalesced payload ranges aimed at each partition.
+///
+/// Aiming for one range per partition cannot balance them, because a payload is
+/// indivisible: see [`plan_payload_partitions`]. Four bounds the error at about
+/// one range, a quarter of a partition's share, and costs at most four object
+/// reads per partition.
+const PAYLOAD_RANGES_PER_PARTITION: u64 = 4;
+
+/// Smallest range size the partition split will ask for.
+///
+/// Below this, splitting trades balance for object-store requests, which is a
+/// poor trade against remote storage: a small file scanned at a high partition
+/// count would otherwise be cut into ranges far under any sensible read size.
+/// Measured on a 4.9 MB slice at eight partitions, this floor keeps most of the
+/// available balance — 4.65x against 5.09x for a 128 KiB floor — at half the
+/// requests. An explicit `max_range_bytes` below this still wins, because the
+/// caller asked for it.
+const MIN_PAYLOAD_RANGE_BYTES: u64 = 256 * 1024;
+
 /// Genotype values emitted by the BGEN provider.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum BgenOutputMode {
@@ -749,7 +768,15 @@ fn plan_payload_partitions(
         .collect::<Result<Vec<_>>>()?;
     // Bridging the metadata gaps between payloads would otherwise merge a whole
     // small file into one range and leave every partition but the first empty,
-    // so cap the coalesced size by an even split of the selected payload bytes.
+    // so cap the coalesced size by a split of the selected payload bytes.
+    //
+    // The cap aims for several ranges per partition rather than one. A payload
+    // is indivisible, so a cap of exactly one partition's share hands the scan
+    // `target_partitions + 1` chunks, and `target + 1` chunks never divide
+    // evenly into `target` partitions: one partition always takes two and
+    // becomes the bottleneck. Measured on a 4.9 MB slice, that capped the
+    // eight-partition speedup at 3.64x with the busiest partition holding 21.8%
+    // of the bytes against an ideal 12.5%.
     //
     // The split uses the requested partition count, while the plan ends up with
     // `min(target_partitions, coalesced.len())` partitions. Asking for many more
@@ -761,8 +788,23 @@ fn plan_payload_partitions(
         .iter()
         .map(|range| range.len())
         .fold(0, u64::saturating_add);
+    let partitions = target_partitions.max(1) as u64;
+    // A single-partition scan has no imbalance to correct, so splitting it finer
+    // would only add object-store round trips to a path that reads the whole
+    // selection sequentially anyway.
+    let chunks = if partitions > 1 {
+        partitions.saturating_mul(PAYLOAD_RANGES_PER_PARTITION)
+    } else {
+        1
+    };
+    // The floor must never cost a partition its work: a file smaller than the
+    // floor would otherwise coalesce into one range and leave every partition
+    // but the first empty, which is the collapse the cap exists to prevent. So
+    // the floor applies only up to one partition's share.
     let partition_cap = payload_bytes
-        .div_ceil(target_partitions.max(1) as u64)
+        .div_ceil(chunks)
+        .max(MIN_PAYLOAD_RANGE_BYTES)
+        .min(payload_bytes.div_ceil(partitions))
         .max(1);
     let coalesced = coalesce_byte_ranges(ranges, max_gap, max_range_bytes.min(partition_cap))?;
 
@@ -833,4 +875,162 @@ fn plan_metadata_partitions(selected: &[usize], target_partitions: usize) -> Vec
             ranges: Vec::new(),
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::BgenVariant;
+
+    /// A catalog of contiguous payloads whose sizes vary the way real ones do.
+    ///
+    /// Uniform sizes are degenerate here: they divide exactly into any partition
+    /// count, so every split looks perfect and the imbalance never appears.
+    fn contiguous_catalog(count: usize, payload_size: u64) -> BgenCatalog {
+        let mut offset = 0;
+        let variants = (0..count)
+            .map(|index| {
+                let payload_size = payload_size + (index as u64 * 37) % 100;
+                let payload_offset = offset;
+                offset += payload_size;
+                BgenVariant {
+                    index,
+                    id: None,
+                    rsid: None,
+                    chrom: "1".to_string(),
+                    start: index as u64,
+                    end: index as u64 + 1,
+                    position: index as u32 + 1,
+                    alleles: vec!["A".to_string(), "C".to_string()],
+                    record_offset: 0,
+                    record_size: 0,
+                    payload_offset,
+                    payload_size,
+                }
+            })
+            .collect::<Vec<_>>();
+        BgenCatalog {
+            variants: Arc::new(variants),
+            bytes_read: 0,
+        }
+    }
+
+    /// Share of the payload bytes held by the busiest partition.
+    fn heaviest_share(partitions: &[BgenPartition]) -> f64 {
+        let bytes: Vec<u64> = partitions
+            .iter()
+            .map(|partition| {
+                partition
+                    .ranges
+                    .iter()
+                    .map(|planned| planned.range.end - planned.range.start)
+                    .sum()
+            })
+            .collect();
+        let total: u64 = bytes.iter().sum();
+        bytes.iter().max().copied().unwrap_or(0) as f64 / total as f64
+    }
+
+    #[test]
+    fn payload_partitions_are_balanced() {
+        // A payload cannot be split across ranges, so capping a range at exactly
+        // one partition's byte share hands the scan `target + 1` indivisible
+        // chunks — and one partition always takes two of them. At two
+        // partitions that is an 87/13 split, which caps the speedup at 1.15x no
+        // matter how fast the decoder is.
+        // Aiming for `PAYLOAD_RANGES_PER_PARTITION` ranges per partition leaves
+        // the busiest one at most a single extra range, so its share stays near
+        // `(k + 1) / k` of a fair share. The bound below is that ratio with a
+        // little room; the failure it guards against is the old behaviour, where
+        // the busiest partition held 1.75x its share and up to 87% of the bytes.
+        let catalog = contiguous_catalog(1_000, 5_000);
+        let selected: Vec<usize> = (0..1_000).collect();
+        let tolerance =
+            (PAYLOAD_RANGES_PER_PARTITION as f64 + 1.0) / PAYLOAD_RANGES_PER_PARTITION as f64;
+        for target in [2_usize, 4, 8] {
+            let partitions =
+                plan_payload_partitions(&selected, &catalog, target, 64 * 1024, 16 * 1024 * 1024)
+                    .unwrap();
+            let share = heaviest_share(&partitions);
+            let fair = 1.0 / target as f64;
+            assert!(
+                share <= fair * tolerance + f64::EPSILON,
+                "target {target}: busiest partition holds {:.1}% of the payload bytes, \
+                 more than {:.1}% — {tolerance:.2}x its {:.1}% fair share",
+                share * 100.0,
+                fair * tolerance * 100.0,
+                fair * 100.0
+            );
+        }
+    }
+
+    #[test]
+    fn a_file_below_the_range_floor_still_fills_its_partitions() {
+        // The floor stops the split asking for object reads far under a sensible
+        // size, but it must not do that by starving partitions: a file smaller
+        // than the floor would coalesce into a single range and leave every
+        // partition but the first empty, which is exactly the collapse the cap
+        // exists to prevent.
+        let payload_size = 200;
+        let count = 64;
+        let catalog = contiguous_catalog(count, payload_size);
+        assert!(
+            (count as u64) * payload_size < MIN_PAYLOAD_RANGE_BYTES,
+            "this fixture only tests the floor while it stays below it"
+        );
+        let selected: Vec<usize> = (0..count).collect();
+        for target in [2_usize, 4, 8] {
+            let partitions =
+                plan_payload_partitions(&selected, &catalog, target, 64 * 1024, 16 * 1024 * 1024)
+                    .unwrap();
+            assert_eq!(
+                partitions.len(),
+                target,
+                "a {} byte payload lost partitions to the floor at target {target}",
+                (count as u64) * payload_size
+            );
+        }
+    }
+
+    #[test]
+    fn the_range_floor_bounds_reads_once_partitions_are_fed() {
+        // Above the floor the split aims for PAYLOAD_RANGES_PER_PARTITION ranges
+        // per partition rather than splitting without bound, so a scan issues a
+        // handful of object reads per partition instead of one per payload.
+        let catalog = contiguous_catalog(25_000, 195);
+        let selected: Vec<usize> = (0..25_000).collect();
+        let partitions =
+            plan_payload_partitions(&selected, &catalog, 8, 64 * 1024, 16 * 1024 * 1024).unwrap();
+        let ranges: usize = partitions
+            .iter()
+            .map(|partition| partition.ranges.len())
+            .sum();
+        // 4.9 MB over eight partitions puts the 256 KiB floor in charge, so the
+        // plan lands near 19 ranges. The window allows for payload-size variance
+        // without being so wide that a regression could hide inside it.
+        assert!(
+            (10..=28).contains(&ranges),
+            "expected roughly 19 ranges for 8 partitions, got {ranges}"
+        );
+    }
+
+    #[test]
+    fn a_single_partition_scan_is_not_split_finer() {
+        // With one partition there is no imbalance to correct, so aiming for
+        // several ranges would only add object-store round trips to a path that
+        // reads its whole selection sequentially.
+        let catalog = contiguous_catalog(25_000, 195);
+        let selected: Vec<usize> = (0..25_000).collect();
+        let partitions =
+            plan_payload_partitions(&selected, &catalog, 1, 64 * 1024, 16 * 1024 * 1024).unwrap();
+        let ranges: usize = partitions
+            .iter()
+            .map(|partition| partition.ranges.len())
+            .sum();
+        assert_eq!(
+            ranges, 1,
+            "a 4.9 MB contiguous selection fits one coalesced range under the \
+             16 MiB limit, so a single-partition scan should issue one read"
+        );
+    }
 }

--- a/docs/superpowers/plans/2026-08-16-bgen-range-granularity.md
+++ b/docs/superpowers/plans/2026-08-16-bgen-range-granularity.md
@@ -1,0 +1,99 @@
+# BGEN payload range granularity
+
+Follow-up to [#226](https://github.com/biodatageeks/datafusion-bio-formats/pull/226),
+which measured this limitation and deliberately left it alone.
+
+## The problem
+
+`plan_payload_partitions` capped each coalesced payload range at
+`payload_bytes / target_partitions` — one partition's byte share. A variant's
+payload is indivisible, so that cap hands the scan `target_partitions + 1`
+chunks, and `target + 1` chunks never divide evenly into `target` partitions:
+one partition always takes two and becomes the bottleneck.
+
+Planned byte shares before, on `chr22.first-25000.unphased.bgen`:
+
+| Target | Shares | Busiest vs fair |
+| --- | --- | --- |
+| 2 | **87.2%**, 12.8% | 1.74x |
+| 4 | 43.6%, 21.8%, 21.8%, 12.9% | 1.74x |
+| 8 | 21.8%, 10.9% x5, 21.8%, 2.0% | 1.74x |
+
+1 / 0.872 = 1.15, which was exactly the measured two-partition speedup.
+
+## The change
+
+Aim for `PAYLOAD_RANGES_PER_PARTITION = 4` ranges per partition instead of one,
+so the busiest partition carries at most one extra range — `(k + 1) / k`, a 1.25x
+share rather than 1.74x.
+
+The multi-range target applies only above one partition. A single-partition scan
+has no imbalance to correct, so splitting it would only add object-store round
+trips to a path that reads its selection sequentially.
+
+`MIN_PAYLOAD_RANGE_BYTES = 256 KiB` stops the split asking for object reads far
+under a useful size. It is capped at one partition's share so it can never
+starve a partition: a file smaller than the floor is still divided across the
+requested partitions rather than collapsing into a single range, which is the
+collapse the original cap existed to prevent and which
+`coalescing_bridges_metadata_gaps_without_collapsing_partitions` guards.
+
+No new public API. A caller who wants something else still has
+`max_range_bytes`, and an explicit value below the floor still wins.
+
+### Why 256 KiB
+
+Measured on the 4.9 MB slice at eight partitions, Rust scan only, varying only
+the cap:
+
+| Cap | Time | Speedup vs 1 partition |
+| --- | --- | --- |
+| 128 KiB | 147.76 ms | 5.09x |
+| **256 KiB** | 166.86 ms | **4.65x** |
+| 512 KiB | 209.94 ms | 3.68x |
+| 1 MiB | 208.32 ms | 3.71x |
+| one partition's share (before) | 204.37 ms | 3.64x |
+
+256 KiB keeps 91% of the available balance at half the requests of 128 KiB.
+
+## Result
+
+Rust scan, `chr22.first-25000.unphased.bgen`, probability output, fixed layout:
+
+| Partitions | Before | After | Speedup before | Speedup after |
+| --- | --- | --- | --- | --- |
+| 1 | 743.97 ms | 759.53 ms | 1.00x | 1.00x |
+| 2 | 641.80 ms | **437.36 ms** | 1.16x | **1.73x** |
+| 4 | 354.23 ms | **235.96 ms** | 2.10x | **3.20x** |
+| 8 | 204.37 ms | **163.09 ms** | 3.64x | **4.63x** |
+
+Dosage on the same file improves in step: 157.76 ms to 132.82 ms at eight
+partitions, a 4.54x speedup against 3.75x. The phased fixture's fixed-layout
+probability read goes from 222.67 ms to 167.94 ms.
+
+One partition plans identically before and after — a single partition has no
+imbalance to correct, so it keeps one coalesced range, and
+`a_single_partition_scan_is_not_split_finer` asserts it. The couple of percent
+between the two one-partition figures is cross-session drift, not the split.
+That the gains are confined to multi-partition scans is the point: this is
+balance, not throughput.
+
+## Cost
+
+More object reads. For the 4.9 MB slice at eight partitions the plan goes from 9
+coalesced ranges to about 19; for the 160 MB chromosome, from about 10 to about
+32. Each is still a bulk sequential read of at least 256 KiB, and the count stays
+bounded at roughly four per partition rather than growing with the variant count.
+That trade is why the floor exists and why it is not smaller.
+
+## Correctness
+
+Element-wise against the `bgen` package, no tolerance, after the change:
+
+| Comparison | Cells | Differing |
+| --- | --- | --- |
+| probabilities, phased fixture, fixed layout, 1 / 2 / 4 / 8 partitions | 254,800,000 each | 0 |
+| dosage, unphased fixture, 8 partitions | 63,700,000 | 0 |
+
+`bitwise_differences` is 0 in every run as well. Re-planning which bytes each
+partition reads changes no emitted value.

--- a/openspec/changes/add-genotype-format-providers/specs/bgen/spec.md
+++ b/openspec/changes/add-genotype-format-providers/specs/bgen/spec.md
@@ -349,6 +349,25 @@ compressed/decompressed work and coalesce only nearby bounded byte ranges.
   object read per variant
 - **AND** coalesced ranges stay small enough to fill the requested partitions.
 
+#### Scenario: Coalescing leaves partitions comparably loaded
+- **WHEN** payload ranges are coalesced for a scan with more than one partition
+- **THEN** a coalesced range covers at most a fraction of one partition's byte
+  share, so several ranges are available to each partition
+- **AND** no partition is assigned materially more than its share of the
+  selected payload bytes.
+
+Sizing a coalesced range at exactly one partition's share cannot balance the
+scan: a variant's payload is indivisible, so the plan is handed one more chunk
+than there are partitions, and one partition always takes two of them.
+
+#### Scenario: Range sizing has a floor that never starves a partition
+- **WHEN** the byte share implied by the partition count falls below the minimum
+  useful object read
+- **THEN** ranges are not split further, so a scan does not issue many reads far
+  below a useful size
+- **AND** a payload smaller than that minimum is still divided across the
+  requested partitions rather than collapsing into one range.
+
 #### Scenario: Decompression isolation
 - **WHEN** one selected BGEN block is malformed
 - **THEN** its partition fails with variant context

--- a/openspec/changes/add-genotype-format-providers/tasks.md
+++ b/openspec/changes/add-genotype-format-providers/tasks.md
@@ -145,6 +145,9 @@
 - [x] 5.22 Derive the fixed probability width from the catalog, NaN-pad narrower
   and missing samples per sample, and bound the derived width by
   `max_states_per_sample`.
+- [x] 5.23 Size coalesced payload ranges for several per partition, with a floor
+  that never starves a partition, so partition scaling is not capped by an
+  unbalanced split.
 
 ## 6. PGEN Provider
 


### PR DESCRIPTION
Replays [#227](https://github.com/biodatageeks/datafusion-bio-formats/pull/227) onto `agent/add-bgen-provider`, because it did not reach #220.

## Why this exists

#226 and #227 were merged 24 seconds apart, and the order made the second one a
no-op for #220:

| PR | merged at | into | result |
|---|---|---|---|
| #226 | 08:49:23 | `agent/add-bgen-provider` | squashed as `4536a66` — this is #220's branch |
| #227 | 08:49:47 | `agent/bgen-probability-perf` | squashed as `fab5b80` — its own base, which #226 had already absorbed |

#227's base was the intermediate branch. Once #226 squash-merged, that branch was
already folded into #220, so #227 landed in a branch nothing points at. GitHub
reports it as merged, which is true — just not anywhere that reaches #220.

This is `fab5b80` cherry-picked onto the current `agent/add-bgen-provider` tip.
Clean pick, no conflicts; `git diff` against the merged `agent/bgen-range-granularity`
tip is empty, so the tree is identical to what was reviewed and approved.

## Why it matters

`BGEN_BENCHMARK.md` in bioformats-benchmark is already published with numbers
produced by this code: **2.576x** snputils on whole-chromosome dosage and ~1.6x
two-partition scaling. Without this, #220 merges at 1.886x and 1.16x, and the
published benchmark documents performance the merged code does not deliver.

## What it contains

`PAYLOAD_RANGES_PER_PARTITION = 4` and `MIN_PAYLOAD_RANGE_BYTES = 256 KiB`, the
single-partition guard, four tests, two spec scenarios, and task 5.23.

A payload range was capped at one partition's byte share; a variant's payload is
indivisible, so the scan got `target + 1` chunks and one partition always took
two. At two partitions the split was 87.2% / 12.8%, and 1 / 0.872 = 1.15 — the
measured speedup.

| Partitions | Before | After | Speedup before | Speedup after |
|---|---:|---:|---:|---:|
| 1 | 743.97 ms | 743.89 ms | 1.00x | 1.00x |
| 2 | 641.80 ms | **431.80 ms** | 1.16x | **1.72x** |
| 4 | 354.23 ms | **235.26 ms** | 2.10x | **3.16x** |
| 8 | 204.37 ms | **163.61 ms** | 3.64x | **4.55x** |

Re-measured on this branch, not copied from #227. One partition is unchanged to
within 0.1 ms, which is the single-partition guard doing its job.

## Verification on this branch

```
cargo test -p datafusion-bio-format-bgen --all-targets    50 passed
cargo test -p datafusion-bio-format-core                 129 passed
cargo clippy ... --all-targets -- -D warnings            clean
cargo fmt --all -- --check                               clean
openspec validate add-genotype-format-providers --strict valid
```

Correctness was established on the identical tree in #227: element-wise against
the `bgen` package with no tolerance, 254,800,000 cells at 1/2/4/8 partitions and
63,700,000 dosage cells, zero differing and zero bitwise in every run.

Both bots approved this content on #227 (`cbbb489`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJHDeWngFTP4GnRWNP2RTq