### PR TITLE
perf(pgen): cut the single-partition scan from 11.2s to 1.19s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,7 @@ dependencies = [
  "datafusion",
  "datafusion-bio-format-core",
  "flate2",
+ "futures",
  "opendal",
  "serde",
  "serde_json",

--- a/datafusion/bio-format-pgen/Cargo.toml
+++ b/datafusion/bio-format-pgen/Cargo.toml
@@ -16,6 +16,7 @@ bytes.workspace = true
 datafusion.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
 flate2.workspace = true
+futures.workspace = true
 opendal.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -24,7 +25,6 @@ zstd = "0.13"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
-futures.workspace = true
 tempfile = "3"
 tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
 

--- a/datafusion/bio-format-pgen/Cargo.toml
+++ b/datafusion/bio-format-pgen/Cargo.toml
@@ -24,6 +24,7 @@ zstd = "0.13"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
+futures.workspace = true
 tempfile = "3"
 tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
 

--- a/datafusion/bio-format-pgen/Cargo.toml
+++ b/datafusion/bio-format-pgen/Cargo.toml
@@ -30,3 +30,7 @@ tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
 [[bench]]
 name = "pgen_scan"
 harness = false
+
+[[bench]]
+name = "pgen_float_build"
+harness = false

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -156,53 +156,26 @@ the count right. Phase validation is shared with the dense path via
 
 ## Optimizations to implement, in order
 
-### 1. Wire `matrix::read_genotype_matrix` into polars-bio
+### 1. Return sample names from the matrix decode
 
-The provider half is done, tested and measured (`src/matrix.rs`). Nothing
-consumes it yet, so none of its gain reaches a user.
+`read_genotype_matrix` is wired into polars-bio and returns positions, but
+`read_pgen_matrix` still opens the fileset a second time through `scan_pgen`
+purely to read sample names out of the schema metadata. That second open parses
+the 108 MB PVAR again.
 
-Measured on chr22, release + `target-cpu=native`, against what polars-bio does
-today (Arrow batches plus a copy):
+On dosage the decode is large enough to absorb it. On hardcall it is not: that
+workload **regressed 9% at one partition and 4% at four** when this landed
+(0.694 s to 0.759 s, 0.365 s to 0.380 s), while gaining 1.36x at eight. The fix
+is to return the selected sample names alongside the shape and positions, the
+same way positions were moved, and drop the metadata scan from `read_pgen_matrix`
+entirely.
 
-| | direct, 1 thread | direct, 8 | polars-bio today, t1 | t8 |
+Measured, correctness-gated against pgenlib:
+
+| | 1 partition | 4 | 8 | scaling |
 |---|---:|---:|---:|---:|
-| `DS` | 1.301 s | **0.373 s** | 1.665 s | 0.902 s |
-| `ALT_COUNT` | 0.683 s | **0.229 s** | 0.694 s | 0.414 s |
-
-Scaling goes 1.85× → 3.49× on dosage, because the copy that capped at ~2.8× is
-gone. Expect peak RSS to drop from ~13.5 GB to ~10.2 GB as well, since the Arrow
-intermediate disappears — that would take the last axis where pgenlib leads.
-
-What it needs, in polars-bio:
-
-1. **Extract the options conversion.** `src/scan.rs`, the `InputFormat::Pgen`
-   arm, already builds a `NativePgenReadOptions` from the PyO3 `PgenReadOptions`.
-   Lift that into a function; the new binding needs the same conversion and it
-   should not be written twice.
-2. **Add a `#[pyfunction]`** taking the path, `PgenReadOptions`, the field name,
-   a thread count, and the destination. Take the destination through
-   `pyo3::buffer::PyBuffer<f32>` / `<i8>` — PyO3 has it built in, so this needs
-   no numpy crate and no new dependency. Check `!readonly()`,
-   `is_c_contiguous()`, and that `item_count()` equals
-   `variants * samples` from `genotype_matrix_shape` before forming the slice;
-   the slice itself is `from_raw_parts_mut` over `buf_ptr()`, which is the
-   unsafe step and the only one. Decode inside `py.allow_threads`, since the
-   provider spawns its own threads and must not hold the GIL.
-3. **Rewire `read_pgen_matrix`** in `polars_bio/io.py` to allocate the array and
-   hand it to the binding. `copy_threads` becomes the decoder's thread count.
-   Keep the default tied to `datafusion.execution.target_partitions` so a
-   single-partition read stays single-threaded and a "one thread" measurement
-   remains one.
-4. **The existing tests should pass unchanged** — `tests/test_pgen_io.py` already
-   asserts values, missing sentinels, sample subsetting, field rejection and
-   partition independence against the DataFrame path. That is the regression
-   net; if any of it fails, the binding is wrong, not the tests.
-5. Re-run the benchmark and refresh `PGEN_BENCHMARK.md` and the blog post.
-
-One caveat to carry into the writeups: the direct-decode figures above are the
-Rust path only. They exclude the Python-side work polars-bio's number includes
-(metadata, the positions array), so the end-to-end gain will be smaller than
-0.902 → 0.373 suggests.
+| dosage | 1.345 s | 0.574 s | **0.468 s** | 2.87x |
+| hardcall | 0.759 s | 0.380 s | **0.304 s** | 2.50x |
 
 ### 2. SIMD the difflist patch loop
 

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -20,19 +20,24 @@ against the previous build in one session:
 Down from 11.2 s for `DS` at the start of the work. Peak RSS is unchanged at
 9.97 GB for `DS` and 2.9 GB for `ALT_COUNT`.
 
-**These are not yet comparable to pgenlib.** The last measured pgenlib
-scan-equivalent float32 number was 1.51 s, but that came from an earlier
-session, and measurement pitfall 5 below is precisely that polars-bio timings
-drifted up to 1.6× across sessions. Re-measure pgenlib interleaved with the
-current build before making any claim about which is faster.
-
-The last full through-Python comparison, from before fusion:
+The full through-Python comparison, re-measured with this build, all readers
+interleaved in one session:
 
 | | dosage (float32) | hardcall (int8) |
 |---|---:|---:|
-| pgenlib | 1.77 s | 0.83 s |
-| snputils (wraps pgenlib) | 3.24 s | 1.51 s |
-| polars-bio | 4.34 s | 2.96 s |
+| pgenlib | 1.79 s | 0.83 s |
+| snputils (wraps pgenlib) | 3.26 s | 1.51 s |
+| polars-bio, before fusion | 4.34 s | 2.96 s |
+| **polars-bio, after** | **3.23 s** | **1.94 s** |
+
+pgenlib and snputils reproduced their earlier figures to within 1%, so the
+polars-bio deltas are the change and not session drift.
+
+**The end-to-end gain (1.35× / 1.53×) is much smaller than the scan's, and that
+is the important result.** Materialization into a contiguous array is untouched
+and is now the larger term — about 2.03 s of the 3.23 s dosage total and 1.35 s
+of the 1.94 s hardcall total. Further decoder work buys progressively less; see
+task 1 in polars-bio's `HANDOVER-pgen-perf.md`.
 
 Correctness: bit-identical to pgenlib across all 2,532,408,788 cells in both
 workloads, at every partition count, with a self-test proving the comparison
@@ -44,15 +49,14 @@ takes the fused path — across all 2,532,408,788 cells of chr22, via
 
 | Branch | Commit | State |
 |---|---|---|
-| `perf/pgen-batch-array-build` | `8e3bf62` | PR #232, open — **not pushed since `4e493c6`** |
+| `perf/pgen-batch-array-build` | `25d6bd2` | PR #232, open, pushed |
 | `perf/pgen-2bit-packed` | `52e9fcf` | pushed, **no PR** — one commit, misleadingly named |
 
 `perf/pgen-2bit-packed` contains a difflist-buffer reuse, not a packed
 representation. Fold it into #232 or rename it.
 
-polars-bio `feat/bgen-pr220-bench` pins the provider at `52e9fcf`
-(uncommitted `Cargo.toml`/`Cargo.lock` at time of writing), so it does **not**
-yet carry the fusion.
+polars-bio `feat/bgen-pr220-bench` (`0285723`, pushed) pins the provider at
+`25d6bd2`, so it carries the fusion.
 
 ## What was already done
 
@@ -155,18 +159,17 @@ so vectorization is limited, but the sample-index delta decoding
 up at ~10% of profile samples before fusion — re-profile, since fusion changed
 the denominator substantially.
 
-### 2. Investigate the dosage peak-RSS increase
+### 2. Investigate the dosage peak RSS
 
-Between the `8fbed14` and `52e9fcf` builds, dosage peak RSS rose from
-17.9 GB to 22.8 GB while the hardcall path stayed flat at 8.45 GB. This was not
-a target of any change and has no explanation yet. It should be understood
-before these numbers are published; a benchmark that quietly regressed memory
-by 27% is not a clean result.
+Through polars-bio, dosage peaks at **22.31 GB** against pgenlib's 12.09 GB for
+the identical 10.13 GB output; hardcall is 8.25 GB against 5.02 GB. The rise from
+17.9 GB happened between the `8fbed14` and `52e9fcf` builds, was not a target of
+any change, and still has no explanation.
 
-Note that those figures are the **through-polars-bio** path, with Python
-materialization. The Rust-only scan peaks at 9.97 GB for `DS` and 2.9 GB for
-`ALT_COUNT`, unchanged by fusion, so whatever the regression is it is unlikely to
-be in the decode itself.
+It is not in the decode. The Rust-only scan peaks at 9.97 GB for `DS` and 2.9 GB
+for `ALT_COUNT`, unchanged by fusion, so the excess is in the materialization
+path — the same place task 1's remaining time is. Resolve before publishing:
+1.85× pgenlib's memory for identical output is not a clean result.
 
 ### 3. Consider exposing a sparse genotype form
 

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -25,19 +25,23 @@ interleaved in one session:
 
 | | dosage (float32) | hardcall (int8) |
 |---|---:|---:|
-| pgenlib | 1.79 s | 0.83 s |
-| snputils (wraps pgenlib) | 3.26 s | 1.51 s |
-| polars-bio, before fusion | 4.34 s | 2.96 s |
-| **polars-bio, after** | **3.23 s** | **1.94 s** |
+| pgenlib | 1.78 s | 0.83 s |
+| snputils (wraps pgenlib) | 3.18 s | 1.49 s |
+| polars-bio, start of this work | 4.34 s | 2.96 s |
+| **polars-bio, now** | **1.85 s** | **0.94 s** |
 
 pgenlib and snputils reproduced their earlier figures to within 1%, so the
 polars-bio deltas are the change and not session drift.
 
-**The end-to-end gain (1.35× / 1.53×) is much smaller than the scan's, and that
-is the important result.** Materialization into a contiguous array is untouched
-and is now the larger term — about 2.03 s of the 3.23 s dosage total and 1.35 s
-of the 1.94 s hardcall total. Further decoder work buys progressively less; see
-task 1 in polars-bio's `HANDOVER-pgen-perf.md`.
+Fusion alone took the end-to-end figures to 3.23 s / 1.94 s — much less than the
+scan's 1.94× / 2.80×, because materialization was then the larger term. Removing
+it (polars-bio's `read_pgen_matrix`, which streams the scan's batches into a
+preallocated array instead of consolidating them into an Arrow buffer first) is
+what produced the rest. polars-bio is now 1.04× pgenlib on dosage and 1.14× on
+hardcall.
+
+Note the harness no longer charges module import time to the read; see
+polars-bio's `HANDOVER-pgen-perf.md`.
 
 Correctness: bit-identical to pgenlib across all 2,532,408,788 cells in both
 workloads, at every partition count, with a self-test proving the comparison
@@ -160,17 +164,14 @@ so vectorization is limited, but the sample-index delta decoding
 up at ~10% of profile samples before fusion — re-profile, since fusion changed
 the denominator substantially.
 
-### 2. Investigate the dosage peak RSS
+### 2. Peak RSS — resolved
 
-Through polars-bio, dosage peaks at **22.31 GB** against pgenlib's 12.09 GB for
-the identical 10.13 GB output; hardcall is 8.25 GB against 5.02 GB. The rise from
-17.9 GB happened between the `8fbed14` and `52e9fcf` builds, was not a target of
-any change, and still has no explanation.
-
-It is not in the decode. The Rust-only scan peaks at 9.97 GB for `DS` and 2.9 GB
-for `ALT_COUNT`, unchanged by fusion, so the excess is in the materialization
-path — the same place task 1's remaining time is. Resolve before publishing:
-1.85× pgenlib's memory for identical output is not a clean result.
+Dosage now peaks at 13.30 GB against pgenlib's 12.09 GB for the identical
+10.13 GB output, down from 22.31 GB; hardcall is 5.74 GB against 5.02 GB, down
+from 8.25 GB. The old 17.9 → 22.8 GB regression was the DataFrame path's second
+full copy of the values, which `read_pgen_matrix` does not make. Nothing in the
+decode was ever implicated: the Rust-only scan has been flat at 9.97 GB for `DS`
+and 2.9 GB for `ALT_COUNT` throughout.
 
 ### 3. Consider exposing a sparse genotype form
 

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -49,14 +49,15 @@ takes the fused path — across all 2,532,408,788 cells of chr22, via
 
 | Branch | Commit | State |
 |---|---|---|
-| `perf/pgen-batch-array-build` | `25d6bd2` | PR #232, open, pushed |
+| `perf/pgen-batch-array-build` | branch tip | PR #232, open, pushed. The tip moves with docs commits; the code state is `25d6bd2` |
 | `perf/pgen-2bit-packed` | `52e9fcf` | pushed, **no PR** — one commit, misleadingly named |
 
 `perf/pgen-2bit-packed` contains a difflist-buffer reuse, not a packed
 representation. Fold it into #232 or rename it.
 
-polars-bio `feat/bgen-pr220-bench` (`0285723`, pushed) pins the provider at
-`25d6bd2`, so it carries the fusion.
+polars-bio `feat/bgen-pr220-bench` (pushed) pins the provider at `25d6bd2`, the
+last commit that touched code on this branch, so it carries the fusion. Later
+commits here are documentation only — no need to re-pin for them.
 
 ## What was already done
 

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -7,34 +7,52 @@ marked otherwise.
 
 Whole chromosome 22 of 1000 Genomes: 993,881 variants × 2,548 samples =
 2,532,408,788 genotypes. Single partition, release build with
-`-C target-cpu=native`, interleaved against pgenlib in one session.
+`-C target-cpu=native`.
+
+The Rust-only scan, excluding materialization — `pgen_ds_profile`, interleaved
+against the previous build in one session:
+
+| field | before fusion | after fusion | speedup |
+|---|---:|---:|---:|
+| `DS` (float32) | 2.31 s | **1.19 s** | 1.94× |
+| `ALT_COUNT` (int8) | 1.65 s | **0.59 s** | 2.80× |
+
+Down from 11.2 s for `DS` at the start of the work. Peak RSS is unchanged at
+9.97 GB for `DS` and 2.9 GB for `ALT_COUNT`.
+
+**These are not yet comparable to pgenlib.** The last measured pgenlib
+scan-equivalent float32 number was 1.51 s, but that came from an earlier
+session, and measurement pitfall 5 below is precisely that polars-bio timings
+drifted up to 1.6× across sessions. Re-measure pgenlib interleaved with the
+current build before making any claim about which is faster.
+
+The last full through-Python comparison, from before fusion:
 
 | | dosage (float32) | hardcall (int8) |
 |---|---:|---:|
 | pgenlib | 1.77 s | 0.83 s |
 | snputils (wraps pgenlib) | 3.24 s | 1.51 s |
-| **polars-bio** | **4.34 s** | **2.96 s** |
-
-The scan alone, excluding materialization, is 2.42 s against pgenlib's 1.51 s
-for the same float32 output — **1.60×**. Down from 11.2 s at the start of the
-work.
+| polars-bio | 4.34 s | 2.96 s |
 
 Correctness: bit-identical to pgenlib across all 2,532,408,788 cells in both
 workloads, at every partition count, with a self-test proving the comparison
-can fail.
+can fail. `ALT_COUNT` and `DS` additionally match the `GT` scan — which never
+takes the fused path — across all 2,532,408,788 cells of chr22, via
+`cargo run --release --example pgen_field_parity -- <path.pgen>`.
 
 ## Branches
 
 | Branch | Commit | State |
 |---|---|---|
-| `perf/pgen-batch-array-build` | `099be29` | PR #232, open |
+| `perf/pgen-batch-array-build` | `8e3bf62` | PR #232, open — **not pushed since `4e493c6`** |
 | `perf/pgen-2bit-packed` | `52e9fcf` | pushed, **no PR** — one commit, misleadingly named |
 
 `perf/pgen-2bit-packed` contains a difflist-buffer reuse, not a packed
 representation. Fold it into #232 or rename it.
 
 polars-bio `feat/bgen-pr220-bench` pins the provider at `52e9fcf`
-(uncommitted `Cargo.toml`/`Cargo.lock` at time of writing).
+(uncommitted `Cargo.toml`/`Cargo.lock` at time of writing), so it does **not**
+yet carry the fusion.
 
 ## What was already done
 
@@ -52,6 +70,10 @@ polars-bio `feat/bgen-pr220-bench` pins the provider at `52e9fcf`
    The count for codes 0..=4 is `0,1,2,0,1`, which is
    `code - 3 * (code >= 3)`. LLVM now emits NEON.
 7. Difflist buffer reused across variants instead of allocated per record.
+8. **The common-value + difflist branch fused into the output buffer** — what
+   was task 1 below. `DS` and `ALT_COUNT` fill their Arrow values slice from the
+   common category and patch the difflist into it, one pass instead of two, for
+   81% of records. See "How the fused decode works" below.
 
 ## Correction to issue #233
 
@@ -85,49 +107,55 @@ packed-then-expand. Packing would make us slower here, not faster.
 
 Update #233 before anyone acts on it.
 
-## Optimizations to implement, in order
+## How the fused decode works
 
-### 1. Fuse the common-value + difflist branch into the output buffer
+`supports_common_difflist_fast_path` picks out main-track representations 4, 6
+and 7. `decode_common_difflist_into` parses only the difflist, returns the common
+category, and leaves validated patches in `GtDecodeWorkspace::patches`. The
+builders' `append_common_difflist` then `resize`s their values slice to the
+mapped common category — one write per sample, nothing read back — and patches
+into it. Validity is one `append_all_valid`/`append_all_invalid` run plus a
+`set_invalid`/`set_valid` per patch, so bitmap work is proportional to the
+difflist, not the sample count.
 
-The highest-value remaining change, targeting 81% of records.
+Three exclusions, each load-bearing:
 
-Today: `decode_main_into` fills a `Vec<u8>` of codes with the common value,
-patches the difflist, and then `append_codes` reads that buffer and writes the
-final `f32`/`i8`. Two full passes over every sample.
+- **`GT`.** It distinguishes `(0,1)` from `(1,0)`, and the fused decode discards
+  the phase orientation. `FastFieldBuilder::needs_phase()` gates this.
+- **LD bases.** A record a later LD-compressed record uses as its base needs its
+  full main track materialized anyway, so `retain_main` skips fusion. That is
+  ~13% of records, and it is why representation 4 still reaches
+  `decode_biallelic_gt_into` sometimes.
+- **Anything with a dosage, HDS or multiallelic track.**
+  `supports_biallelic_gt_fast_path` rejects those; their bytes would be left
+  unparsed.
 
-Fused: fill the builder's output slice directly with `map(common)` — where
-`map` is `alt_count_from_code` for `ALT_COUNT`, or its `f32` cast for `DS` —
-then apply the difflist patches straight into that slice. One pass.
-
-Expected: removes one full read+write pass over 2.53 billion cells.
-
-**The obstacle, and it is the whole difficulty of this change.** Records of
-type `0x14` carry a hardcall-phase track that must still be validated and
-consumed even when its orientation is discarded. Validating it needs the
-heterozygote count, which today comes from scanning the per-sample buffer that
-fusion eliminates. It is derivable without that buffer:
+The hardcall-phase track is still validated and consumed — its length depends on
+the heterozygote count, so misparsing it would shift every following track. The
+count is derived from the difflist rather than from the per-sample buffer fusion
+removes:
 
 ```
 het_count = (common == 1 ? sample_count - difflist_len : 0)
           + (number of difflist entries whose value is 1)
 ```
 
-Both terms are available while parsing the difflist. Get this wrong and the
-phase track is misparsed, which will show up as a trailing-bytes error rather
-than silently — but verify against `validated_dense_hardcalls`, which already
-does the equivalent validation for the dense branch.
+PGEN reserves representation 5, so `common == 1` cannot occur and the first term
+is always zero today; it is written out anyway because the identity is what makes
+the count right. Phase validation is shared with the dense path via
+`validate_phase_track`.
 
-Applies only when the field needs no phase orientation, i.e. `DS` and
-`ALT_COUNT`, not `GT`. `FastFieldBuilder::needs_phase()` already encodes this.
+## Optimizations to implement, in order
 
-### 2. SIMD the difflist patch loop
+### 1. SIMD the difflist patch loop
 
-After (1), the remaining per-variant work is the sparse patch. Patches are
-scattered writes, so vectorization is limited, but the sample-index delta
-decoding (`Cursor::varint`, `decode_difflist_into`) is sequential varint work
-that showed up at ~10% of profile samples. Worth looking at only after (1).
+The remaining per-variant work is the sparse patch. Patches are scattered writes,
+so vectorization is limited, but the sample-index delta decoding
+(`Cursor::varint`, `decode_difflist_into`) is sequential varint work that showed
+up at ~10% of profile samples before fusion — re-profile, since fusion changed
+the denominator substantially.
 
-### 3. Investigate the dosage peak-RSS increase
+### 2. Investigate the dosage peak-RSS increase
 
 Between the `8fbed14` and `52e9fcf` builds, dosage peak RSS rose from
 17.9 GB to 22.8 GB while the hardcall path stayed flat at 8.45 GB. This was not
@@ -135,7 +163,12 @@ a target of any change and has no explanation yet. It should be understood
 before these numbers are published; a benchmark that quietly regressed memory
 by 27% is not a clean result.
 
-### 4. Consider exposing a sparse genotype form
+Note that those figures are the **through-polars-bio** path, with Python
+materialization. The Rust-only scan peaks at 9.97 GB for `DS` and 2.9 GB for
+`ALT_COUNT`, unchanged by fusion, so whatever the regression is it is unlikely to
+be in the decode itself.
+
+### 3. Consider exposing a sparse genotype form
 
 Out of scope for matrix materialization, but pgenlib's
 `ReadDifflistOrGenovecSubsetUnsafe` returns `difflist_common_geno` + `raregeno`
@@ -164,12 +197,31 @@ Keep both green.
 
 ## How to measure
 
-Rust only, no Python, no materialization — this is the number to optimize:
+Rust only, no Python, no materialization — this is the number to optimize. The
+third argument is the genotype field, `DS` by default:
 
 ```bash
 RUSTFLAGS="-C target-cpu=native" cargo run --release \
   -p datafusion-bio-format-pgen --example pgen_ds_profile -- \
-  /path/to/chr22.full.pgen 3
+  /path/to/chr22.full.pgen 3 DS
+```
+
+Build the binary once and interleave it against the previous one rather than
+comparing across sessions — see pitfall 5:
+
+```bash
+cp target/release/examples/pgen_ds_profile /tmp/prof_new   # then git stash, rebuild, /tmp/prof_old
+for i in 1 2 3; do /tmp/prof_old $PGEN 1 DS; /tmp/prof_new $PGEN 1 DS; done
+```
+
+Correctness gate on real records at full scale, no Python: `ALT_COUNT` and `DS`
+against the `GT` scan, which never takes the fused decode. Exits nonzero on any
+disagreement:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo run --release \
+  -p datafusion-bio-format-pgen --example pgen_field_parity -- \
+  /path/to/chr22.full.pgen
 ```
 
 Full reader comparison with the correctness gate:

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -156,7 +156,55 @@ the count right. Phase validation is shared with the dense path via
 
 ## Optimizations to implement, in order
 
-### 1. SIMD the difflist patch loop
+### 1. Wire `matrix::read_genotype_matrix` into polars-bio
+
+The provider half is done, tested and measured (`src/matrix.rs`). Nothing
+consumes it yet, so none of its gain reaches a user.
+
+Measured on chr22, release + `target-cpu=native`, against what polars-bio does
+today (Arrow batches plus a copy):
+
+| | direct, 1 thread | direct, 8 | polars-bio today, t1 | t8 |
+|---|---:|---:|---:|---:|
+| `DS` | 1.301 s | **0.373 s** | 1.665 s | 0.902 s |
+| `ALT_COUNT` | 0.683 s | **0.229 s** | 0.694 s | 0.414 s |
+
+Scaling goes 1.85× → 3.49× on dosage, because the copy that capped at ~2.8× is
+gone. Expect peak RSS to drop from ~13.5 GB to ~10.2 GB as well, since the Arrow
+intermediate disappears — that would take the last axis where pgenlib leads.
+
+What it needs, in polars-bio:
+
+1. **Extract the options conversion.** `src/scan.rs`, the `InputFormat::Pgen`
+   arm, already builds a `NativePgenReadOptions` from the PyO3 `PgenReadOptions`.
+   Lift that into a function; the new binding needs the same conversion and it
+   should not be written twice.
+2. **Add a `#[pyfunction]`** taking the path, `PgenReadOptions`, the field name,
+   a thread count, and the destination. Take the destination through
+   `pyo3::buffer::PyBuffer<f32>` / `<i8>` — PyO3 has it built in, so this needs
+   no numpy crate and no new dependency. Check `!readonly()`,
+   `is_c_contiguous()`, and that `item_count()` equals
+   `variants * samples` from `genotype_matrix_shape` before forming the slice;
+   the slice itself is `from_raw_parts_mut` over `buf_ptr()`, which is the
+   unsafe step and the only one. Decode inside `py.allow_threads`, since the
+   provider spawns its own threads and must not hold the GIL.
+3. **Rewire `read_pgen_matrix`** in `polars_bio/io.py` to allocate the array and
+   hand it to the binding. `copy_threads` becomes the decoder's thread count.
+   Keep the default tied to `datafusion.execution.target_partitions` so a
+   single-partition read stays single-threaded and a "one thread" measurement
+   remains one.
+4. **The existing tests should pass unchanged** — `tests/test_pgen_io.py` already
+   asserts values, missing sentinels, sample subsetting, field rejection and
+   partition independence against the DataFrame path. That is the regression
+   net; if any of it fails, the binding is wrong, not the tests.
+5. Re-run the benchmark and refresh `PGEN_BENCHMARK.md` and the blog post.
+
+One caveat to carry into the writeups: the direct-decode figures above are the
+Rust path only. They exclude the Python-side work polars-bio's number includes
+(metadata, the positions array), so the end-to-end gain will be smaller than
+0.902 → 0.373 suggests.
+
+### 2. SIMD the difflist patch loop
 
 The remaining per-variant work is the sparse patch. Patches are scattered writes,
 so vectorization is limited, but the sample-index delta decoding
@@ -164,16 +212,17 @@ so vectorization is limited, but the sample-index delta decoding
 up at ~10% of profile samples before fusion — re-profile, since fusion changed
 the denominator substantially.
 
-### 2. Peak RSS — resolved
+### 3. Peak RSS — resolved
 
-Dosage now peaks at 13.30 GB against pgenlib's 12.09 GB for the identical
-10.13 GB output, down from 22.31 GB; hardcall is 5.74 GB against 5.02 GB, down
-from 8.25 GB. The old 17.9 → 22.8 GB regression was the DataFrame path's second
+Dosage now peaks at 13.50 GB against pgenlib's 12.38 GB for the identical
+10.13 GB output, down from 22.31 GB; hardcall is 6.13 GB against 5.14 GB, down
+from 8.25 GB. Task 1 should close the rest, since it removes the Arrow
+intermediate entirely. The old 17.9 → 22.8 GB regression was the DataFrame path's second
 full copy of the values, which `read_pgen_matrix` does not make. Nothing in the
 decode was ever implicated: the Rust-only scan has been flat at 9.97 GB for `DS`
 and 2.9 GB for `ALT_COUNT` throughout.
 
-### 3. Consider exposing a sparse genotype form
+### 4. Consider exposing a sparse genotype form
 
 Out of scope for matrix materialization, but pgenlib's
 `ReadDifflistOrGenovecSubsetUnsafe` returns `difflist_common_geno` + `raregeno`

--- a/datafusion/bio-format-pgen/PERF_HANDOVER.md
+++ b/datafusion/bio-format-pgen/PERF_HANDOVER.md
@@ -1,0 +1,227 @@
+# PGEN scan performance — handover
+
+State as of 2026-08-17. Everything below is measured on this machine unless
+marked otherwise.
+
+## Where things stand
+
+Whole chromosome 22 of 1000 Genomes: 993,881 variants × 2,548 samples =
+2,532,408,788 genotypes. Single partition, release build with
+`-C target-cpu=native`, interleaved against pgenlib in one session.
+
+| | dosage (float32) | hardcall (int8) |
+|---|---:|---:|
+| pgenlib | 1.77 s | 0.83 s |
+| snputils (wraps pgenlib) | 3.24 s | 1.51 s |
+| **polars-bio** | **4.34 s** | **2.96 s** |
+
+The scan alone, excluding materialization, is 2.42 s against pgenlib's 1.51 s
+for the same float32 output — **1.60×**. Down from 11.2 s at the start of the
+work.
+
+Correctness: bit-identical to pgenlib across all 2,532,408,788 cells in both
+workloads, at every partition count, with a self-test proving the comparison
+can fail.
+
+## Branches
+
+| Branch | Commit | State |
+|---|---|---|
+| `perf/pgen-batch-array-build` | `099be29` | PR #232, open |
+| `perf/pgen-2bit-packed` | `52e9fcf` | pushed, **no PR** — one commit, misleadingly named |
+
+`perf/pgen-2bit-packed` contains a difflist-buffer reuse, not a packed
+representation. Fold it into #232 or rename it.
+
+polars-bio `feat/bgen-pr220-bench` pins the provider at `52e9fcf`
+(uncommitted `Cargo.toml`/`Cargo.lock` at time of writing).
+
+## What was already done
+
+1. Arrow values/validity buffers built directly instead of a per-cell
+   `ListBuilder::append_option`. Isolated bench: 352 → 860 Melem/s.
+2. `DS` joined the single-field fast path that `GT` had, removing a per-variant
+   `Vec<Option<f32>>`.
+3. `append_codes` rewritten table-driven with bulk validity.
+4. Hardcall phase orientation skipped for dosage projections — a phased
+   heterozygote and an unphased one carry the same dosage, so applying it was a
+   full pass over every sample of every phased record for no change in output.
+5. `ALT_COUNT` column added: hardcall allele count as `Int8`, one byte per
+   genotype instead of the four `DS` needs.
+6. Expansion loops made auto-vectorizable — no lookup table, no `Vec::push`.
+   The count for codes 0..=4 is `0,1,2,0,1`, which is
+   `code - 3 * (code >= 3)`. LLVM now emits NEON.
+7. Difflist buffer reused across variants instead of allocated per record.
+
+## Correction to issue #233
+
+**Issue #233 proposes the wrong optimization for this workload.** It argues for
+keeping the decoded main track 2-bit packed, the way pgenlib does. That reading
+came from the LD-compressed branch. It is wrong for the record type that
+actually dominates.
+
+Tracing which path records take on a `plink2 --make-pgen` fileset:
+
+| record type | share | branch |
+|---|---:|---|
+| `0x14` | 81% | common value + difflist (`record_type & 7 == 4`) |
+| `0x11`, `0x12` | 13% | LD-compressed |
+| `0x10` | 3.8% | dense, eligible for the direct decode |
+
+The dominant branch has **no per-sample base to pack**. `decode_main_into` does
+`output.resize(sample_count, common)` and then patches a sparse difflist.
+pgenlib's equivalent is:
+
+```c
+vecset(genovec, vrtype_low2 * kMask5555, vec_ct);   // packed, vectorized
+```
+
+— a SIMD memset over `sample_ct/4` bytes, followed by `Expand2bitTo8` writing
+`sample_ct` bytes at the end. Total `sample_ct/4 + sample_ct` written.
+
+Our output is one value per sample regardless. A **fused** fill writes
+`sample_ct` bytes and nothing else, which is *fewer* writes than pgenlib's
+packed-then-expand. Packing would make us slower here, not faster.
+
+Update #233 before anyone acts on it.
+
+## Optimizations to implement, in order
+
+### 1. Fuse the common-value + difflist branch into the output buffer
+
+The highest-value remaining change, targeting 81% of records.
+
+Today: `decode_main_into` fills a `Vec<u8>` of codes with the common value,
+patches the difflist, and then `append_codes` reads that buffer and writes the
+final `f32`/`i8`. Two full passes over every sample.
+
+Fused: fill the builder's output slice directly with `map(common)` — where
+`map` is `alt_count_from_code` for `ALT_COUNT`, or its `f32` cast for `DS` —
+then apply the difflist patches straight into that slice. One pass.
+
+Expected: removes one full read+write pass over 2.53 billion cells.
+
+**The obstacle, and it is the whole difficulty of this change.** Records of
+type `0x14` carry a hardcall-phase track that must still be validated and
+consumed even when its orientation is discarded. Validating it needs the
+heterozygote count, which today comes from scanning the per-sample buffer that
+fusion eliminates. It is derivable without that buffer:
+
+```
+het_count = (common == 1 ? sample_count - difflist_len : 0)
+          + (number of difflist entries whose value is 1)
+```
+
+Both terms are available while parsing the difflist. Get this wrong and the
+phase track is misparsed, which will show up as a trailing-bytes error rather
+than silently — but verify against `validated_dense_hardcalls`, which already
+does the equivalent validation for the dense branch.
+
+Applies only when the field needs no phase orientation, i.e. `DS` and
+`ALT_COUNT`, not `GT`. `FastFieldBuilder::needs_phase()` already encodes this.
+
+### 2. SIMD the difflist patch loop
+
+After (1), the remaining per-variant work is the sparse patch. Patches are
+scattered writes, so vectorization is limited, but the sample-index delta
+decoding (`Cursor::varint`, `decode_difflist_into`) is sequential varint work
+that showed up at ~10% of profile samples. Worth looking at only after (1).
+
+### 3. Investigate the dosage peak-RSS increase
+
+Between the `8fbed14` and `52e9fcf` builds, dosage peak RSS rose from
+17.9 GB to 22.8 GB while the hardcall path stayed flat at 8.45 GB. This was not
+a target of any change and has no explanation yet. It should be understood
+before these numbers are published; a benchmark that quietly regressed memory
+by 27% is not a clean result.
+
+### 4. Consider exposing a sparse genotype form
+
+Out of scope for matrix materialization, but pgenlib's
+`ReadDifflistOrGenovecSubsetUnsafe` returns `difflist_common_geno` + `raregeno`
++ `sample_ids` without ever materializing a full genotype vector. Callers that
+only aggregate — allele counts, frequencies, missingness — skip O(sample_ct)
+work per variant entirely. That is exactly the shape of a query-engine
+workload, and it is a capability polars-bio does not have. Larger than a
+perf change; a real feature.
+
+## What not to do
+
+**Do not narrow `DS` from `Float32`.** PGEN dosages are genuinely fractional —
+a dosage fileset holds values like `0.125`, and the hardcall and dosage tracks
+of the same record disagree completely:
+
+```
+dosages   : [ 0.125  1.0  1.875  missing ]
+hardcalls : [ missing  1  missing  missing ]
+```
+
+`ALT_COUNT` already covers the hardcall case at one byte per genotype. An
+intermediate version of the fast path returned hardcalls where dosages were
+asked for; the `pgenlib_written_filesets_decode_without_the_oracle` and
+`differential_pgenlib_and_snputils_oracles_when_installed` tests caught it.
+Keep both green.
+
+## How to measure
+
+Rust only, no Python, no materialization — this is the number to optimize:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo run --release \
+  -p datafusion-bio-format-pgen --example pgen_ds_profile -- \
+  /path/to/chr22.full.pgen 3
+```
+
+Full reader comparison with the correctness gate:
+
+```bash
+cd bioformats-benchmark
+.venv-bcf/bin/python run_pgen_benchmarks.py --runs 3 --modes dosage hardcall \
+  --polars-bio-partitions 1 8 --pgen /path/to/chr22.full.pgen \
+  --expected-rows 993881 --expected-samples 2548 \
+  --output results/pgen_full_t1.json
+```
+
+Isolated array-build microbenchmark:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo bench \
+  -p datafusion-bio-format-pgen --bench pgen_float_build
+```
+
+## Measurement pitfalls, each of which produced a wrong number here
+
+1. **Build profile.** A plain `maturin develop` is a debug build and measured
+   3.1× slower — enough to invert the comparison against snputils. Always
+   `RUSTFLAGS="-C target-cpu=native" maturin develop --release`. The release
+   extension is ~228 MB, debug ~336 MB.
+2. **Core count.** pgenlib, snputils, and the `bgen` package are all
+   single-threaded. Comparing polars-bio at 8 partitions against them measures
+   core count, not the reader. Use one partition for any claim.
+3. **Native APIs.** Every reader must use its own fastest path.
+   `pgenlib.read_list` (bulk) is 5.5× faster than a per-variant `read` loop;
+   `snputils.read_pgen(genotype_mode="dosage")` is 27× faster than
+   `PGENReader().read()` plus a 3-D sum.
+4. **Workload naming.** snputils' `genotype_mode="dosage"` returns int8
+   *hardcall counts*. pgenlib separates `read_list` from `read_dosages_list`.
+   Comparing across that boundary compares different data.
+5. **Cross-session timings drift.** polars-bio measurements varied by up to
+   1.6× across this session while pgenlib stayed within 4%. Interleave the
+   readers in a single session; do not compare against a number from an earlier
+   run.
+6. **snputils is not an independent oracle for PGEN** — it calls
+   `pgenlib.read_list` directly. The load-bearing check is polars-bio against
+   pgenlib.
+
+## Source references
+
+Read from `plink-ng/2.0`:
+
+- `include/pgenlib_read.cc` — `ParseAndApplyDifflist` (LD diffs applied
+  directly into the packed array), `PrunedDifflistToGenovecSubsetUnsafe` and
+  `ReadDifflistOrGenovecSubsetUnsafe` (the `vecset` common-value fill and the
+  sparse-form return).
+- `include/pgenlib_misc.h` — `GenoarrLookup256x1bx4`, `InitLookup256x1bx4`,
+  `Expand2bitTo8`. Note the comment in `Expand2bitTo8`: the 256-entry table
+  lookup "takes ~3-4x as long" as the SIMD path, so the table is their
+  fallback, not their fast path.

--- a/datafusion/bio-format-pgen/benches/pgen_float_build.rs
+++ b/datafusion/bio-format-pgen/benches/pgen_float_build.rs
@@ -1,0 +1,109 @@
+//! Isolates the cost of turning decoded per-sample dosages into an Arrow
+//! `List<Float32>`, which profiling showed dominates a whole-chromosome DS
+//! scan. Comparing the two strategies in one binary removes the thermal and
+//! page-cache drift that makes end-to-end timings hard to A/B.
+
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use datafusion::arrow::array::{ArrayRef, Float32Array, Float32Builder, ListArray, ListBuilder};
+use datafusion::arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
+
+/// One 2,548-sample cohort, the shape of the benchmark fixture.
+const SAMPLES: usize = 2548;
+/// A batch's worth of variants.
+const VARIANTS: usize = 2000;
+
+fn sample_field() -> FieldRef {
+    Arc::new(Field::new("sample", DataType::Float32, true))
+}
+
+/// Dosages with a realistic missing rate; the callset is dense, so most cells
+/// are present and the validity bitmap is nearly all ones.
+fn rows() -> Vec<Vec<Option<f32>>> {
+    (0..VARIANTS)
+        .map(|variant| {
+            (0..SAMPLES)
+                .map(|sample| {
+                    if (variant * SAMPLES + sample).is_multiple_of(997) {
+                        None
+                    } else {
+                        Some(((sample % 3) as f32) * 0.5)
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// The original strategy: one `append_option` per genotype cell.
+fn build_with_list_builder(field: &FieldRef, rows: &[Vec<Option<f32>>]) -> ArrayRef {
+    let mut builder = ListBuilder::new(Float32Builder::new()).with_field(field.clone());
+    for row in rows {
+        for value in row {
+            builder.values().append_option(*value);
+        }
+        builder.append(true);
+    }
+    Arc::new(builder.finish())
+}
+
+/// The replacement: fill the values and validity buffers directly, with the
+/// total size reserved up front and a repeated-length offset buffer.
+fn build_with_buffers(field: &FieldRef, rows: &[Vec<Option<f32>>]) -> ArrayRef {
+    let sample_count = rows.first().map(Vec::len).unwrap_or(0);
+    let total = rows.len() * sample_count;
+    let mut values: Vec<f32> = Vec::with_capacity(total);
+    let mut bytes: Vec<u8> = Vec::with_capacity(total.div_ceil(8));
+    let mut len = 0usize;
+    let mut null_count = 0usize;
+    for row in rows {
+        for value in row {
+            let shift = len % 8;
+            if len.is_multiple_of(8) {
+                bytes.push(0);
+            }
+            match value {
+                Some(value) => {
+                    values.push(*value);
+                    let last = bytes.len() - 1;
+                    bytes[last] |= 1 << shift;
+                }
+                None => {
+                    values.push(0.0);
+                    null_count += 1;
+                }
+            }
+            len += 1;
+        }
+    }
+    let nulls =
+        (null_count != 0).then(|| NullBuffer::new(BooleanBuffer::new(Buffer::from(bytes), 0, len)));
+    let values = Arc::new(Float32Array::new(values.into(), nulls)) as ArrayRef;
+    Arc::new(ListArray::new(
+        field.clone(),
+        OffsetBuffer::from_repeated_length(sample_count, rows.len()),
+        values,
+        None,
+    ))
+}
+
+fn bench(criterion: &mut Criterion) {
+    let field = sample_field();
+    let rows = rows();
+    let cells = VARIANTS * SAMPLES;
+
+    let mut group = criterion.benchmark_group("ds_array_build");
+    group.throughput(criterion::Throughput::Elements(cells as u64));
+    group.bench_function("list_builder_append_option", |bencher| {
+        bencher.iter(|| build_with_list_builder(&field, &rows))
+    });
+    group.bench_function("direct_buffers", |bencher| {
+        bencher.iter(|| build_with_buffers(&field, &rows))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/datafusion/bio-format-pgen/examples/pgen_ds_profile.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_ds_profile.rs
@@ -1,9 +1,10 @@
-//! Times a single-partition `DS` scan of a real fileset, with no Python and no
-//! materialization into a contiguous array, so the decode path can be profiled
-//! and compared against pgenlib's `read_dosages_list` directly.
+//! Times a single-partition genotype scan of a real fileset, with no Python and
+//! no materialization into a contiguous array, so the decode path can be profiled
+//! and compared against pgenlib directly: `DS` against `read_dosages_list`,
+//! `ALT_COUNT` against `read_list`.
 //!
 //! Usage:
-//!   cargo run --release --example pgen_ds_profile -- <path.pgen> [repeats]
+//!   cargo run --release --example pgen_ds_profile -- <path.pgen> [repeats] [field]
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -16,15 +17,16 @@ async fn main() {
     let mut args = std::env::args().skip(1);
     let path = args
         .next()
-        .expect("usage: pgen_ds_profile <path.pgen> [repeats]");
+        .expect("usage: pgen_ds_profile <path.pgen> [repeats] [field]");
     let repeats: usize = args
         .next()
         .map(|value| value.parse().expect("repeats must be a number"))
         .unwrap_or(3);
+    let field = args.next().unwrap_or_else(|| "DS".to_string());
 
     for round in 1..=repeats {
         let options = PgenReadOptions {
-            genotype_fields: Some(vec!["DS".to_string()]),
+            genotype_fields: Some(vec![field.clone()]),
             ..Default::default()
         };
         let provider = PgenTableProvider::try_new(path.clone(), options)
@@ -50,7 +52,7 @@ async fn main() {
 
         let rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
         println!(
-            "round {round}: {:.3}s  rows={rows}  batches={}",
+            "round {round}: {field} {:.3}s  rows={rows}  batches={}",
             elapsed.as_secs_f64(),
             batches.len()
         );

--- a/datafusion/bio-format-pgen/examples/pgen_ds_profile.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_ds_profile.rs
@@ -1,0 +1,58 @@
+//! Times a single-partition `DS` scan of a real fileset, with no Python and no
+//! materialization into a contiguous array, so the decode path can be profiled
+//! and compared against pgenlib's `read_dosages_list` directly.
+//!
+//! Usage:
+//!   cargo run --release --example pgen_ds_profile -- <path.pgen> [repeats]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_pgen::{PgenReadOptions, PgenTableProvider};
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: pgen_ds_profile <path.pgen> [repeats]");
+    let repeats: usize = args
+        .next()
+        .map(|value| value.parse().expect("repeats must be a number"))
+        .unwrap_or(3);
+
+    for round in 1..=repeats {
+        let options = PgenReadOptions {
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        };
+        let provider = PgenTableProvider::try_new(path.clone(), options)
+            .await
+            .expect("open fileset");
+        let config = SessionConfig::new()
+            .with_target_partitions(1)
+            .with_batch_size(1 << 20);
+        let context = SessionContext::new_with_config(config);
+        context
+            .register_table("pgen", Arc::new(provider))
+            .expect("register");
+
+        let started = Instant::now();
+        let batches = context
+            .sql("SELECT genotypes FROM pgen")
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("collect");
+        let elapsed = started.elapsed();
+
+        let rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+        println!(
+            "round {round}: {:.3}s  rows={rows}  batches={}",
+            elapsed.as_secs_f64(),
+            batches.len()
+        );
+    }
+}

--- a/datafusion/bio-format-pgen/examples/pgen_field_parity.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_field_parity.rs
@@ -1,0 +1,218 @@
+//! Cross-checks the `ALT_COUNT` and `DS` scans against the `GT` scan of the same
+//! fileset, on real records and at full scale.
+//!
+//! The three fields take different decode paths: `GT` applies hardcall phase and
+//! goes through the per-sample code buffer, while `ALT_COUNT` and `DS` take the
+//! fused common-value decode that never materializes one. They must still agree
+//! cell for cell, because an ALT allele count does not depend on which haplotype
+//! carries the allele.
+//!
+//! Each variant is reduced to a hash of its per-sample allele counts, so the
+//! comparison covers every cell without holding two whole matrices at once.
+//! Missing calls hash as a distinct sentinel, so a validity difference shows up
+//! as loudly as a value difference.
+//!
+//! `DS` is only comparable when the fileset stores no dosage track — a stored
+//! dosage of 0.125 is genuinely not a hardcall count. Non-integral values are
+//! reported rather than silently treated as a mismatch.
+//!
+//! Usage:
+//!   cargo run --release -p datafusion-bio-format-pgen --example pgen_field_parity \
+//!     -- <path.pgen> [partitions]
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, FixedSizeListArray, Float32Array, Int8Array, ListArray, StructArray,
+};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_pgen::{PgenReadOptions, PgenTableProvider};
+use futures::StreamExt;
+
+/// The per-sample byte a missing call contributes to a variant's hash.
+const MISSING: u8 = 0xff;
+
+#[derive(Default)]
+struct Hasher(u64);
+
+impl Hasher {
+    fn new() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+
+    #[inline]
+    fn write(&mut self, byte: u8) {
+        self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(0x100_0000_01b3);
+    }
+}
+
+/// Reduces one genotype field of one fileset to a per-variant hash of its
+/// per-sample ALT allele counts.
+async fn field_digests(
+    path: &str,
+    field: &str,
+    partitions: usize,
+) -> (Vec<u64>, usize, Option<f32>) {
+    let options = PgenReadOptions {
+        genotype_fields: Some(vec![field.to_string()]),
+        ..Default::default()
+    };
+    let provider = PgenTableProvider::try_new(path.to_string(), options)
+        .await
+        .expect("open fileset");
+    let config = SessionConfig::new()
+        .with_target_partitions(partitions)
+        .with_batch_size(1 << 12);
+    let context = SessionContext::new_with_config(config);
+    context
+        .register_table("pgen", Arc::new(provider))
+        .expect("register");
+    let mut stream = context
+        .sql("SELECT genotypes FROM pgen")
+        .await
+        .expect("plan")
+        .execute_stream()
+        .await
+        .expect("execute");
+
+    let mut digests = Vec::new();
+    let mut cells = 0;
+    let mut fractional = None;
+    while let Some(batch) = stream.next().await {
+        let batch = batch.expect("batch");
+        let values = field_list(&batch, field);
+        for row in 0..batch.num_rows() {
+            let samples = values.value(row);
+            let mut hasher = Hasher::new();
+            match field {
+                "GT" => {
+                    let pairs = samples
+                        .as_any()
+                        .downcast_ref::<FixedSizeListArray>()
+                        .expect("GT is a fixed-size allele pair");
+                    let alleles = pairs
+                        .values()
+                        .as_any()
+                        .downcast_ref::<datafusion::arrow::array::UInt16Array>()
+                        .expect("alleles are u16");
+                    for sample in 0..pairs.len() {
+                        if pairs.is_null(sample) {
+                            hasher.write(MISSING);
+                            continue;
+                        }
+                        let left = alleles.value(sample * 2);
+                        let right = alleles.value(sample * 2 + 1);
+                        hasher.write(u8::from(left == 1) + u8::from(right == 1));
+                    }
+                    cells += pairs.len();
+                }
+                "ALT_COUNT" => {
+                    let counts = samples
+                        .as_any()
+                        .downcast_ref::<Int8Array>()
+                        .expect("ALT_COUNT is int8");
+                    for sample in 0..counts.len() {
+                        if counts.is_null(sample) {
+                            hasher.write(MISSING);
+                        } else {
+                            hasher.write(counts.value(sample) as u8);
+                        }
+                    }
+                    cells += counts.len();
+                }
+                "DS" => {
+                    let dosages = samples
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .expect("DS is float32");
+                    for sample in 0..dosages.len() {
+                        if dosages.is_null(sample) {
+                            hasher.write(MISSING);
+                            continue;
+                        }
+                        let dosage = dosages.value(sample);
+                        if dosage.fract() != 0.0 && fractional.is_none() {
+                            fractional = Some(dosage);
+                        }
+                        hasher.write(dosage as u8);
+                    }
+                    cells += dosages.len();
+                }
+                other => panic!("unsupported field {other}"),
+            }
+            digests.push(hasher.0);
+        }
+    }
+    (digests, cells, fractional)
+}
+
+fn field_list<'a>(batch: &'a RecordBatch, field: &str) -> &'a ListArray {
+    batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .expect("genotypes is a struct")
+        .column_by_name(field)
+        .expect("projected field")
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .expect("field is a list")
+}
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: pgen_field_parity <path.pgen> [partitions]");
+    let partitions: usize = args
+        .next()
+        .map(|value| value.parse().expect("partitions must be a number"))
+        .unwrap_or(1);
+
+    let (reference, cells, _) = field_digests(&path, "GT", partitions).await;
+    println!(
+        "GT: {} variants, {cells} cells (the oracle: GT never takes the fused decode)",
+        reference.len()
+    );
+
+    let mut failures = 0;
+    for field in ["ALT_COUNT", "DS"] {
+        let (digests, field_cells, fractional) = field_digests(&path, field, partitions).await;
+        if let Some(dosage) = fractional {
+            println!(
+                "{field}: fileset stores fractional dosages (saw {dosage}); \
+                 not comparable to hardcall counts"
+            );
+            continue;
+        }
+        if digests.len() != reference.len() || field_cells != cells {
+            println!(
+                "{field}: MISMATCH in shape — {} variants / {field_cells} cells vs {} / {cells}",
+                digests.len(),
+                reference.len()
+            );
+            failures += 1;
+            continue;
+        }
+        let differing = digests
+            .iter()
+            .zip(&reference)
+            .filter(|(field, reference)| field != reference)
+            .count();
+        if differing == 0 {
+            println!("{field}: matches GT across all {field_cells} cells");
+        } else {
+            println!(
+                "{field}: MISMATCH on {differing} of {} variants",
+                digests.len()
+            );
+            failures += 1;
+        }
+    }
+
+    if failures != 0 {
+        std::process::exit(1);
+    }
+}

--- a/datafusion/bio-format-pgen/examples/pgen_matrix_profile.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_matrix_profile.rs
@@ -1,0 +1,95 @@
+//! Times decoding straight into a caller matrix, against the Arrow scan.
+//!
+//! The scan builds Arrow batches that something else must copy into the
+//! destination; this writes the values at their final address. The gap between
+//! the two is the copy that copy-elimination removes.
+//!
+//! Usage:
+//!   cargo run --release -p datafusion-bio-format-pgen --example pgen_matrix_profile \
+//!     -- <path.pgen> [field] [threads...]
+
+use std::time::Instant;
+
+use datafusion_bio_format_pgen::PgenReadOptions;
+use datafusion_bio_format_pgen::matrix::{MatrixData, genotype_matrix_shape, read_genotype_matrix};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: pgen_matrix_profile <path.pgen> [field] [threads...]");
+    let field = args.next().unwrap_or_else(|| "DS".to_string());
+    let thread_counts: Vec<usize> = {
+        let rest: Vec<usize> = args.map(|v| v.parse().expect("thread count")).collect();
+        if rest.is_empty() {
+            vec![1, 2, 4, 8]
+        } else {
+            rest
+        }
+    };
+
+    let options = PgenReadOptions::default();
+    let shape = genotype_matrix_shape(path.clone(), &options)
+        .await
+        .expect("shape");
+    let cells = shape.variants * shape.samples;
+    println!(
+        "{} variants x {} samples = {cells} cells, field {field}",
+        shape.variants, shape.samples
+    );
+    println!(
+        "{:>8} {:>9} {:>9} {:>12}",
+        "threads", "seconds", "speedup", "checksum"
+    );
+
+    let mut base = None;
+    for threads in thread_counts {
+        // The checksum is deliberately outside the timer: it reads the whole
+        // matrix back, which on the dosage workload is another 10 GB and would
+        // roughly double the figure being reported.
+        let elapsed;
+        let checksum;
+        if field == "ALT_COUNT" {
+            let mut values = vec![0_i8; cells];
+            let started = Instant::now();
+            read_genotype_matrix(
+                path.clone(),
+                &options,
+                MatrixData::AltCount {
+                    values: &mut values,
+                    missing: -9,
+                },
+                threads,
+            )
+            .await
+            .expect("read");
+            elapsed = started.elapsed().as_secs_f64();
+            checksum = values.iter().map(|&v| i64::from(v)).sum::<i64>();
+        } else {
+            let mut values = vec![0.0_f32; cells];
+            let started = Instant::now();
+            read_genotype_matrix(
+                path.clone(),
+                &options,
+                MatrixData::Dosage {
+                    values: &mut values,
+                    missing: f32::NAN,
+                },
+                threads,
+            )
+            .await
+            .expect("read");
+            elapsed = started.elapsed().as_secs_f64();
+            checksum = values
+                .iter()
+                .map(|&v| if v.is_nan() { 0 } else { v as i64 })
+                .sum::<i64>();
+        }
+        let speedup = base.map_or(1.0, |b: f64| b / elapsed);
+        if base.is_none() {
+            base = Some(elapsed);
+        }
+        println!("{threads:>8} {elapsed:>9.3} {speedup:>8.2}x {checksum:>12}");
+    }
+}

--- a/datafusion/bio-format-pgen/examples/pgen_open_profile.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_open_profile.rs
@@ -1,0 +1,47 @@
+//! Times opening a PGEN fileset, which is dominated by parsing the `.pvar`.
+//!
+//! This is the scan's serial prologue: it happens once, before any partition
+//! runs, so it does not shrink when partitions are added and is a fixed floor
+//! under every multi-partition read.
+//!
+//! Usage:
+//!   cargo run --release -p datafusion-bio-format-pgen --example pgen_open_profile \
+//!     -- <path.pgen> [repeats]
+
+use std::time::Instant;
+
+use datafusion::catalog::TableProvider;
+use datafusion_bio_format_pgen::{PgenReadOptions, PgenTableProvider};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: pgen_open_profile <path.pgen> [repeats]");
+    let repeats: usize = args
+        .next()
+        .map(|value| value.parse().expect("repeats must be a number"))
+        .unwrap_or(5);
+
+    let mut best = f64::MAX;
+    for round in 1..=repeats {
+        let options = PgenReadOptions {
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        };
+        let started = Instant::now();
+        let provider = PgenTableProvider::try_new(path.clone(), options)
+            .await
+            .expect("open fileset");
+        let elapsed = started.elapsed().as_secs_f64();
+        best = best.min(elapsed);
+        let variants = TableProvider::schema(&provider)
+            .metadata()
+            .get("bio.pgen.variant_count")
+            .cloned()
+            .unwrap_or_default();
+        println!("round {round}: {elapsed:.4}s  variants={variants}");
+    }
+    println!("best: {best:.4}s");
+}

--- a/datafusion/bio-format-pgen/examples/pgen_scaling_probe.rs
+++ b/datafusion/bio-format-pgen/examples/pgen_scaling_probe.rs
@@ -1,0 +1,116 @@
+//! Measures how a PGEN scan scales with partition count, with no Python in the
+//! way, and reports the scan metrics alongside the wall clock.
+//!
+//! Poor scaling has two candidate explanations that look identical from the
+//! outside: the work does not divide (a serial stage dominates), or it divides
+//! but each partition redoes some of it. `DependencyRecords` separates them —
+//! it counts records a partition must decode to reconstruct an LD chain but
+//! never emits, which is duplicated work that grows with the partition count.
+//!
+//! Usage:
+//!   cargo run --release -p datafusion-bio-format-pgen --example pgen_scaling_probe \
+//!     -- <path.pgen> [field] [partitions...]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_core::genotype::GenotypeMetric;
+use datafusion_bio_format_pgen::{PgenExec, PgenReadOptions, PgenTableProvider};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: pgen_scaling_probe <path.pgen> [field] [partitions...]");
+    let field = args.next().unwrap_or_else(|| "DS".to_string());
+    let partition_counts: Vec<usize> = {
+        let rest: Vec<usize> = args.map(|v| v.parse().expect("partition count")).collect();
+        if rest.is_empty() {
+            vec![1, 2, 4, 8, 16]
+        } else {
+            rest
+        }
+    };
+
+    println!(
+        "{:>5} {:>9} {:>8} {:>12} {:>12} {:>10} {:>12}",
+        "parts", "seconds", "speedup", "emitted", "dependency", "ranges", "bytes read"
+    );
+    let mut baseline = None;
+
+    for partitions in partition_counts {
+        let options = PgenReadOptions {
+            genotype_fields: Some(vec![field.clone()]),
+            ..Default::default()
+        };
+        let provider = PgenTableProvider::try_new(path.clone(), options)
+            .await
+            .expect("open fileset");
+        let config = SessionConfig::new()
+            .with_target_partitions(partitions)
+            .with_batch_size(1 << 20);
+        let context = SessionContext::new_with_config(config);
+        context
+            .register_table("pgen", Arc::new(provider))
+            .expect("register");
+
+        // Execute the plan we hold, not a fresh one: `DataFrame::collect` builds
+        // its own physical plan, and reading metrics off a different instance
+        // reports an unexecuted scan.
+        let plan = context
+            .sql("SELECT genotypes FROM pgen")
+            .await
+            .expect("plan")
+            .create_physical_plan()
+            .await
+            .expect("physical plan");
+
+        let started = Instant::now();
+        let batches = datafusion::physical_plan::collect(plan.clone(), context.task_ctx())
+            .await
+            .expect("collect");
+        let elapsed = started.elapsed().as_secs_f64();
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+
+        let exec = find_pgen_exec(&plan).expect("PgenExec in plan");
+        let snapshot = exec.metrics_snapshot();
+        let get = |metric: GenotypeMetric| {
+            snapshot
+                .iter()
+                .find(|(m, _)| *m == metric)
+                .map(|(_, v)| *v)
+                .unwrap_or(0)
+        };
+
+        let speedup = baseline.map_or(1.0, |b: f64| b / elapsed);
+        if baseline.is_none() {
+            baseline = Some(elapsed);
+        }
+        println!(
+            "{:>5} {:>9.3} {:>7.2}x {:>12} {:>12} {:>10} {:>12}",
+            partitions,
+            elapsed,
+            speedup,
+            rows,
+            get(GenotypeMetric::DependencyRecords),
+            get(GenotypeMetric::RangeRequests),
+            get(GenotypeMetric::PrimaryBytesRead),
+        );
+    }
+}
+
+/// The collected plan is wrapped by coalesce/repartition nodes, so walk to it.
+fn find_pgen_exec(plan: &Arc<dyn ExecutionPlan>) -> Option<&PgenExec> {
+    if let Some(exec) = plan.as_any().downcast_ref::<PgenExec>() {
+        return Some(exec);
+    }
+    for child in plan.children() {
+        if let Some(found) = find_pgen_exec(child) {
+            return Some(found);
+        }
+    }
+    None
+}

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -1490,8 +1490,11 @@ fn implicit_haplotype_dosages(
         .collect()
 }
 
+#[inline]
 fn alt1_hardcall_dosage(call: &[u16; 2]) -> f32 {
-    call.iter().filter(|&&allele| allele == 1).count() as f32
+    // Counted branchlessly rather than through an iterator filter/count: this
+    // runs once per genotype cell, billions of times on a whole chromosome.
+    f32::from(u8::from(call[0] == 1) + u8::from(call[1] == 1))
 }
 
 fn category_call(category: u8) -> Option<[u16; 2]> {

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -27,6 +27,15 @@ pub(crate) struct GenotypeProjection {
 }
 
 impl GenotypeProjection {
+    pub(crate) fn alt_count_only() -> Self {
+        // ALT_COUNT is the hardcall allele count, so the GT calls are what the
+        // builder narrows; no dosage track is needed.
+        Self {
+            gt: true,
+            ..Self::default()
+        }
+    }
+
     pub(crate) fn gt_only() -> Self {
         Self {
             gt: true,
@@ -38,6 +47,8 @@ impl GenotypeProjection {
         let mut projection = Self::default();
         for field in fields {
             match field.as_str() {
+                // ALT_COUNT is narrowed from the hardcall calls.
+                "ALT_COUNT" => projection.gt = true,
                 "GT" => projection.gt = true,
                 "PHASED" => projection.phased = true,
                 "DS" => projection.ds = true,
@@ -405,6 +416,35 @@ pub(crate) static DENSE_DOSAGE_QUADS: [[f32; 4]; 256] = build_dense_dosage_quads
 
 /// The PLINK 1 variant, whose two-bit codes use a different order.
 pub(crate) static DENSE_DOSAGE_QUADS_PLINK1: [[f32; 4]; 256] = build_dense_dosage_quads(true);
+
+/// ALT allele count for the four samples packed in one dense hardcall byte.
+///
+/// The `int8` counterpart of [`DENSE_DOSAGE_QUADS`], for the `ALT_COUNT` field.
+pub(crate) static DENSE_ALT_COUNT_QUADS: [[i8; 4]; 256] = build_dense_alt_counts(false);
+
+/// The PLINK 1 variant of [`DENSE_ALT_COUNT_QUADS`].
+pub(crate) static DENSE_ALT_COUNT_QUADS_PLINK1: [[i8; 4]; 256] = build_dense_alt_counts(true);
+
+const fn build_dense_alt_counts(plink1: bool) -> [[i8; 4]; 256] {
+    let mut output = [[0_i8; 4]; 256];
+    let mut byte = 0;
+    while byte < 256 {
+        let mut sample = 0;
+        while sample < 4 {
+            let code = internal_code(((byte >> (sample * 2)) & 3) as u8, plink1);
+            output[byte][sample] = match code {
+                0 => 0,
+                1 => 1,
+                2 => 2,
+                // Missing; the validity table records it.
+                _ => 0,
+            };
+            sample += 1;
+        }
+        byte += 1;
+    }
+    output
+}
 
 /// Validity nibble for the four samples packed in one dense hardcall byte.
 pub(crate) static DENSE_DOSAGE_VALIDITY: [u8; 256] = build_dense_dosage_validity(false);

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -275,6 +275,79 @@ where
     Ok(())
 }
 
+/// Validates a dense biallelic record and returns its packed hardcall bytes.
+///
+/// Performs exactly the checks `decode_dense_biallelic_gt` performs — padding,
+/// the hardcall-phase track, and trailing bytes — but emits nothing, so a
+/// caller that only needs dosages can walk the two-bit codes itself instead of
+/// paying a callback per four samples. The phase track is validated and then
+/// discarded: phase never changes a dosage.
+pub(crate) fn validated_dense_hardcalls(
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+) -> Result<&[u8]> {
+    if !supports_biallelic_gt_fast_path(record_type, 2)
+        || mode != PgenMode::Plink1 && record_type & 7 != 0
+    {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN variant {variant_index} is not eligible for direct dense dosage decoding"
+        )));
+    }
+
+    let mut cursor = Cursor::new(bytes, variant_index);
+    let packed = cursor.take(sample_count.div_ceil(4), "dense hardcalls")?;
+    validate_packed_padding(packed, sample_count, 2, &cursor)?;
+
+    if mode != PgenMode::Plink1 && record_type != 0xff && record_type & 0x10 != 0 {
+        let heterozygous_count = packed
+            .iter()
+            .map(|&byte| usize::from(HETEROZYGOUS_PER_BYTE[usize::from(byte)]))
+            .sum::<usize>();
+        if heterozygous_count == 0 {
+            return Err(cursor
+                .error("hardcall-phase track is present without heterozygous calls".to_string()));
+        }
+        let first = *cursor
+            .bytes
+            .get(cursor.position)
+            .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
+        if first & 1 != 0 {
+            let present = cursor.take(
+                (heterozygous_count + 1).div_ceil(8),
+                "phase-present bitarray",
+            )?;
+            validate_phase_padding(present, heterozygous_count + 1, &cursor)?;
+            let phased_count = (0..heterozygous_count)
+                .filter(|&index| bit(present, index + 1))
+                .count();
+            let info = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
+            validate_packed_padding(info, phased_count, 1, &cursor)?;
+        } else {
+            let info = cursor.take(
+                (heterozygous_count + 1).div_ceil(8),
+                "implicit phase-info bitarray",
+            )?;
+            if info.first().is_some_and(|byte| byte & 1 != 0) {
+                return Err(
+                    cursor.error("implicit phase track has phase-present marker set".to_string())
+                );
+            }
+            validate_phase_padding(info, heterozygous_count + 1, &cursor)?;
+        }
+    }
+
+    if !cursor.is_finished() {
+        return Err(cursor.error(format!(
+            "{} trailing bytes remain after direct dense dosage decoding",
+            cursor.remaining()
+        )));
+    }
+    Ok(packed)
+}
+
 fn emit_dense_quads<F, P>(packed: &[u8], sample_count: usize, mut phase_pattern: P, emit: &mut F)
 where
     F: FnMut(&[u16], u8, usize),
@@ -319,6 +392,78 @@ struct DecodedQuad {
 }
 
 static DENSE_QUADS: [[DecodedQuad; 16]; 256] = build_dense_quads();
+
+/// ALT dosage for the four samples packed in one dense hardcall byte.
+///
+/// Phase never changes a dosage — a phased heterozygote `(1,0)` and an
+/// unphased one `(0,1)` both carry a single ALT allele — so unlike
+/// `DENSE_QUADS` this needs no phase-pattern dimension. That keeps it at 4 KiB
+/// instead of ~80 KiB, so a dosage scan indexes a table that stays in L1.
+///
+/// Missing calls hold `0.0`; the parallel validity table marks them.
+pub(crate) static DENSE_DOSAGE_QUADS: [[f32; 4]; 256] = build_dense_dosage_quads(false);
+
+/// The PLINK 1 variant, whose two-bit codes use a different order.
+pub(crate) static DENSE_DOSAGE_QUADS_PLINK1: [[f32; 4]; 256] = build_dense_dosage_quads(true);
+
+/// Validity nibble for the four samples packed in one dense hardcall byte.
+pub(crate) static DENSE_DOSAGE_VALIDITY: [u8; 256] = build_dense_dosage_validity(false);
+
+/// The PLINK 1 variant of [`DENSE_DOSAGE_VALIDITY`].
+pub(crate) static DENSE_DOSAGE_VALIDITY_PLINK1: [u8; 256] = build_dense_dosage_validity(true);
+
+/// Maps a raw two-bit code to the internal one, which PLINK 1 permutes.
+const fn internal_code(raw: u8, plink1: bool) -> u8 {
+    if plink1 {
+        match raw {
+            0 => 2,
+            1 => 3,
+            2 => 1,
+            _ => 0,
+        }
+    } else {
+        raw
+    }
+}
+
+const fn build_dense_dosage_quads(plink1: bool) -> [[f32; 4]; 256] {
+    let mut output = [[0.0_f32; 4]; 256];
+    let mut byte = 0;
+    while byte < 256 {
+        let mut sample = 0;
+        while sample < 4 {
+            let code = internal_code(((byte >> (sample * 2)) & 3) as u8, plink1);
+            output[byte][sample] = match code {
+                0 => 0.0,
+                1 => 1.0,
+                2 => 2.0,
+                // Missing; the validity table records it and the value is
+                // never read back.
+                _ => 0.0,
+            };
+            sample += 1;
+        }
+        byte += 1;
+    }
+    output
+}
+
+const fn build_dense_dosage_validity(plink1: bool) -> [u8; 256] {
+    let mut output = [0_u8; 256];
+    let mut byte = 0;
+    while byte < 256 {
+        let mut sample = 0;
+        while sample < 4 {
+            let code = internal_code(((byte >> (sample * 2)) & 3) as u8, plink1);
+            if code != 3 {
+                output[byte] |= 1 << sample;
+            }
+            sample += 1;
+        }
+        byte += 1;
+    }
+    output
+}
 
 const fn build_dense_quads() -> [[DecodedQuad; 16]; 256] {
     const EMPTY: DecodedQuad = DecodedQuad {
@@ -408,6 +553,7 @@ pub(crate) fn decode_biallelic_gt_into(
     selected_samples: &[usize],
     ld_base: Option<&[u8]>,
     retain_main: bool,
+    apply_phase: bool,
 ) -> Result<()> {
     if !supports_biallelic_gt_fast_path(record_type, 2) {
         return Err(DataFusionError::Execution(format!(
@@ -451,6 +597,7 @@ pub(crate) fn decode_biallelic_gt_into(
             &workspace.source_to_output,
             &mut workspace.selected_codes,
             workspace.identity_selection,
+            apply_phase,
         )?;
     }
 
@@ -1181,7 +1328,13 @@ fn decode_phase_for_selected_gt(
     source_to_output: &[usize],
     selected_codes: &mut [u8],
     identity_selection: bool,
+    orient: bool,
 ) -> Result<()> {
+    // `orient == false` still parses and validates the phase track but skips
+    // applying it. A dosage projection needs the validation and the cursor
+    // advance, but not the orientation: a phased heterozygote `(1,0)` and an
+    // unphased one `(0,1)` carry the same ALT dosage. Skipping it avoids a full
+    // pass over every sample of every phased record.
     // With a subset selection, phase orientation belongs only in selected_codes:
     // categories must remain the raw main track so it can become a later LD base.
     // For an identity selection, retain_main snapshots categories before this call.
@@ -1209,6 +1362,9 @@ fn decode_phase_for_selected_gt(
         let info = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
         validate_packed_padding(info, phased_count, 1, cursor)?;
 
+        if !orient {
+            return Ok(());
+        }
         let mut heterozygous_index = 0;
         let mut info_index = 0;
         for source in 0..categories.len() {
@@ -1242,6 +1398,9 @@ fn decode_phase_for_selected_gt(
             );
         }
         validate_phase_padding(info, heterozygous_count + 1, cursor)?;
+        if !orient {
+            return Ok(());
+        }
         let mut heterozygous_index = 0;
         for source in 0..categories.len() {
             let category = categories[source];

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -118,6 +118,11 @@ pub(crate) struct GtDecodeWorkspace {
     categories: Vec<u8>,
     /// Reused across every variant in a partition; see `decode_difflist_into`.
     difflist: Vec<(usize, Option<u8>)>,
+    /// The validated patches of the most recent fused common-value decode.
+    ///
+    /// Compacted out of `difflist` so the builder's patch loop is a plain slice
+    /// walk with no per-entry `Option` to unwrap.
+    patches: Vec<(usize, u8)>,
     selected_codes: Vec<u8>,
     source_to_output: Vec<usize>,
     identity_selection: bool,
@@ -144,6 +149,7 @@ impl GtDecodeWorkspace {
         Ok(Self {
             categories: Vec::with_capacity(sample_count),
             difflist: Vec::new(),
+            patches: Vec::new(),
             selected_codes: Vec::with_capacity(selected_samples.len()),
             source_to_output,
             identity_selection: selected_samples.len() == sample_count
@@ -166,6 +172,11 @@ impl GtDecodeWorkspace {
 
     pub(crate) fn has_identity_selection(&self) -> bool {
         self.identity_selection
+    }
+
+    /// The sparse patches left by the most recent [`decode_common_difflist_into`].
+    pub(crate) fn patches(&self) -> &[(usize, u8)] {
+        &self.patches
     }
 
     pub(crate) fn swap_main_track(&mut self, track: &mut Vec<u8>) {
@@ -320,37 +331,7 @@ pub(crate) fn validated_dense_hardcalls(
             .iter()
             .map(|&byte| usize::from(HETEROZYGOUS_PER_BYTE[usize::from(byte)]))
             .sum::<usize>();
-        if heterozygous_count == 0 {
-            return Err(cursor
-                .error("hardcall-phase track is present without heterozygous calls".to_string()));
-        }
-        let first = *cursor
-            .bytes
-            .get(cursor.position)
-            .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
-        if first & 1 != 0 {
-            let present = cursor.take(
-                (heterozygous_count + 1).div_ceil(8),
-                "phase-present bitarray",
-            )?;
-            validate_phase_padding(present, heterozygous_count + 1, &cursor)?;
-            let phased_count = (0..heterozygous_count)
-                .filter(|&index| bit(present, index + 1))
-                .count();
-            let info = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
-            validate_packed_padding(info, phased_count, 1, &cursor)?;
-        } else {
-            let info = cursor.take(
-                (heterozygous_count + 1).div_ceil(8),
-                "implicit phase-info bitarray",
-            )?;
-            if info.first().is_some_and(|byte| byte & 1 != 0) {
-                return Err(
-                    cursor.error("implicit phase track has phase-present marker set".to_string())
-                );
-            }
-            validate_phase_padding(info, heterozygous_count + 1, &cursor)?;
-        }
+        validate_phase_track(&mut cursor, heterozygous_count)?;
     }
 
     if !cursor.is_finished() {
@@ -652,6 +633,86 @@ pub(crate) fn decode_biallelic_gt_into(
         )));
     }
     Ok(())
+}
+
+/// Whether a record's main track is one common category plus a sparse difflist.
+///
+/// These are main-track representations 4, 6 and 7 — 81% of the records in a
+/// `plink2 --make-pgen` fileset. Unlike every other representation they have no
+/// per-sample base to unpack, so a projection that needs no phase orientation
+/// can fill its output slice from the common category and patch it, instead of
+/// materializing a code buffer and then reading it back.
+pub(crate) fn supports_common_difflist_fast_path(mode: PgenMode, record_type: u8) -> bool {
+    mode != PgenMode::Plink1 && record_type != 0xff && matches!(record_type & 7, 4 | 6 | 7)
+}
+
+/// Decodes a common-value + difflist main track without materializing it.
+///
+/// Returns the common category. The sparse patches land in the workspace, to be
+/// read back through [`GtDecodeWorkspace::patches`]; together they describe the
+/// same codes `decode_biallelic_gt_into` would have written, leaving the caller
+/// to fill and patch its output buffer in one pass rather than two.
+///
+/// The hardcall-phase track is validated and consumed but never applied, so this
+/// is correct only for a projection whose output does not distinguish `(0,1)`
+/// from `(1,0)` — `DS` and `ALT_COUNT`, not `GT`.
+pub(crate) fn decode_common_difflist_into(
+    workspace: &mut GtDecodeWorkspace,
+    bytes: &[u8],
+    mode: PgenMode,
+    record_type: u8,
+    variant_index: usize,
+    sample_count: usize,
+) -> Result<u8> {
+    if !supports_biallelic_gt_fast_path(record_type, 2)
+        || !supports_common_difflist_fast_path(mode, record_type)
+    {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN variant {variant_index} is not eligible for the fused common-value decode"
+        )));
+    }
+    let GtDecodeWorkspace {
+        difflist, patches, ..
+    } = workspace;
+    let common = record_type & 3;
+    let mut cursor = Cursor::new(bytes, variant_index);
+    decode_difflist_into(&mut cursor, sample_count, true, difflist)?;
+    patches.clear();
+    patches.reserve(difflist.len());
+    for &(sample, value) in difflist.iter() {
+        let value = value.ok_or_else(|| {
+            cursor.error("hardcall difflist omitted a genotype value".to_string())
+        })?;
+        patches.push((sample, value));
+    }
+
+    if record_type & 0x10 != 0 {
+        // The heterozygote count the phase track is sized by normally comes from
+        // scanning the decoded per-sample codes — precisely the pass this decode
+        // removes. It is derivable from the difflist alone: every unpatched
+        // sample carries the common category, so it is heterozygous exactly when
+        // that category is.
+        //
+        // PGEN reserves main-track representation 5, so a common category of 1
+        // cannot occur here and the first term is always zero today. It is
+        // written out because the identity, not the current encoding, is what
+        // makes the count right.
+        let common_heterozygotes = if common == 1 {
+            sample_count - patches.len()
+        } else {
+            0
+        };
+        let patched_heterozygotes = patches.iter().filter(|&&(_, value)| value == 1).count();
+        validate_phase_track(&mut cursor, common_heterozygotes + patched_heterozygotes)?;
+    }
+
+    if !cursor.is_finished() {
+        return Err(cursor.error(format!(
+            "{} trailing bytes remain after decoding the declared GT tracks",
+            cursor.remaining()
+        )));
+    }
+    Ok(common)
 }
 
 #[cfg(test)]
@@ -1736,6 +1797,53 @@ fn category_call(category: u8) -> Option<[u16; 2]> {
     }
 }
 
+/// Parses and validates a hardcall-phase track without applying its orientation.
+///
+/// A projection that sums the two alleles — `DS`, `ALT_COUNT` — still has to
+/// consume this track: its length depends on the heterozygote count, so
+/// misparsing it would silently shift every following track. It just does not
+/// need the orientation, because a phased heterozygote and an unphased one carry
+/// the same allele count.
+///
+/// `heterozygous_count` is however the caller derived it: from the packed
+/// hardcall bytes for a dense record, or from the common category and the
+/// difflist for a fused one.
+fn validate_phase_track(cursor: &mut Cursor<'_>, heterozygous_count: usize) -> Result<()> {
+    if heterozygous_count == 0 {
+        return Err(
+            cursor.error("hardcall-phase track is present without heterozygous calls".to_string())
+        );
+    }
+    let first = *cursor
+        .bytes
+        .get(cursor.position)
+        .ok_or_else(|| cursor.error("truncated hardcall-phase track".to_string()))?;
+    if first & 1 != 0 {
+        let present = cursor.take(
+            (heterozygous_count + 1).div_ceil(8),
+            "phase-present bitarray",
+        )?;
+        validate_phase_padding(present, heterozygous_count + 1, cursor)?;
+        let phased_count = (0..heterozygous_count)
+            .filter(|&index| bit(present, index + 1))
+            .count();
+        let info = cursor.take(phased_count.div_ceil(8), "phase-info bitarray")?;
+        validate_packed_padding(info, phased_count, 1, cursor)?;
+    } else {
+        let info = cursor.take(
+            (heterozygous_count + 1).div_ceil(8),
+            "implicit phase-info bitarray",
+        )?;
+        if info.first().is_some_and(|byte| byte & 1 != 0) {
+            return Err(
+                cursor.error("implicit phase track has phase-present marker set".to_string())
+            );
+        }
+        validate_phase_padding(info, heterozygous_count + 1, cursor)?;
+    }
+    Ok(())
+}
+
 fn validate_phase_padding(bytes: &[u8], bit_count: usize, cursor: &Cursor<'_>) -> Result<()> {
     validate_packed_padding(bytes, bit_count, 1, cursor)
 }
@@ -2026,6 +2134,151 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("invalid sample index 63"), "{error}");
+    }
+
+    /// The eligible common-value records, with the phase-track shapes that make
+    /// the derived heterozygote count load-bearing.
+    ///
+    /// Each entry is `(record_type, bytes, main-track codes)`; the codes are what
+    /// the record's main track decodes to before any phase orientation, and their
+    /// length is the sample count.
+    fn common_difflist_records() -> Vec<(u8, Vec<u8>, Vec<u8>)> {
+        vec![
+            // Common 0, no phase track: the 81% case.
+            (0x04, vec![1, 2, 2], vec![0, 0, 2, 0]),
+            // Common 2, and a patch to the missing category.
+            (0x06, vec![1, 3, 3], vec![2, 2, 2, 3]),
+            // Common 3 with an empty difflist: every call missing.
+            (0x07, vec![0], vec![3, 3, 3, 3]),
+            // Common 0 with two patched heterozygotes and an implicit phase
+            // track, which is sized by the count derived from the difflist.
+            (0x14, vec![2, 1, 5, 2, 0b0000_0100], vec![0, 1, 0, 1]),
+            // The same, with an explicit phase-present bitarray.
+            (
+                0x14,
+                vec![2, 0, 5, 1, 0b0000_0011, 0b0000_0001],
+                vec![1, 1, 0, 0],
+            ),
+            // Common 2 with one patched heterozygote and a phase track.
+            (0x16, vec![1, 0, 1, 0b0000_0010], vec![1, 2, 2, 2]),
+            // Common 3 with a phase track, so the derived count must ignore the
+            // all-missing base and see only the patched heterozygote.
+            (0x17, vec![2, 1, 9, 1, 0], vec![3, 1, 2, 3]),
+            // Eight patches of which one is heterozygous, so the phase track is
+            // one byte for the true count and two for the difflist length: a
+            // count derived from the wrong term truncates the record here.
+            (
+                0x14,
+                vec![8, 0, 0xa9, 0xaa, 1, 1, 1, 1, 1, 1, 1, 0b0000_0010],
+                vec![1, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+            ),
+        ]
+    }
+
+    fn fused_common_difflist(
+        record_type: u8,
+        bytes: &[u8],
+        sample_count: usize,
+    ) -> Result<Vec<u8>> {
+        let selected = (0..sample_count).collect::<Vec<_>>();
+        let mut workspace = GtDecodeWorkspace::new(sample_count, &selected)?;
+        let common = decode_common_difflist_into(
+            &mut workspace,
+            bytes,
+            PgenMode::Variable,
+            record_type,
+            0,
+            sample_count,
+        )?;
+        let mut codes = vec![common; sample_count];
+        for &(sample, value) in workspace.patches() {
+            codes[sample] = value;
+        }
+        Ok(codes)
+    }
+
+    #[test]
+    fn fused_common_difflist_reconstructs_the_main_track_and_consumes_the_phase_track() {
+        for (record_type, bytes, expected) in common_difflist_records() {
+            assert!(
+                supports_common_difflist_fast_path(PgenMode::Variable, record_type),
+                "record type {record_type:#04x} should be eligible"
+            );
+            let samples = expected.len();
+            // The main track the existing decoder produces is the reference. The
+            // fused decode never materializes it, so agreement here is what says
+            // the common category and the patches describe the same calls.
+            let mut cursor = Cursor::new(&bytes, 0);
+            let reference =
+                decode_main(&mut cursor, PgenMode::Variable, record_type, samples, None)
+                    .unwrap_or_else(|error| panic!("record type {record_type:#04x}: {error}"));
+            assert_eq!(reference, expected, "record type {record_type:#04x}");
+            assert_eq!(
+                fused_common_difflist(record_type, &bytes, samples)
+                    .unwrap_or_else(|error| panic!("record type {record_type:#04x}: {error}")),
+                expected,
+                "record type {record_type:#04x}"
+            );
+        }
+    }
+
+    #[test]
+    fn fused_common_difflist_rejects_a_misderived_phase_track() {
+        // A phase track whose length disagrees with the derived heterozygote
+        // count leaves bytes behind rather than reading the wrong ones as the
+        // next record's, so the failure surfaces instead of corrupting output.
+        let mut bytes = vec![2, 1, 5, 2, 0b0000_0100];
+        bytes.push(0);
+        let error = fused_common_difflist(0x14, &bytes, 4)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("1 trailing bytes remain"), "{error}");
+
+        // Type 0x14 declares a phase track, but a difflist that patches nothing
+        // to the heterozygous category leaves no heterozygote to phase.
+        let error = fused_common_difflist(0x14, &[1, 2, 2, 0], 4)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("phase track is present without heterozygous calls"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn fused_common_difflist_refuses_ineligible_records() {
+        // Main tracks that carry a per-sample base have nothing to fuse, and a
+        // PLINK 1 fileset has no representation byte at all.
+        for (mode, record_type) in [
+            (PgenMode::Variable, 0x00),
+            (PgenMode::Variable, 0x01),
+            (PgenMode::Variable, 0x02),
+            (PgenMode::Plink1, 0xff),
+        ] {
+            assert!(!supports_common_difflist_fast_path(mode, record_type));
+        }
+
+        // A dosage or multiallelic track alongside a common-value main track is
+        // rejected by the biallelic gate instead: those bytes would be left
+        // unparsed.
+        for (mode, record_type) in [
+            (PgenMode::Variable, 0x00),
+            (PgenMode::Variable, 0x01),
+            (PgenMode::Variable, 0x02),
+            (PgenMode::Variable, 0x24),
+            (PgenMode::Variable, 0x0c),
+            (PgenMode::Plink1, 0xff),
+        ] {
+            let mut workspace = GtDecodeWorkspace::new(4, &[0, 1, 2, 3]).unwrap();
+            let error =
+                decode_common_difflist_into(&mut workspace, &[1, 2, 2], mode, record_type, 0, 4)
+                    .unwrap_err()
+                    .to_string();
+            assert!(
+                error.contains("not eligible for the fused common-value decode"),
+                "record type {record_type:#04x}: {error}"
+            );
+        }
     }
 
     fn pack_two_bit_values(values: &[u8]) -> Vec<u8> {

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -28,12 +28,11 @@ pub(crate) struct GenotypeProjection {
 
 impl GenotypeProjection {
     pub(crate) fn alt_count_only() -> Self {
-        // ALT_COUNT is the hardcall allele count, so the GT calls are what the
-        // builder narrows; no dosage track is needed.
-        Self {
-            gt: true,
-            ..Self::default()
-        }
+        // ALT_COUNT is the hardcall allele count, so the GT calls are exactly
+        // what the builder narrows and no dosage track is needed. It is the
+        // same projection as `gt_only` and says so by construction, rather than
+        // by two literals that happen to agree.
+        Self::gt_only()
     }
 
     pub(crate) fn gt_only() -> Self {

--- a/datafusion/bio-format-pgen/src/decode.rs
+++ b/datafusion/bio-format-pgen/src/decode.rs
@@ -116,6 +116,8 @@ impl DosageTrack<'_> {
 /// dosage, and phased-dosage intermediates for every variant.
 pub(crate) struct GtDecodeWorkspace {
     categories: Vec<u8>,
+    /// Reused across every variant in a partition; see `decode_difflist_into`.
+    difflist: Vec<(usize, Option<u8>)>,
     selected_codes: Vec<u8>,
     source_to_output: Vec<usize>,
     identity_selection: bool,
@@ -141,6 +143,7 @@ impl GtDecodeWorkspace {
         }
         Ok(Self {
             categories: Vec::with_capacity(sample_count),
+            difflist: Vec::new(),
             selected_codes: Vec::with_capacity(selected_samples.len()),
             source_to_output,
             identity_selection: selected_samples.len() == sample_count
@@ -608,6 +611,7 @@ pub(crate) fn decode_biallelic_gt_into(
         sample_count,
         ld_base,
         &mut workspace.categories,
+        &mut workspace.difflist,
     )?;
 
     workspace.retained_main_valid = false;
@@ -908,6 +912,7 @@ fn decode_main(
     ld_base: Option<&[u8]>,
 ) -> Result<Vec<u8>> {
     let mut output = Vec::with_capacity(sample_count);
+    let mut difflist = Vec::new();
     decode_main_into(
         cursor,
         mode,
@@ -915,6 +920,7 @@ fn decode_main(
         sample_count,
         ld_base,
         &mut output,
+        &mut difflist,
     )?;
     Ok(output)
 }
@@ -926,6 +932,7 @@ fn decode_main_into(
     sample_count: usize,
     ld_base: Option<&[u8]>,
     output: &mut Vec<u8>,
+    difflist: &mut Vec<(usize, Option<u8>)>,
 ) -> Result<()> {
     output.clear();
     if mode == PgenMode::Plink1 {
@@ -951,7 +958,7 @@ fn decode_main_into(
             unpack_two_bit(bytes, sample_count, output);
             Ok(())
         }
-        1 => decode_onebit_into(cursor, sample_count, output),
+        1 => decode_onebit_into(cursor, sample_count, output, difflist),
         2 | 3 => {
             let base = ld_base.ok_or_else(|| {
                 cursor.error("LD-compressed record was decoded without its base".to_string())
@@ -963,7 +970,8 @@ fn decode_main_into(
                 )));
             }
             output.extend_from_slice(base);
-            for (sample, value) in decode_difflist(cursor, sample_count, true)? {
+            decode_difflist_into(cursor, sample_count, true, difflist)?;
+            for &(sample, value) in difflist.iter() {
                 output[sample] = value.ok_or_else(|| {
                     cursor.error("LD difflist omitted a genotype value".to_string())
                 })?;
@@ -984,7 +992,8 @@ fn decode_main_into(
         common @ (4 | 6 | 7) => {
             let common = common & 3;
             output.resize(sample_count, common);
-            for (sample, value) in decode_difflist(cursor, sample_count, true)? {
+            decode_difflist_into(cursor, sample_count, true, difflist)?;
+            for &(sample, value) in difflist.iter() {
                 output[sample] = value.ok_or_else(|| {
                     cursor.error("hardcall difflist omitted a genotype value".to_string())
                 })?;
@@ -1000,6 +1009,7 @@ fn decode_onebit_into(
     cursor: &mut Cursor<'_>,
     sample_count: usize,
     output: &mut Vec<u8>,
+    difflist: &mut Vec<(usize, Option<u8>)>,
 ) -> Result<()> {
     let code = cursor.byte("one-bit common-category code")?;
     // PLINK packs the lower common category in bits 2+ and the positive
@@ -1016,7 +1026,8 @@ fn decode_onebit_into(
     for sample in 0..sample_count {
         output.push(lower + (bit(bits, sample) as u8) * delta);
     }
-    for (sample, value) in decode_difflist(cursor, sample_count, true)? {
+    decode_difflist_into(cursor, sample_count, true, difflist)?;
+    for &(sample, value) in difflist.iter() {
         output[sample] = value.ok_or_else(|| {
             cursor.error("one-bit exception omitted a genotype value".to_string())
         })?;
@@ -1034,11 +1045,31 @@ fn unpack_two_bit(bytes: &[u8], sample_count: usize, output: &mut Vec<u8>) {
     output.truncate(sample_count);
 }
 
+/// Allocating wrapper for the cold paths and tests.
 fn decode_difflist(
     cursor: &mut Cursor<'_>,
     sample_count: usize,
     has_values: bool,
 ) -> Result<Vec<(usize, Option<u8>)>> {
+    let mut output = Vec::new();
+    decode_difflist_into(cursor, sample_count, has_values, &mut output)?;
+    Ok(output)
+}
+
+/// Decodes a difflist into a caller-owned buffer.
+///
+/// The hot paths reuse one buffer across every variant in a partition: a scan
+/// of a `plink2 --make-pgen` fileset decodes a difflist for most of its
+/// records, and allocating a fresh `Vec` for each one is ~10^6 allocations on
+/// a chromosome.
+fn decode_difflist_into(
+    cursor: &mut Cursor<'_>,
+    sample_count: usize,
+    has_values: bool,
+    output: &mut Vec<(usize, Option<u8>)>,
+) -> Result<()> {
+    output.clear();
+    output.reserve(sample_count.min(64));
     let length = usize::try_from(cursor.varint("difflist length")?)
         .map_err(|_| cursor.error("difflist length does not fit usize".to_string()))?;
     if length > sample_count {
@@ -1047,7 +1078,7 @@ fn decode_difflist(
         )));
     }
     if length == 0 {
-        return Ok(Vec::new());
+        return Ok(());
     }
     let group_count = length.div_ceil(64);
     let id_width = bytes_to_represent(sample_count);
@@ -1070,7 +1101,6 @@ fn decode_difflist(
         validate_packed_padding(values, length, 2, cursor)?;
     }
 
-    let mut result = Vec::with_capacity(length);
     let mut previous_global = None;
     for group in 0..group_count {
         let group_len = (length - group * 64).min(64);
@@ -1101,7 +1131,7 @@ fn decode_difflist(
             }
             let value =
                 packed_values.map(|values| packed_value(values, group * 64 + element, 2) as u8);
-            result.push((sample, value));
+            output.push((sample, value));
             previous_global = Some(sample);
         }
         if group + 1 < group_count {
@@ -1114,7 +1144,7 @@ fn decode_difflist(
             }
         }
     }
-    Ok(result)
+    Ok(())
 }
 
 fn apply_multiallelic_patches(

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -578,6 +578,13 @@ enum PvarStop {
 const PARALLEL_PVAR_MIN_BYTES: usize = 1 << 20;
 
 /// The most chunks a PVAR body is split into, regardless of core count.
+///
+/// Parsing a chunk is memory-bound, so the split stops paying well before the
+/// core count on a large host: past that point each extra chunk costs a thread,
+/// a `Vec` to join and a share of the reconciliation without shortening the
+/// wall clock. The cap is a bound on that waste rather than a tuned optimum —
+/// the PVAR parse is a prologue measured in tens of milliseconds, so it is set
+/// generously and deliberately not derived from `available_parallelism`.
 const PARALLEL_PVAR_MAX_CHUNKS: usize = 16;
 
 fn parse_pvar(

--- a/datafusion/bio-format-pgen/src/fileset.rs
+++ b/datafusion/bio-format-pgen/src/fileset.rs
@@ -555,11 +555,50 @@ fn decode_text_companion(path: &str, bytes: &[u8], max_decoded: usize) -> Result
     Ok(decoded)
 }
 
+/// Column positions a PVAR body is parsed against, resolved once from the header.
+struct PvarLayout {
+    chrom: usize,
+    position: usize,
+    id: usize,
+    reference: usize,
+    alternate: usize,
+    width: usize,
+}
+
+/// What stopped a chunk parser short of consuming its whole range.
+enum PvarStop {
+    /// `max_variants` was already reached and another variant line followed.
+    Limit,
+    /// A line was malformed; the payload is the detail for `pvar_line_error`.
+    Malformed(String),
+}
+
+/// Bodies below this parse faster in one thread than split across several: a
+/// small PVAR fits in cache and the spawn cost dominates the work.
+const PARALLEL_PVAR_MIN_BYTES: usize = 1 << 20;
+
+/// The most chunks a PVAR body is split into, regardless of core count.
+const PARALLEL_PVAR_MAX_CHUNKS: usize = 16;
+
 fn parse_pvar(
     path: &str,
     bytes: &[u8],
     coordinates: CoordinateSystem,
     max_variants: usize,
+) -> Result<Vec<PvarVariant>> {
+    parse_pvar_chunked(path, bytes, coordinates, max_variants, None)
+}
+
+/// `chunks` pins how many pieces the body is split into; `None` decides from the
+/// body size and the host's core count. Tests pin it, because reconciling the
+/// row limit across chunk boundaries only has anything to reconcile when a
+/// particular boundary falls in a particular place.
+fn parse_pvar_chunked(
+    path: &str,
+    bytes: &[u8],
+    coordinates: CoordinateSystem,
+    max_variants: usize,
+    chunks: Option<usize>,
 ) -> Result<Vec<PvarVariant>> {
     let text = std::str::from_utf8(bytes).map_err(|error| {
         DataFusionError::Plan(format!(
@@ -567,22 +606,36 @@ fn parse_pvar(
             sanitize_location(path)
         ))
     })?;
-    let mut lines = text.lines().enumerate();
-    let mut header = None;
-    let mut body_start = 0;
-    let first_body = loop {
-        match lines.next() {
-            Some((line_index, line)) if line.starts_with('#') => {
-                body_start = line_index + 1;
-                if line.starts_with("#CHROM") {
-                    header = Some((line_index, line));
-                }
-            }
-            body => break body,
+
+    // The header is walked with byte offsets, not through `lines()`, so the
+    // body's start is known as a byte position and can be split for parallel
+    // parsing. Line semantics match `str::lines`: split on `\n`, strip a
+    // trailing `\r`.
+    let mut header: Option<(usize, &str)> = None;
+    let mut header_lines = 0;
+    let mut body_start_byte = 0;
+    let mut offset = 0;
+    while offset < text.len() {
+        let rest = &text[offset..];
+        let (raw, next) = match rest.find('\n') {
+            Some(newline) => (&rest[..newline], offset + newline + 1),
+            None => (rest, text.len()),
+        };
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        if !line.starts_with('#') {
+            break;
         }
-    };
+        if line.starts_with("#CHROM") {
+            header = Some((header_lines, line));
+        }
+        header_lines += 1;
+        offset = next;
+        body_start_byte = offset;
+    }
+    let body = &text[body_start_byte..];
+
     let columns = if let Some((header_index, header)) = header {
-        if header_index + 1 != body_start {
+        if header_index + 1 != header_lines {
             return Err(DataFusionError::Plan(format!(
                 "PVAR {} #CHROM line must be the final header line",
                 sanitize_location(path)
@@ -594,18 +647,16 @@ fn parse_pvar(
             .map(str::to_string)
             .collect::<Vec<_>>()
     } else {
-        if body_start > 0 {
+        if header_lines > 0 {
             return Err(DataFusionError::Plan(format!(
                 "PVAR {} header does not end with #CHROM",
                 sanitize_location(path)
             )));
         }
-        let first_width = first_body
-            .iter()
-            .copied()
-            .chain(lines.clone())
-            .find(|(_, line)| !line.is_empty())
-            .map(|(_, line)| line.split_whitespace().count())
+        let first_width = body
+            .lines()
+            .find(|line| !line.is_empty())
+            .map(|line| line.split_whitespace().count())
             .unwrap_or(0);
         // PLINK 2 specifies BIM order for a headerless PVAR. The five-column
         // form omits CM: CHROM, ID, POS, ALT, REF.
@@ -634,78 +685,216 @@ fn parse_pvar(
                 ))
             })
     };
-    let chrom_col = column("CHROM")?;
-    let pos_col = column("POS")?;
-    let id_col = column("ID")?;
-    let ref_col = column("REF")?;
-    let alt_col = column("ALT")?;
-    let required_width = [chrom_col, pos_col, id_col, ref_col, alt_col]
-        .into_iter()
-        .max()
-        .unwrap_or(0)
-        + 1;
+    let (chrom, position, id, reference, alternate) = (
+        column("CHROM")?,
+        column("POS")?,
+        column("ID")?,
+        column("REF")?,
+        column("ALT")?,
+    );
+    let layout = PvarLayout {
+        chrom,
+        position,
+        id,
+        reference,
+        alternate,
+        width: [chrom, position, id, reference, alternate]
+            .into_iter()
+            .max()
+            .unwrap_or(0)
+            + 1,
+    };
+    let layout = &layout;
 
+    let chunks = pvar_chunk_ranges(body, chunks.unwrap_or_else(|| pvar_chunk_count(body)));
+    let parsed = if chunks.len() <= 1 {
+        chunks
+            .iter()
+            .map(|&(start, end)| {
+                parse_pvar_chunk(&body[start..end], coordinates, max_variants, layout)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        // Scoped threads borrow `body` and `layout` directly, so the body is
+        // never copied and no runtime is involved. The work is CPU-bound and
+        // joins before this returns.
+        std::thread::scope(|scope| {
+            let handles = chunks
+                .iter()
+                .map(|&(start, end)| {
+                    scope.spawn(move || {
+                        parse_pvar_chunk(&body[start..end], coordinates, max_variants, layout)
+                    })
+                })
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle.join().map_err(|_| {
+                        DataFusionError::Plan(format!(
+                            "PVAR {} chunk parser panicked",
+                            sanitize_location(path)
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()
+        })?
+    };
+
+    let limit_error = || {
+        DataFusionError::Plan(format!(
+            "PVAR {} exceeds configured max_variants {max_variants}",
+            sanitize_location(path)
+        ))
+    };
+    let mut variants = Vec::with_capacity(parsed.iter().map(|(rows, _)| rows.len()).sum());
+    for ((rows, stop), &(chunk_start, _)) in parsed.into_iter().zip(&chunks) {
+        // Whichever condition comes first in the file wins, exactly as it does
+        // when one pass reads the whole body. The limit trips inside this
+        // chunk's rows when they would carry the total past it, which is
+        // earlier than any error the chunk reports, because a chunk stops at
+        // its first bad line.
+        if variants.len() + rows.len() > max_variants {
+            return Err(limit_error());
+        }
+        variants.extend(rows);
+        if let Some((chunk_line, stop)) = stop {
+            // The chunk stopped, so a further line exists. A serial pass would
+            // check the limit before reading it.
+            if variants.len() >= max_variants {
+                return Err(limit_error());
+            }
+            return Err(match stop {
+                PvarStop::Limit => limit_error(),
+                PvarStop::Malformed(detail) => {
+                    let preceding = body[..chunk_start].bytes().filter(|&b| b == b'\n').count();
+                    pvar_line_error(path, header_lines + preceding + chunk_line, detail)
+                }
+            });
+        }
+    }
+    Ok(variants)
+}
+
+/// Byte ranges covering `body`, each holding whole lines.
+///
+/// Split points are advanced to the next newline, so a range never starts or
+/// ends mid-line and each chunk can be parsed independently.
+fn pvar_chunk_ranges(body: &str, target_chunks: usize) -> Vec<(usize, usize)> {
+    if body.is_empty() {
+        return Vec::new();
+    }
+    if target_chunks <= 1 {
+        return vec![(0, body.len())];
+    }
+
+    let bytes = body.as_bytes();
+    let mut ranges = Vec::with_capacity(target_chunks);
+    let mut start = 0;
+    for chunk in 1..target_chunks {
+        if start >= bytes.len() {
+            break;
+        }
+        let mut cut = (bytes.len() * chunk / target_chunks).max(start);
+        while cut < bytes.len() && bytes[cut] != b'\n' {
+            cut += 1;
+        }
+        // A newline is a char boundary and so is the byte after it, so slicing
+        // here is always valid UTF-8.
+        if cut < bytes.len() {
+            cut += 1;
+        }
+        if cut > start {
+            ranges.push((start, cut));
+            start = cut;
+        }
+    }
+    if start < bytes.len() {
+        ranges.push((start, bytes.len()));
+    }
+    ranges
+}
+
+/// How many pieces to split a body into, from its size and the host's cores.
+fn pvar_chunk_count(body: &str) -> usize {
+    if body.len() < PARALLEL_PVAR_MIN_BYTES {
+        return 1;
+    }
+    std::thread::available_parallelism()
+        .map(|value| value.get())
+        .unwrap_or(1)
+        .min(PARALLEL_PVAR_MAX_CHUNKS)
+}
+
+/// Parses one chunk, reporting where it stopped in chunk-local line numbers.
+fn parse_pvar_chunk(
+    body: &str,
+    coordinates: CoordinateSystem,
+    max_variants: usize,
+    layout: &PvarLayout,
+) -> (Vec<PvarVariant>, Option<(usize, PvarStop)>) {
     let mut variants = Vec::new();
-    for (line_index, line) in first_body.into_iter().chain(lines) {
+    for (chunk_line, line) in body.lines().enumerate() {
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
+        // A chunk cannot know the running total, so the exact limit is the
+        // caller's job. This bounds a chunk's own allocation on a file far over
+        // the limit, and changes no output: whatever this reports, the caller
+        // re-derives the same answer from the counts.
         if variants.len() >= max_variants {
-            return Err(DataFusionError::Plan(format!(
-                "PVAR {} exceeds configured max_variants {max_variants}",
-                sanitize_location(path)
-            )));
+            return (variants, Some((chunk_line, PvarStop::Limit)));
         }
-        let fields: Vec<_> = line.split_whitespace().collect();
-        if fields.len() < required_width {
-            return Err(pvar_line_error(
-                path,
-                line_index,
-                format!(
-                    "has {} columns; at least {required_width} required",
-                    fields.len()
-                ),
-            ));
+        match parse_pvar_record(line, coordinates, layout) {
+            Ok(variant) => variants.push(variant),
+            Err(detail) => return (variants, Some((chunk_line, PvarStop::Malformed(detail)))),
         }
-        let position = fields[pos_col].parse::<u64>().map_err(|error| {
-            pvar_line_error(path, line_index, format!("has invalid POS: {error}"))
-        })?;
-        let site = coordinates
-            .site(position)
-            .map_err(|error| pvar_line_error(path, line_index, error.to_string()))?;
-        let reference = fields[ref_col];
-        if reference.is_empty() || reference == "." || reference.contains(',') {
-            return Err(pvar_line_error(
-                path,
-                line_index,
-                "has malformed REF allele".to_string(),
-            ));
-        }
-        let alternate = fields[alt_col]
-            .split(',')
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        if alternate.is_empty()
-            || alternate
-                .iter()
-                .any(|allele| allele.is_empty() || allele == ".")
-        {
-            return Err(pvar_line_error(
-                path,
-                line_index,
-                "has malformed ALT allele list".to_string(),
-            ));
-        }
-        variants.push(PvarVariant {
-            chrom: fields[chrom_col].to_string(),
-            start: site.start,
-            end: site.end,
-            id: (fields[id_col] != ".").then(|| fields[id_col].to_string()),
-            reference: reference.to_string(),
-            alternate,
-        });
     }
-    Ok(variants)
+    (variants, None)
+}
+
+fn parse_pvar_record(
+    line: &str,
+    coordinates: CoordinateSystem,
+    layout: &PvarLayout,
+) -> std::result::Result<PvarVariant, String> {
+    let fields: Vec<_> = line.split_whitespace().collect();
+    if fields.len() < layout.width {
+        return Err(format!(
+            "has {} columns; at least {} required",
+            fields.len(),
+            layout.width
+        ));
+    }
+    let position = fields[layout.position]
+        .parse::<u64>()
+        .map_err(|error| format!("has invalid POS: {error}"))?;
+    let site = coordinates
+        .site(position)
+        .map_err(|error| error.to_string())?;
+    let reference = fields[layout.reference];
+    if reference.is_empty() || reference == "." || reference.contains(',') {
+        return Err("has malformed REF allele".to_string());
+    }
+    let alternate = fields[layout.alternate]
+        .split(',')
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if alternate.is_empty()
+        || alternate
+            .iter()
+            .any(|allele| allele.is_empty() || allele == ".")
+    {
+        return Err("has malformed ALT allele list".to_string());
+    }
+    Ok(PvarVariant {
+        chrom: fields[layout.chrom].to_string(),
+        start: site.start,
+        end: site.end,
+        id: (fields[layout.id] != ".").then(|| fields[layout.id].to_string()),
+        reference: reference.to_string(),
+        alternate,
+    })
 }
 
 fn pvar_line_error(path: &str, line_index: usize, detail: String) -> DataFusionError {
@@ -1706,6 +1895,178 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(error.contains("max_variants 1"), "{error}");
+    }
+
+    /// A body large enough to cross `PARALLEL_PVAR_MIN_BYTES` and be split.
+    fn large_pvar(rows: usize, malformed_at: Option<usize>) -> (String, usize) {
+        let mut text = String::from("##fileformat=PVARv1.0\n#CHROM\tPOS\tID\tREF\tALT\n");
+        let header_lines = 2;
+        for row in 0..rows {
+            if Some(row) == malformed_at {
+                text.push_str("22\tnot-a-position\tbad\tA\tC\n");
+            } else {
+                let position = row + 1;
+                text.push_str(&format!("22\t{position}\trs{row}\tA\tC\n"));
+            }
+        }
+        (text, header_lines)
+    }
+
+    /// `rows` valid records, split into exactly `chunks` pieces.
+    fn parse_pinned(text: &str, max_variants: usize, chunks: usize) -> Result<Vec<PvarVariant>> {
+        parse_pvar_chunked(
+            "cohort.pvar",
+            text.as_bytes(),
+            CoordinateSystem::ZeroBasedHalfOpen,
+            max_variants,
+            Some(chunks),
+        )
+    }
+
+    #[test]
+    fn enforces_the_row_limit_on_a_body_with_no_bad_line() {
+        // Nothing stops any chunk here, so the only thing that can enforce the
+        // limit is reconciling the counts as the chunks are joined.
+        let (text, _) = large_pvar(400, None);
+        assert_eq!(parse_pinned(&text, 400, 8).unwrap().len(), 400);
+        let error = parse_pinned(&text, 399, 8).unwrap_err().to_string();
+        assert!(error.contains("max_variants 399"), "{error}");
+    }
+
+    #[test]
+    fn the_row_limit_beats_a_malformed_row_reached_at_the_same_moment() {
+        // 400 good rows then a bad one, with the limit at exactly 400: a serial
+        // pass checks the limit before reading the bad line, so the limit wins.
+        // A chunk cannot see that on its own — it only knows its own rows — so
+        // this is what the reconciliation exists for.
+        let (mut text, header_lines) = large_pvar(400, None);
+        text.push_str("22\tnot-a-position\tbad\tA\tC\n");
+        let error = parse_pinned(&text, 400, 8).unwrap_err().to_string();
+        assert!(error.contains("max_variants 400"), "{error}");
+
+        // One more allowed row and the bad line is read, so it reports instead.
+        let error = parse_pinned(&text, 401, 8).unwrap_err().to_string();
+        assert!(
+            error.contains(&format!("line {} has invalid POS", header_lines + 401)),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn chunk_ranges_cover_the_body_on_line_boundaries() {
+        // Whatever the split points land on, the ranges must tile the body
+        // exactly and never cut a line: a chunk that starts mid-line would
+        // parse a fragment as a record.
+        for body in [
+            "".to_string(),
+            "a\n".to_string(),
+            "a\nbb\nccc\n".to_string(),
+            "a\nbb\nccc".to_string(),
+            "x\n".repeat(400_000),
+            format!("{}\nlast-line-without-newline", "y\n".repeat(400_000)),
+        ] {
+            let ranges = pvar_chunk_ranges(&body, 8);
+            if body.is_empty() {
+                assert!(ranges.is_empty());
+                continue;
+            }
+            assert_eq!(ranges.first().unwrap().0, 0);
+            assert_eq!(ranges.last().unwrap().1, body.len());
+            for window in ranges.windows(2) {
+                assert_eq!(window[0].1, window[1].0, "ranges must be contiguous");
+            }
+            for &(start, end) in &ranges {
+                assert!(start < end);
+                assert!(start == 0 || body.as_bytes()[start - 1] == b'\n');
+                assert!(end == body.len() || body.as_bytes()[end - 1] == b'\n');
+            }
+            // Splitting must not change how many lines there are.
+            let split_lines: usize = ranges
+                .iter()
+                .map(|&(start, end)| body[start..end].lines().count())
+                .sum();
+            assert_eq!(split_lines, body.lines().count());
+        }
+    }
+
+    #[test]
+    fn parses_a_split_pvar_identically_to_a_single_chunk() {
+        let rows = 60_000;
+        let (text, _) = large_pvar(rows, None);
+        assert!(
+            text.len() > PARALLEL_PVAR_MIN_BYTES,
+            "fixture must be large enough to be split"
+        );
+        let variants = parse_pvar(
+            "cohort.pvar",
+            text.as_bytes(),
+            CoordinateSystem::ZeroBasedHalfOpen,
+            usize::MAX,
+        )
+        .unwrap();
+        // Order and content must survive being parsed out of order.
+        assert_eq!(variants.len(), rows);
+        for (row, variant) in variants.iter().enumerate() {
+            assert_eq!(variant.chrom, "22");
+            assert_eq!(variant.start, row as u64);
+            assert_eq!(variant.id.as_deref(), Some(format!("rs{row}").as_str()));
+            assert_eq!(variant.reference, "A");
+            assert_eq!(variant.alternate, vec!["C"]);
+        }
+    }
+
+    #[test]
+    fn reports_the_file_line_of_a_malformed_row_in_a_split_body() {
+        // The chunk that finds the bad line only knows its own line numbers, so
+        // this is what catches a missing chunk offset.
+        for malformed_at in [0_usize, 1, 30_000, 59_999] {
+            let (text, header_lines) = large_pvar(60_000, Some(malformed_at));
+            let error = parse_pvar(
+                "cohort.pvar",
+                text.as_bytes(),
+                CoordinateSystem::ZeroBasedHalfOpen,
+                usize::MAX,
+            )
+            .unwrap_err()
+            .to_string();
+            let expected = format!("line {} has invalid POS", header_lines + malformed_at + 1);
+            assert!(error.contains(&expected), "{error} (expected {expected})");
+        }
+    }
+
+    #[test]
+    fn enforces_the_row_limit_before_a_malformed_row_in_a_split_body() {
+        // A serial pass checks the limit before reading the offending line, and
+        // the limit is reached in an earlier chunk than the bad line. The
+        // reconciliation across chunks has to reproduce that ordering.
+        let (text, _) = large_pvar(60_000, Some(50_000));
+        let error = parse_pvar(
+            "cohort.pvar",
+            text.as_bytes(),
+            CoordinateSystem::ZeroBasedHalfOpen,
+            10_000,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("max_variants 10000"), "{error}");
+    }
+
+    #[test]
+    fn reports_a_malformed_row_that_precedes_the_row_limit() {
+        // The mirror of the test above: the bad line comes first, so it wins.
+        let (text, header_lines) = large_pvar(60_000, Some(100));
+        let error = parse_pvar(
+            "cohort.pvar",
+            text.as_bytes(),
+            CoordinateSystem::ZeroBasedHalfOpen,
+            50_000,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains(&format!("line {} has invalid POS", header_lines + 101)),
+            "{error}"
+        );
     }
 
     #[test]

--- a/datafusion/bio-format-pgen/src/lib.rs
+++ b/datafusion/bio-format-pgen/src/lib.rs
@@ -5,6 +5,7 @@
 mod decode;
 mod fileset;
 mod filter;
+pub mod matrix;
 mod physical_exec;
 mod source;
 mod table_provider;

--- a/datafusion/bio-format-pgen/src/matrix.rs
+++ b/datafusion/bio-format-pgen/src/matrix.rs
@@ -114,12 +114,16 @@ pub async fn genotype_matrix_shape(
 /// `destination` must be exactly `variants * samples` long; use
 /// [`genotype_matrix_shape`] to size it. `threads` bounds the decoders, which
 /// write disjoint row ranges and so never contend.
+///
+/// Returns the shape and the variant start positions, in row order. The
+/// positions come from the fileset this already opened, so a caller that needs
+/// them does not have to parse the PVAR a second time to get them.
 pub async fn read_genotype_matrix(
     pgen_path: String,
     options: &PgenReadOptions,
     mut destination: MatrixData<'_>,
     threads: usize,
-) -> Result<MatrixShape> {
+) -> Result<(MatrixShape, Vec<u64>)> {
     let field = destination.field();
     let fileset = Arc::new(PgenFileset::open(pgen_path, options).await?);
     let samples = fileset.selected_samples.source_indices().len();
@@ -135,8 +139,15 @@ pub async fn read_genotype_matrix(
             destination.len()
         )));
     }
+    let positions = || {
+        fileset
+            .variants
+            .iter()
+            .map(|variant| variant.start)
+            .collect::<Vec<_>>()
+    };
     if expected == 0 {
-        return Ok(shape);
+        return Ok((shape, positions()));
     }
 
     let threads = threads.max(1);
@@ -221,7 +232,7 @@ pub async fn read_genotype_matrix(
             )?;
         }
     }
-    Ok(shape)
+    Ok((shape, positions()))
 }
 
 type LoadedRanges = Vec<(ByteRange, Vec<u8>)>;

--- a/datafusion/bio-format-pgen/src/matrix.rs
+++ b/datafusion/bio-format-pgen/src/matrix.rs
@@ -121,14 +121,85 @@ pub async fn genotype_matrix_shape(
 pub async fn read_genotype_matrix(
     pgen_path: String,
     options: &PgenReadOptions,
-    mut destination: MatrixData<'_>,
+    destination: MatrixData<'_>,
     threads: usize,
 ) -> Result<(MatrixShape, Vec<u64>)> {
+    let reader = GenotypeMatrixReader::open(pgen_path, options).await?;
+    let positions = reader.positions();
+    reader.read_into(destination, threads).await?;
+    Ok((reader.shape(), positions))
+}
+
+/// An opened fileset, ready to decode into a destination.
+///
+/// Opening parses the PVAR and PSAM — 108 MB of text on a whole chromosome. A
+/// caller that must learn the shape before it can allocate would otherwise pay
+/// that twice, once to ask and once to decode, and on the hardcall workload the
+/// second parse is a fifth of the whole operation.
+pub struct GenotypeMatrixReader {
+    fileset: Arc<PgenFileset>,
+    /// Read-coalescing bounds, kept because they belong to the request rather
+    /// than to the fileset and the decode still needs them.
+    max_range_gap: u64,
+    max_range_bytes: u64,
+}
+
+impl GenotypeMatrixReader {
+    /// Opens a fileset and reads its companions.
+    pub async fn open(pgen_path: String, options: &PgenReadOptions) -> Result<Self> {
+        Ok(Self {
+            fileset: Arc::new(PgenFileset::open(pgen_path, options).await?),
+            max_range_gap: options.max_range_gap,
+            max_range_bytes: options.max_range_bytes,
+        })
+    }
+
+    /// The shape a decode will produce.
+    pub fn shape(&self) -> MatrixShape {
+        MatrixShape {
+            variants: self.fileset.variants.len(),
+            samples: self.fileset.selected_samples.source_indices().len(),
+        }
+    }
+
+    /// The selected sample names, in column order.
+    pub fn sample_names(&self) -> &[String] {
+        self.fileset.selected_samples.names()
+    }
+
+    /// The variant start positions, in row order.
+    pub fn positions(&self) -> Vec<u64> {
+        self.fileset
+            .variants
+            .iter()
+            .map(|variant| variant.start)
+            .collect()
+    }
+
+    /// Decodes into `destination`, which must be exactly `variants * samples`
+    /// long.
+    pub async fn read_into(&self, destination: MatrixData<'_>, threads: usize) -> Result<()> {
+        decode_matrix(
+            &self.fileset,
+            destination,
+            threads,
+            self.max_range_gap,
+            self.max_range_bytes,
+        )
+        .await
+    }
+}
+
+async fn decode_matrix(
+    fileset: &Arc<PgenFileset>,
+    mut destination: MatrixData<'_>,
+    threads: usize,
+    max_range_gap: u64,
+    max_range_bytes: u64,
+) -> Result<()> {
     let field = destination.field();
-    let fileset = Arc::new(PgenFileset::open(pgen_path, options).await?);
     let samples = fileset.selected_samples.source_indices().len();
     let variants = fileset.variants.len();
-    let shape = MatrixShape { variants, samples };
 
     let expected = variants
         .checked_mul(samples)
@@ -139,26 +210,14 @@ pub async fn read_genotype_matrix(
             destination.len()
         )));
     }
-    let positions = || {
-        fileset
-            .variants
-            .iter()
-            .map(|variant| variant.start)
-            .collect::<Vec<_>>()
-    };
     if expected == 0 {
-        return Ok((shape, positions()));
+        return Ok(());
     }
 
     let threads = threads.max(1);
     let selection = Arc::new((0..variants).collect::<Vec<_>>());
-    let partitions = plan_payload_partitions(
-        selection,
-        &fileset,
-        threads,
-        options.max_range_gap,
-        options.max_range_bytes,
-    )?;
+    let partitions =
+        plan_payload_partitions(selection, fileset, threads, max_range_gap, max_range_bytes)?;
 
     // Byte ranges are fetched here, in order, because the object source is
     // async; decoding is what runs in parallel afterwards.
@@ -196,7 +255,7 @@ pub async fn read_genotype_matrix(
         MatrixData::AltCount { values, missing } => {
             let missing = *missing;
             decode_into(
-                &fileset,
+                fileset,
                 field,
                 &work,
                 values,
@@ -216,7 +275,7 @@ pub async fn read_genotype_matrix(
         MatrixData::Dosage { values, missing } => {
             let missing = *missing;
             decode_into(
-                &fileset,
+                fileset,
                 field,
                 &work,
                 values,
@@ -232,7 +291,7 @@ pub async fn read_genotype_matrix(
             )?;
         }
     }
-    Ok((shape, positions()))
+    Ok(())
 }
 
 type LoadedRanges = Vec<(ByteRange, Vec<u8>)>;

--- a/datafusion/bio-format-pgen/src/matrix.rs
+++ b/datafusion/bio-format-pgen/src/matrix.rs
@@ -15,7 +15,8 @@
 //! its position in the selection, so partitions own disjoint row ranges and need
 //! no coordination to write them.
 
-use std::ops::Range;
+use std::collections::HashSet;
+use std::iter::Peekable;
 use std::sync::Arc;
 
 use datafusion::common::{DataFusionError, Result};
@@ -27,7 +28,7 @@ use crate::decode::{
     supports_common_difflist_fast_path, validated_dense_hardcalls,
 };
 use crate::fileset::{PgenFileset, PgenMode};
-use crate::physical_exec::{PgenPartition, alt_count_from_code, record_payload};
+use crate::physical_exec::{MergedIndices, PgenPartition, alt_count_from_code, record_payload};
 use crate::table_provider::{PgenReadOptions, plan_payload_partitions};
 
 /// The internal code for a missing call.
@@ -219,31 +220,16 @@ async fn decode_matrix(
     let partitions =
         plan_payload_partitions(selection, fileset, threads, max_range_gap, max_range_bytes)?;
 
-    // Byte ranges are fetched here, in order, because the object source is
-    // async; decoding is what runs in parallel afterwards.
-    let mut loaded = Vec::with_capacity(partitions.len());
-    let mut reader = fileset.source.range_reader(&fileset.pgen_path).await?;
-    for partition in &partitions {
-        let mut ranges = Vec::with_capacity(partition.ranges.len());
-        for range in partition.ranges.iter().copied() {
-            let bytes = reader.read_range(range.start..range.end).await?;
-            ranges.push((range, bytes.to_vec()));
-        }
-        loaded.push(ranges);
-    }
-
     // Partitions own contiguous, ascending row ranges, so the destination
     // splits into disjoint pieces and the workers never share a byte.
     let mut cursor = 0;
-    let mut work = Vec::with_capacity(partitions.len());
-    for (partition, ranges) in partitions.iter().zip(loaded) {
+    for partition in &partitions {
         if partition.owned.start != cursor {
             return Err(DataFusionError::Execution(
                 "PGEN matrix partitions are not contiguous in variant order".to_string(),
             ));
         }
         cursor = partition.owned.end;
-        work.push((partition, ranges, partition.owned.clone()));
     }
     if cursor != variants {
         return Err(DataFusionError::Execution(format!(
@@ -254,10 +240,10 @@ async fn decode_matrix(
     match &mut destination {
         MatrixData::AltCount { values, missing } => {
             let missing = *missing;
-            decode_into(
+            decode_rounds(
                 fileset,
                 field,
-                &work,
+                &partitions,
                 values,
                 samples,
                 move |code| {
@@ -270,14 +256,15 @@ async fn decode_matrix(
                 // ALT_COUNT never reads the dosage track, so the general path
                 // narrows the hardcall it already has.
                 move |dosage| dosage.map_or(missing, |value| value as i8),
-            )?;
+            )
+            .await?;
         }
         MatrixData::Dosage { values, missing } => {
             let missing = *missing;
-            decode_into(
+            decode_rounds(
                 fileset,
                 field,
-                &work,
+                &partitions,
                 values,
                 samples,
                 move |code| {
@@ -288,21 +275,29 @@ async fn decode_matrix(
                     }
                 },
                 move |dosage| dosage.unwrap_or(missing),
-            )?;
+            )
+            .await?;
         }
     }
     Ok(())
 }
 
-type LoadedRanges = Vec<(ByteRange, Vec<u8>)>;
-type PartitionWork<'a> = (&'a PgenPartition, LoadedRanges, Range<usize>);
-
-#[allow(clippy::too_many_arguments)]
-fn decode_into<T, F, D>(
-    fileset: &Arc<PgenFileset>,
+/// Fetches and decodes the fileset a round at a time: one byte range per
+/// partition, read concurrently, then decoded in parallel.
+///
+/// Reading every range of every partition up front was simpler, but it held the
+/// whole compressed PGEN in memory on top of the destination matrix — and on a
+/// sample subset the destination is small while the input is not — and it left
+/// object-store latency serial no matter how many decoders were asked for. A
+/// round holds `partitions * max_range_bytes` instead, and its reads overlap.
+///
+/// The decoders keep their per-partition state across rounds, so a variant that
+/// depends on an LD base decoded in an earlier round still finds it.
+async fn decode_rounds<'a, T, F, D>(
+    fileset: &'a PgenFileset,
     field: MatrixField,
-    work: &[PartitionWork<'_>],
-    values: &mut [T],
+    partitions: &'a [PgenPartition],
+    values: &'a mut [T],
     samples: usize,
     value_of: F,
     dosage_of: D,
@@ -313,89 +308,191 @@ where
     D: Fn(Option<f32>) -> T + Copy + Send + Sync,
 {
     let mut rest = values;
-    let mut slices = Vec::with_capacity(work.len());
-    for (_, _, owned) in work {
-        let (head, tail) = rest.split_at_mut(owned.len() * samples);
-        slices.push(head);
+    let mut decoders = Vec::with_capacity(partitions.len());
+    for partition in partitions {
+        let (head, tail) = rest.split_at_mut(partition.owned.len() * samples);
         rest = tail;
+        decoders.push(PartitionDecoder::new(
+            fileset, field, partition, head, samples, value_of, dosage_of,
+        )?);
     }
 
-    std::thread::scope(|scope| {
-        let handles = work
+    // One reader per partition: they seek independently, so a round's reads do
+    // not have to wait on each other.
+    let mut readers = Vec::with_capacity(partitions.len());
+    for _ in partitions {
+        readers.push(fileset.source.range_reader(&fileset.pgen_path).await?);
+    }
+
+    let rounds = partitions
+        .iter()
+        .map(|partition| partition.ranges.len())
+        .max()
+        .unwrap_or(0);
+    for round in 0..rounds {
+        let fetches = readers
+            .iter_mut()
+            .zip(partitions)
+            .map(|(reader, partition)| async move {
+                match partition.ranges.get(round).copied() {
+                    Some(range) => {
+                        reader.read_range(range.start..range.end).await?;
+                        Ok::<_, DataFusionError>(Some(range))
+                    }
+                    // A partition with fewer ranges than the widest one sits
+                    // this round out.
+                    None => Ok(None),
+                }
+            });
+        let fetched = futures::future::try_join_all(fetches).await?;
+        // The decoders read out of the readers' own buffers, so a range is
+        // never copied and the buffers are reused from one round to the next.
+        let loaded = readers
             .iter()
-            .zip(slices)
-            .map(|((partition, ranges, _), slice)| {
-                scope.spawn(move || {
-                    decode_partition(
-                        fileset, field, partition, ranges, slice, samples, value_of, dosage_of,
-                    )
-                })
-            })
+            .zip(&fetched)
+            .map(|(reader, range)| range.map(|range| (range, reader.bytes())))
             .collect::<Vec<_>>();
-        handles
-            .into_iter()
-            .map(|handle| {
-                handle.join().map_err(|_| {
-                    DataFusionError::Execution("PGEN matrix decoder panicked".to_string())
-                })?
-            })
-            .collect::<Result<Vec<_>>>()
-    })?;
+
+        std::thread::scope(|scope| {
+            let handles = decoders
+                .iter_mut()
+                .zip(&loaded)
+                .filter_map(|(decoder, slot)| {
+                    slot.map(|(range, bytes)| {
+                        scope.spawn(move || decoder.decode_range(range, bytes))
+                    })
+                })
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle.join().map_err(|_| {
+                        DataFusionError::Execution("PGEN matrix decoder panicked".to_string())
+                    })?
+                })
+                .collect::<Result<Vec<_>>>()
+        })?;
+    }
     Ok(())
 }
 
-/// Decodes one partition's variants into its own slice of the matrix.
+/// One partition's decode, resumable across byte ranges.
 ///
-/// Mirrors the scan's per-record dispatch — direct dense, fused common-value,
-/// the biallelic fast path, then the general decoder — but each branch writes
-/// its values at their final address instead of into an Arrow builder.
-#[allow(clippy::too_many_arguments)]
-fn decode_partition<T, F, D>(
-    fileset: &PgenFileset,
+/// Everything the record loop carries between ranges lives here — the
+/// workspace, the retained LD base, the position in the required-variant list
+/// and the next destination row — because a partition is now handed its input
+/// a range at a time rather than all at once.
+struct PartitionDecoder<'a, T, F, D> {
+    fileset: &'a PgenFileset,
     field: MatrixField,
-    partition: &PgenPartition,
-    ranges: &LoadedRanges,
-    values: &mut [T],
+    values: &'a mut [T],
     samples: usize,
     value_of: F,
     dosage_of: D,
-) -> Result<()>
+    workspace: GtDecodeWorkspace,
+    projection: GenotypeProjection,
+    owned: &'a [usize],
+    retained: HashSet<usize>,
+    /// Lazy rather than collected: the whole selection is a usize per variant,
+    /// and materialising it per partition costs more than the walk it saves.
+    required: Peekable<MergedIndices<'a>>,
+    ld_base_index: Option<usize>,
+    ld_base: Vec<u8>,
+    row: usize,
+}
+
+impl<'a, T, F, D> PartitionDecoder<'a, T, F, D>
 where
     T: Copy,
     F: Fn(u8) -> T,
     D: Fn(Option<f32>) -> T,
 {
-    let selected = fileset.selected_samples.source_indices();
-    let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected)?;
-    let projection = match field {
-        MatrixField::AltCount => GenotypeProjection::alt_count_only(),
-        MatrixField::Dosage => GenotypeProjection::from_fields(&["DS".to_string()]),
-    };
-
-    let owned = partition.owned();
-    let mut retained = std::collections::HashSet::new();
-    for index in partition.required() {
-        if let Some(base) = fileset.records.record(index)?.ld_base {
-            retained.insert(base);
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        fileset: &'a PgenFileset,
+        field: MatrixField,
+        partition: &'a PgenPartition,
+        values: &'a mut [T],
+        samples: usize,
+        value_of: F,
+        dosage_of: D,
+    ) -> Result<Self> {
+        let selected = fileset.selected_samples.source_indices();
+        let projection = match field {
+            MatrixField::AltCount => GenotypeProjection::alt_count_only(),
+            MatrixField::Dosage => GenotypeProjection::from_fields(&["DS".to_string()]),
+        };
+        let mut retained = HashSet::new();
+        for index in partition.required() {
+            if let Some(base) = fileset.records.record(index)?.ld_base {
+                retained.insert(base);
+            }
         }
+        Ok(Self {
+            fileset,
+            field,
+            values,
+            samples,
+            value_of,
+            dosage_of,
+            workspace: GtDecodeWorkspace::new(fileset.sample_count, selected)?,
+            projection,
+            owned: partition.owned(),
+            retained,
+            required: partition.required().peekable(),
+            ld_base_index: None,
+            ld_base: Vec::with_capacity(fileset.sample_count),
+            row: 0,
+        })
     }
-    let mut ld_base_index = None;
-    let mut ld_base = Vec::with_capacity(fileset.sample_count);
-    let mut required = partition.required().peekable();
-    let mut row = 0;
 
-    for (range, bytes) in ranges {
+    /// Decodes every variant of this partition that lives in `range`.
+    ///
+    /// Mirrors the scan's per-record dispatch — direct dense, fused
+    /// common-value, the biallelic fast path, then the general decoder — but
+    /// each branch writes its values at their final address instead of into an
+    /// Arrow builder.
+    fn decode_range(&mut self, range: ByteRange, bytes: &[u8]) -> Result<()> {
+        // Destructured so the loop can borrow the LD base and the workspace at
+        // the same time, the way it could when these were locals.
+        let Self {
+            fileset,
+            field,
+            values,
+            samples,
+            value_of,
+            dosage_of,
+            workspace,
+            projection,
+            owned,
+            retained,
+            required,
+            ld_base_index,
+            ld_base,
+            row,
+        } = self;
+        // The row cursor runs in a local rather than through a `&mut` field:
+        // the loop is per-record, and reaching through a reference for each
+        // step costs measurably at whole-chromosome scale. It is written back
+        // once the range is done; an error aborts the whole matrix read, so a
+        // cursor left stale on that path is never observed.
+        let fileset: &PgenFileset = fileset;
+        let field = *field;
+        let samples = *samples;
+        let values: &mut [T] = values;
+        let mut next_row = *row;
+        let selected = fileset.selected_samples.source_indices();
+
         while let Some(&variant_index) = required.peek() {
             let record = fileset.records.record(variant_index)?;
             if record.offset >= range.end {
                 break;
             }
-            let payload =
-                record_payload(*range, bytes, record.offset, record.end(), variant_index)?;
+            let payload = record_payload(range, bytes, record.offset, record.end(), variant_index)?;
             let base = record
                 .ld_base
                 .map(|base_index| {
-                    if ld_base_index != Some(base_index) {
+                    if *ld_base_index != Some(base_index) {
                         return Err(DataFusionError::Execution(format!(
                             "PGEN variant {variant_index} dependency base {base_index} was not decoded first"
                         )));
@@ -417,18 +514,18 @@ where
                     base,
                 )?;
                 if retained.contains(&variant_index) {
-                    ld_base = main;
-                    ld_base_index = Some(variant_index);
+                    *ld_base = main;
+                    *ld_base_index = Some(variant_index);
                 }
                 required.next();
                 continue;
             }
 
             let out = values
-                .get_mut(row * samples..(row + 1) * samples)
+                .get_mut(next_row * samples..(next_row + 1) * samples)
                 .ok_or_else(|| {
                     DataFusionError::Execution(format!(
-                        "PGEN variant {variant_index} row {row} is outside the matrix"
+                        "PGEN variant {variant_index} row {next_row} is outside the matrix"
                     ))
                 })?;
             let allele_count = fileset.variants[variant_index].allele_count();
@@ -457,7 +554,7 @@ where
                 && supports_common_difflist_fast_path(fileset.mode, record.record_type)
             {
                 let common = decode_common_difflist_into(
-                    &mut workspace,
+                    workspace,
                     payload,
                     fileset.mode,
                     record.record_type,
@@ -472,7 +569,7 @@ where
                 }
             } else if biallelic {
                 decode_biallelic_gt_into(
-                    &mut workspace,
+                    workspace,
                     payload,
                     fileset.mode,
                     record.record_type,
@@ -487,8 +584,8 @@ where
                     *slot = value_of(code);
                 }
                 if retain_main {
-                    workspace.swap_main_track(&mut ld_base);
-                    ld_base_index = Some(variant_index);
+                    workspace.swap_main_track(ld_base);
+                    *ld_base_index = Some(variant_index);
                 }
             } else {
                 let (decoded, main) = decode_record_and_main(
@@ -498,21 +595,22 @@ where
                     variant_index,
                     fileset.sample_count,
                     allele_count,
-                    projection,
+                    *projection,
                     selected,
                     base,
                 )?;
-                write_general(out, field, &decoded, &value_of, &dosage_of);
+                write_general(out, field, &decoded, value_of, dosage_of);
                 if retain_main {
-                    ld_base = main;
-                    ld_base_index = Some(variant_index);
+                    *ld_base = main;
+                    *ld_base_index = Some(variant_index);
                 }
             }
-            row += 1;
+            next_row += 1;
             required.next();
         }
+        *row = next_row;
+        Ok(())
     }
-    Ok(())
 }
 
 /// The internal code of one sample in a packed dense hardcall track.

--- a/datafusion/bio-format-pgen/src/matrix.rs
+++ b/datafusion/bio-format-pgen/src/matrix.rs
@@ -1,0 +1,492 @@
+//! Decoding one genotype field straight into a caller-owned matrix.
+//!
+//! The DataFusion scan builds Arrow batches and something else copies them into
+//! whatever the caller actually wanted. For a dense matrix that copy is pure
+//! overhead — on a whole chromosome it is 10 GB read and 10 GB written — and it
+//! is the stage that stops a materializing read from scaling, because it
+//! saturates memory bandwidth long before it runs out of threads.
+//!
+//! This path skips it. Decoders write genotypes at their final address, so the
+//! values are touched once, by the same threads that produced them.
+//!
+//! Two things make that simpler here than in the Arrow path rather than harder:
+//! a matrix has no validity bitmap, so a missing call is just a sentinel the
+//! caller chooses; and a full-file read gives every variant a row index equal to
+//! its position in the selection, so partitions own disjoint row ranges and need
+//! no coordination to write them.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion_bio_format_core::range_planning::ByteRange;
+
+use crate::decode::{
+    GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into, decode_common_difflist_into,
+    decode_main_track_and_validate, decode_record_and_main, supports_biallelic_gt_fast_path,
+    supports_common_difflist_fast_path, validated_dense_hardcalls,
+};
+use crate::fileset::{PgenFileset, PgenMode};
+use crate::physical_exec::{PgenPartition, alt_count_from_code, record_payload};
+use crate::table_provider::{PgenReadOptions, plan_payload_partitions};
+
+/// The internal code for a missing call.
+const MISSING_CODE: u8 = 3;
+
+/// A genotype field with one value per sample, which is what a matrix can hold.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MatrixField {
+    /// Hardcall ALT allele count, one byte per genotype.
+    AltCount,
+    /// ALT dosage. Fractional when the fileset carries a dosage track.
+    Dosage,
+}
+
+impl MatrixField {
+    /// The genotype child this field corresponds to in the Arrow schema.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::AltCount => "ALT_COUNT",
+            Self::Dosage => "DS",
+        }
+    }
+}
+
+/// The caller's matrix, row-major, one row per variant.
+pub enum MatrixData<'a> {
+    /// `int8` destination, for [`MatrixField::AltCount`].
+    AltCount {
+        /// Row-major values, `variants * samples` long.
+        values: &'a mut [i8],
+        /// Written where a genotype is missing.
+        missing: i8,
+    },
+    /// `float32` destination, for [`MatrixField::Dosage`].
+    Dosage {
+        /// Row-major values, `variants * samples` long.
+        values: &'a mut [f32],
+        /// Written where a genotype is missing.
+        missing: f32,
+    },
+}
+
+impl MatrixData<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::AltCount { values, .. } => values.len(),
+            Self::Dosage { values, .. } => values.len(),
+        }
+    }
+
+    fn field(&self) -> MatrixField {
+        match self {
+            Self::AltCount { .. } => MatrixField::AltCount,
+            Self::Dosage { .. } => MatrixField::Dosage,
+        }
+    }
+}
+
+/// The shape a fileset will produce, reported before any genotype is read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MatrixShape {
+    /// Rows, one per PVAR variant.
+    pub variants: usize,
+    /// Columns, one per selected sample.
+    pub samples: usize,
+}
+
+/// Reports the matrix shape a fileset would produce under `options`.
+///
+/// Reads only the companions, so a caller can allocate before deciding to scan.
+pub async fn genotype_matrix_shape(
+    pgen_path: String,
+    options: &PgenReadOptions,
+) -> Result<MatrixShape> {
+    let fileset = PgenFileset::open(pgen_path, options).await?;
+    Ok(MatrixShape {
+        variants: fileset.variants.len(),
+        samples: fileset.selected_samples.source_indices().len(),
+    })
+}
+
+/// Decodes one genotype field of a whole fileset into `destination`.
+///
+/// `destination` must be exactly `variants * samples` long; use
+/// [`genotype_matrix_shape`] to size it. `threads` bounds the decoders, which
+/// write disjoint row ranges and so never contend.
+pub async fn read_genotype_matrix(
+    pgen_path: String,
+    options: &PgenReadOptions,
+    mut destination: MatrixData<'_>,
+    threads: usize,
+) -> Result<MatrixShape> {
+    let field = destination.field();
+    let fileset = Arc::new(PgenFileset::open(pgen_path, options).await?);
+    let samples = fileset.selected_samples.source_indices().len();
+    let variants = fileset.variants.len();
+    let shape = MatrixShape { variants, samples };
+
+    let expected = variants
+        .checked_mul(samples)
+        .ok_or_else(|| DataFusionError::Execution("PGEN matrix size overflowed".to_string()))?;
+    if destination.len() != expected {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN matrix destination has {} values; expected {expected} ({variants} variants x {samples} samples)",
+            destination.len()
+        )));
+    }
+    if expected == 0 {
+        return Ok(shape);
+    }
+
+    let threads = threads.max(1);
+    let selection = Arc::new((0..variants).collect::<Vec<_>>());
+    let partitions = plan_payload_partitions(
+        selection,
+        &fileset,
+        threads,
+        options.max_range_gap,
+        options.max_range_bytes,
+    )?;
+
+    // Byte ranges are fetched here, in order, because the object source is
+    // async; decoding is what runs in parallel afterwards.
+    let mut loaded = Vec::with_capacity(partitions.len());
+    let mut reader = fileset.source.range_reader(&fileset.pgen_path).await?;
+    for partition in &partitions {
+        let mut ranges = Vec::with_capacity(partition.ranges.len());
+        for range in partition.ranges.iter().copied() {
+            let bytes = reader.read_range(range.start..range.end).await?;
+            ranges.push((range, bytes.to_vec()));
+        }
+        loaded.push(ranges);
+    }
+
+    // Partitions own contiguous, ascending row ranges, so the destination
+    // splits into disjoint pieces and the workers never share a byte.
+    let mut cursor = 0;
+    let mut work = Vec::with_capacity(partitions.len());
+    for (partition, ranges) in partitions.iter().zip(loaded) {
+        if partition.owned.start != cursor {
+            return Err(DataFusionError::Execution(
+                "PGEN matrix partitions are not contiguous in variant order".to_string(),
+            ));
+        }
+        cursor = partition.owned.end;
+        work.push((partition, ranges, partition.owned.clone()));
+    }
+    if cursor != variants {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN matrix partitions cover {cursor} of {variants} variants"
+        )));
+    }
+
+    match &mut destination {
+        MatrixData::AltCount { values, missing } => {
+            let missing = *missing;
+            decode_into(
+                &fileset,
+                field,
+                &work,
+                values,
+                samples,
+                move |code| {
+                    if code == MISSING_CODE {
+                        missing
+                    } else {
+                        alt_count_from_code(code)
+                    }
+                },
+                // ALT_COUNT never reads the dosage track, so the general path
+                // narrows the hardcall it already has.
+                move |dosage| dosage.map_or(missing, |value| value as i8),
+            )?;
+        }
+        MatrixData::Dosage { values, missing } => {
+            let missing = *missing;
+            decode_into(
+                &fileset,
+                field,
+                &work,
+                values,
+                samples,
+                move |code| {
+                    if code == MISSING_CODE {
+                        missing
+                    } else {
+                        f32::from(alt_count_from_code(code))
+                    }
+                },
+                move |dosage| dosage.unwrap_or(missing),
+            )?;
+        }
+    }
+    Ok(shape)
+}
+
+type LoadedRanges = Vec<(ByteRange, Vec<u8>)>;
+type PartitionWork<'a> = (&'a PgenPartition, LoadedRanges, Range<usize>);
+
+#[allow(clippy::too_many_arguments)]
+fn decode_into<T, F, D>(
+    fileset: &Arc<PgenFileset>,
+    field: MatrixField,
+    work: &[PartitionWork<'_>],
+    values: &mut [T],
+    samples: usize,
+    value_of: F,
+    dosage_of: D,
+) -> Result<()>
+where
+    T: Copy + Send + Sync,
+    F: Fn(u8) -> T + Copy + Send + Sync,
+    D: Fn(Option<f32>) -> T + Copy + Send + Sync,
+{
+    let mut rest = values;
+    let mut slices = Vec::with_capacity(work.len());
+    for (_, _, owned) in work {
+        let (head, tail) = rest.split_at_mut(owned.len() * samples);
+        slices.push(head);
+        rest = tail;
+    }
+
+    std::thread::scope(|scope| {
+        let handles = work
+            .iter()
+            .zip(slices)
+            .map(|((partition, ranges, _), slice)| {
+                scope.spawn(move || {
+                    decode_partition(
+                        fileset, field, partition, ranges, slice, samples, value_of, dosage_of,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle.join().map_err(|_| {
+                    DataFusionError::Execution("PGEN matrix decoder panicked".to_string())
+                })?
+            })
+            .collect::<Result<Vec<_>>>()
+    })?;
+    Ok(())
+}
+
+/// Decodes one partition's variants into its own slice of the matrix.
+///
+/// Mirrors the scan's per-record dispatch — direct dense, fused common-value,
+/// the biallelic fast path, then the general decoder — but each branch writes
+/// its values at their final address instead of into an Arrow builder.
+#[allow(clippy::too_many_arguments)]
+fn decode_partition<T, F, D>(
+    fileset: &PgenFileset,
+    field: MatrixField,
+    partition: &PgenPartition,
+    ranges: &LoadedRanges,
+    values: &mut [T],
+    samples: usize,
+    value_of: F,
+    dosage_of: D,
+) -> Result<()>
+where
+    T: Copy,
+    F: Fn(u8) -> T,
+    D: Fn(Option<f32>) -> T,
+{
+    let selected = fileset.selected_samples.source_indices();
+    let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected)?;
+    let projection = match field {
+        MatrixField::AltCount => GenotypeProjection::alt_count_only(),
+        MatrixField::Dosage => GenotypeProjection::from_fields(&["DS".to_string()]),
+    };
+
+    let owned = partition.owned();
+    let mut retained = std::collections::HashSet::new();
+    for index in partition.required() {
+        if let Some(base) = fileset.records.record(index)?.ld_base {
+            retained.insert(base);
+        }
+    }
+    let mut ld_base_index = None;
+    let mut ld_base = Vec::with_capacity(fileset.sample_count);
+    let mut required = partition.required().peekable();
+    let mut row = 0;
+
+    for (range, bytes) in ranges {
+        while let Some(&variant_index) = required.peek() {
+            let record = fileset.records.record(variant_index)?;
+            if record.offset >= range.end {
+                break;
+            }
+            let payload =
+                record_payload(*range, bytes, record.offset, record.end(), variant_index)?;
+            let base = record
+                .ld_base
+                .map(|base_index| {
+                    if ld_base_index != Some(base_index) {
+                        return Err(DataFusionError::Execution(format!(
+                            "PGEN variant {variant_index} dependency base {base_index} was not decoded first"
+                        )));
+                    }
+                    Ok(ld_base.as_slice())
+                })
+                .transpose()?;
+
+            // A record this partition does not emit is decoded only far enough
+            // to serve as the next one's LD base.
+            if owned.binary_search(&variant_index).is_err() {
+                let main = decode_main_track_and_validate(
+                    payload,
+                    fileset.mode,
+                    record.record_type,
+                    variant_index,
+                    fileset.sample_count,
+                    fileset.variants[variant_index].allele_count(),
+                    base,
+                )?;
+                if retained.contains(&variant_index) {
+                    ld_base = main;
+                    ld_base_index = Some(variant_index);
+                }
+                required.next();
+                continue;
+            }
+
+            let out = values
+                .get_mut(row * samples..(row + 1) * samples)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "PGEN variant {variant_index} row {row} is outside the matrix"
+                    ))
+                })?;
+            let allele_count = fileset.variants[variant_index].allele_count();
+            let retain_main = retained.contains(&variant_index);
+            let identity = workspace.has_identity_selection();
+            let biallelic = supports_biallelic_gt_fast_path(record.record_type, allele_count);
+
+            if identity
+                && !retain_main
+                && biallelic
+                && (fileset.mode == PgenMode::Plink1 || record.record_type & 7 == 0)
+            {
+                let packed = validated_dense_hardcalls(
+                    payload,
+                    fileset.mode,
+                    record.record_type,
+                    variant_index,
+                    fileset.sample_count,
+                )?;
+                for (sample, slot) in out.iter_mut().enumerate() {
+                    *slot = value_of(dense_code(packed, sample, fileset.mode));
+                }
+            } else if identity
+                && !retain_main
+                && biallelic
+                && supports_common_difflist_fast_path(fileset.mode, record.record_type)
+            {
+                let common = decode_common_difflist_into(
+                    &mut workspace,
+                    payload,
+                    fileset.mode,
+                    record.record_type,
+                    variant_index,
+                    fileset.sample_count,
+                )?;
+                // One write per sample and nothing read back, which is the whole
+                // point of decoding at the destination.
+                out.fill(value_of(common));
+                for &(sample, value) in workspace.patches() {
+                    out[sample] = value_of(value);
+                }
+            } else if biallelic {
+                decode_biallelic_gt_into(
+                    &mut workspace,
+                    payload,
+                    fileset.mode,
+                    record.record_type,
+                    variant_index,
+                    fileset.sample_count,
+                    selected,
+                    base,
+                    retain_main,
+                    false,
+                )?;
+                for (slot, &code) in out.iter_mut().zip(workspace.selected_codes()) {
+                    *slot = value_of(code);
+                }
+                if retain_main {
+                    workspace.swap_main_track(&mut ld_base);
+                    ld_base_index = Some(variant_index);
+                }
+            } else {
+                let (decoded, main) = decode_record_and_main(
+                    payload,
+                    fileset.mode,
+                    record.record_type,
+                    variant_index,
+                    fileset.sample_count,
+                    allele_count,
+                    projection,
+                    selected,
+                    base,
+                )?;
+                write_general(out, field, &decoded, &value_of, &dosage_of);
+                if retain_main {
+                    ld_base = main;
+                    ld_base_index = Some(variant_index);
+                }
+            }
+            row += 1;
+            required.next();
+        }
+    }
+    Ok(())
+}
+
+/// The internal code of one sample in a packed dense hardcall track.
+#[inline]
+fn dense_code(packed: &[u8], sample: usize, mode: PgenMode) -> u8 {
+    let raw = (packed[sample / 4] >> ((sample % 4) * 2)) & 3;
+    if mode == PgenMode::Plink1 {
+        match raw {
+            0 => 2,
+            1 => MISSING_CODE,
+            2 => 1,
+            _ => 0,
+        }
+    } else {
+        raw
+    }
+}
+
+/// Writes a record the fast paths could not take, from the general decoder's
+/// output rather than from internal codes.
+fn write_general<T: Copy, F: Fn(u8) -> T, D: Fn(Option<f32>) -> T>(
+    out: &mut [T],
+    field: MatrixField,
+    decoded: &crate::decode::DecodedRecord,
+    value_of: &F,
+    dosage_of: &D,
+) {
+    match field {
+        MatrixField::AltCount => {
+            for (slot, call) in out.iter_mut().zip(&decoded.gt) {
+                *slot = match call {
+                    Some(call) => value_of(u8::from(call[0] == 1) + u8::from(call[1] == 1)),
+                    None => value_of(MISSING_CODE),
+                };
+            }
+        }
+        // This is the branch a record with a real dosage track takes, and its
+        // values are genuinely fractional — 0.125 is a dosage a fileset holds.
+        // They cannot go through the internal-code mapping, which only has
+        // 0, 1 and 2 to say.
+        MatrixField::Dosage => {
+            for (slot, dosage) in out.iter_mut().zip(&decoded.ds) {
+                *slot = dosage_of(*dosage);
+            }
+        }
+    }
+}

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -44,7 +44,7 @@ impl PgenPartition {
         &self.selection[self.owned.clone()]
     }
 
-    pub(crate) fn required(&self) -> impl Iterator<Item = usize> + '_ {
+    pub(crate) fn required(&self) -> MergedIndices<'_> {
         MergedIndices {
             owned: self.owned(),
             dependencies: &self.dependencies,
@@ -54,7 +54,9 @@ impl PgenPartition {
     }
 }
 
-struct MergedIndices<'a> {
+/// Owned and dependency indices merged in file order, resumable because the
+/// matrix decoder carries one across the byte ranges of its partition.
+pub(crate) struct MergedIndices<'a> {
     owned: &'a [usize],
     dependencies: &'a [usize],
     owned_position: usize,
@@ -1263,7 +1265,8 @@ fn execute_single_field(
     let stream = try_stream! {
         let selected_samples = fileset.selected_samples.source_indices();
         let selected_sample_count = selected_samples.len();
-        let estimated_row_bytes = estimate_genotype_bytes(selected_sample_count, &["GT".to_string()]);
+        let estimated_row_bytes =
+            estimate_genotype_bytes(selected_sample_count, std::slice::from_ref(&field));
         let mut sizer = GenotypeBatchSizer::new(max_rows, soft_bytes)?;
         let partition_row_capacity = initial_batch_row_capacity(
             max_rows,
@@ -1481,6 +1484,8 @@ fn estimate_genotype_bytes(samples: usize, fields: &[String]) -> usize {
             "PHASED" => samples.saturating_mul(2),
             "DS" => samples.saturating_mul(5),
             "DS_STORED" => samples.saturating_mul(5),
+            // One `i8` per sample plus validity and the list offset.
+            "ALT_COUNT" => samples.saturating_mul(2),
             "HDS" => samples.saturating_mul(9),
             _ => 0,
         })
@@ -1922,6 +1927,26 @@ mod tests {
         assert_eq!(
             initial_batch_row_capacity(8192, 3, 64 * 1024 * 1024, estimated_row_bytes),
             3
+        );
+    }
+
+    #[test]
+    fn sizes_alt_count_batches_by_its_own_width_not_by_gt() {
+        // An `ALT_COUNT` row is a byte per sample, not the five `GT` needs; a
+        // GT-shaped estimate would flush batches roughly five times too often
+        // and report the same inflation as `GenotypeBytes`.
+        let alt_count = estimate_genotype_bytes(100_000, &["ALT_COUNT".to_string()]);
+        assert_eq!(alt_count, 200_000);
+        let gt = estimate_genotype_bytes(100_000, &["GT".to_string()]);
+        assert!(alt_count < gt);
+        assert_eq!(
+            initial_batch_row_capacity(8192, 8192, 64 * 1024 * 1024, alt_count),
+            335
+        );
+        // A multi-field projection must not price `ALT_COUNT` at zero.
+        assert_eq!(
+            estimate_genotype_bytes(100_000, &["GT".to_string(), "ALT_COUNT".to_string()]),
+            gt + alt_count
         );
     }
 

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -23,9 +23,10 @@ use datafusion_bio_format_core::genotype::{
 use datafusion_bio_format_core::range_planning::ByteRange;
 
 use crate::decode::{
-    DecodedRecord, GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into,
-    decode_dense_biallelic_gt, decode_main_track_and_validate, decode_record_and_main,
-    supports_biallelic_gt_fast_path,
+    DENSE_DOSAGE_QUADS, DENSE_DOSAGE_QUADS_PLINK1, DENSE_DOSAGE_VALIDITY,
+    DENSE_DOSAGE_VALIDITY_PLINK1, DecodedRecord, GenotypeProjection, GtDecodeWorkspace,
+    decode_biallelic_gt_into, decode_dense_biallelic_gt, decode_main_track_and_validate,
+    decode_record_and_main, supports_biallelic_gt_fast_path, validated_dense_hardcalls,
 };
 use crate::fileset::{PgenFileset, PgenMode};
 
@@ -556,11 +557,6 @@ impl DsBatchBuilder {
         })
     }
 
-    #[inline]
-    fn alt1_dosage(left: u16, right: u16) -> f32 {
-        f32::from(u8::from(left == 1) + u8::from(right == 1))
-    }
-
     /// Appends decoded dosages. These must come from the record's dosage
     /// track when it has one — deriving them from hardcalls would silently
     /// replace a fractional dosage such as 0.125 with an allele count.
@@ -581,34 +577,86 @@ impl DsBatchBuilder {
     }
 
     fn append_codes(&mut self, variant_index: usize, codes: &[u8]) -> Result<()> {
+        // Codes 0..=4 map to a dosage through a table so the loop stays branch
+        // free, and validity is accumulated a byte at a time rather than a bit
+        // at a time. This is the path almost every record takes: plink2 writes
+        // LD-compressed records, which are not eligible for the dense decode,
+        // so this runs once per genotype cell across a whole scan.
+        const DOSAGE: [f32; 5] = [0.0, 1.0, 2.0, 0.0, 1.0];
+        if let Some(code) = codes.iter().copied().find(|&code| code > 4) {
+            return Err(DataFusionError::Execution(format!(
+                "invalid internal biallelic GT code {code}"
+            )));
+        }
+
+        self.dosages.reserve(codes.len());
+        let mut present = true;
         for &code in codes {
-            let (dosage, valid) = match code {
-                0 => (0.0, true),
-                1 => (1.0, true),
-                2 => (2.0, true),
-                3 => (0.0, false),
-                4 => (1.0, true),
-                _ => {
-                    return Err(DataFusionError::Execution(format!(
-                        "invalid internal biallelic GT code {code}"
-                    )));
+            self.dosages.push(DOSAGE[usize::from(code)]);
+            present &= code != 3;
+        }
+
+        if present {
+            // A variant with no missing call is the common case in a dense
+            // callset, and skips the bitmap bookkeeping entirely.
+            self.sample_validity.append_all_valid(codes.len());
+        } else {
+            for chunk in codes.chunks(8) {
+                let mut bits = 0_u8;
+                for (index, &code) in chunk.iter().enumerate() {
+                    if code != 3 {
+                        bits |= 1 << index;
+                    }
                 }
-            };
-            self.dosages.push(dosage);
-            self.sample_validity.append(valid);
+                self.sample_validity.append_packed(bits, chunk.len());
+            }
         }
         self.finish_variant(variant_index);
         Ok(())
     }
 
-    #[inline]
-    fn append_chunk(&mut self, alleles: &[u16], validity: u8, sample_count: usize) {
-        for sample in 0..sample_count {
-            let left = alleles[sample * 2];
-            let right = alleles[sample * 2 + 1];
-            self.dosages.push(Self::alt1_dosage(left, right));
+    /// Appends one whole variant straight from its packed two-bit hardcalls.
+    ///
+    /// Walking the bytes here rather than through a per-quad callback keeps the
+    /// inner loop free of indirect calls so it can be unrolled, and indexes a
+    /// 4 KiB dosage table instead of the ~80 KiB allele table the GT path uses.
+    fn append_dense(&mut self, packed: &[u8], sample_count: usize, mode: PgenMode) {
+        let (quads, validity_of) = if mode == PgenMode::Plink1 {
+            (&DENSE_DOSAGE_QUADS_PLINK1, &DENSE_DOSAGE_VALIDITY_PLINK1)
+        } else {
+            (&DENSE_DOSAGE_QUADS, &DENSE_DOSAGE_VALIDITY)
+        };
+        let full_bytes = sample_count / 4;
+        self.dosages.reserve(sample_count);
+
+        // A variant with no missing call is the common case in a dense
+        // callset, and lets the whole validity run be appended at once instead
+        // of a nibble at a time.
+        let mut all_present = true;
+        for &byte in &packed[..full_bytes] {
+            self.dosages.extend_from_slice(&quads[usize::from(byte)]);
+            all_present &= validity_of[usize::from(byte)] == 0x0f;
         }
-        self.sample_validity.append_packed(validity, sample_count);
+        let remainder = sample_count % 4;
+        if remainder != 0 {
+            let byte = packed[full_bytes];
+            self.dosages
+                .extend_from_slice(&quads[usize::from(byte)][..remainder]);
+        }
+
+        if all_present && remainder == 0 {
+            self.sample_validity.append_all_valid(sample_count);
+        } else {
+            for &byte in &packed[..full_bytes] {
+                self.sample_validity
+                    .append_packed(validity_of[usize::from(byte)], 4);
+            }
+            if remainder != 0 {
+                let byte = packed[full_bytes];
+                self.sample_validity
+                    .append_packed(validity_of[usize::from(byte)], remainder);
+            }
+        }
     }
 
     fn finish_variant(&mut self, variant_index: usize) {
@@ -679,6 +727,14 @@ impl FastFieldBuilder {
         }
     }
 
+    /// Whether hardcall phase orientation affects this field's output.
+    ///
+    /// `GT` distinguishes `(0,1)` from `(1,0)`; `DS` sums them, so a dosage
+    /// scan can validate the phase track without applying it.
+    fn needs_phase(&self) -> bool {
+        matches!(self, Self::Gt(_))
+    }
+
     /// The projection the generic fallback must decode for this field.
     fn projection(&self) -> GenotypeProjection {
         match self {
@@ -694,11 +750,39 @@ impl FastFieldBuilder {
         }
     }
 
-    #[inline]
-    fn append_chunk(&mut self, alleles: &[u16], validity: u8, sample_count: usize) {
+    /// Decodes one dense biallelic record directly into this builder.
+    ///
+    /// `GT` needs the phase pattern, so it goes through the quad callback.
+    /// `DS` does not, so it validates the record once and then walks the
+    /// two-bit codes inline against a compact dosage table.
+    fn append_dense_record(
+        &mut self,
+        payload: &[u8],
+        mode: PgenMode,
+        record_type: u8,
+        variant_index: usize,
+        sample_count: usize,
+    ) -> Result<()> {
         match self {
-            Self::Gt(builder) => builder.append_chunk(alleles, validity, sample_count),
-            Self::Ds(builder) => builder.append_chunk(alleles, validity, sample_count),
+            Self::Gt(builder) => decode_dense_biallelic_gt(
+                payload,
+                mode,
+                record_type,
+                variant_index,
+                sample_count,
+                |alleles, validity, samples| builder.append_chunk(alleles, validity, samples),
+            ),
+            Self::Ds(builder) => {
+                let packed = validated_dense_hardcalls(
+                    payload,
+                    mode,
+                    record_type,
+                    variant_index,
+                    sample_count,
+                )?;
+                builder.append_dense(packed, sample_count, mode);
+                Ok(())
+            }
         }
     }
 
@@ -794,6 +878,35 @@ impl PackedValidityBuilder {
         }
         self.len = new_len;
         self.null_count += count - bits.count_ones() as usize;
+    }
+
+    /// Appends `count` valid entries at once.
+    ///
+    /// Used when a whole variant has no missing call, which avoids touching
+    /// the bitmap once per sample for the common dense case.
+    fn append_all_valid(&mut self, count: usize) {
+        let shift = self.len % 8;
+        let mut remaining = count;
+        if shift != 0 {
+            let head = (8 - shift).min(remaining);
+            let mask = if head == 8 {
+                u8::MAX
+            } else {
+                ((1_u8 << head) - 1) << shift
+            };
+            let last = self.bytes.len() - 1;
+            self.bytes[last] |= mask;
+            self.len += head;
+            remaining -= head;
+        }
+        let whole = remaining / 8;
+        self.bytes.resize(self.bytes.len() + whole, u8::MAX);
+        self.len += whole * 8;
+        remaining -= whole * 8;
+        if remaining != 0 {
+            self.bytes.push((1_u8 << remaining) - 1);
+            self.len += remaining;
+        }
     }
 
     fn finish(&mut self) -> Option<NullBuffer> {
@@ -912,15 +1025,12 @@ fn execute_single_field(
                     && supports_biallelic_gt_fast_path(record.record_type, allele_count)
                     && (fileset.mode == PgenMode::Plink1 || record.record_type & 7 == 0);
                 if direct_dense {
-                    decode_dense_biallelic_gt(
+                    batch.append_dense_record(
                         payload,
                         fileset.mode,
                         record.record_type,
                         variant_index,
                         fileset.sample_count,
-                        |alleles, validity, samples| {
-                            batch.append_chunk(alleles, validity, samples)
-                        },
                     )?;
                     batch.finish_variant(variant_index);
                 } else if supports_biallelic_gt_fast_path(record.record_type, allele_count) {
@@ -934,6 +1044,7 @@ fn execute_single_field(
                         selected_samples,
                         base,
                         retain_main,
+                        batch.needs_phase(),
                     )?;
                     batch.append_codes(variant_index, workspace.selected_codes())?;
                     if retained_bases.contains(&variant_index) {

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -25,9 +25,9 @@ use datafusion_bio_format_core::range_planning::ByteRange;
 use crate::decode::{
     DENSE_ALT_COUNT_QUADS, DENSE_ALT_COUNT_QUADS_PLINK1, DENSE_DOSAGE_QUADS,
     DENSE_DOSAGE_QUADS_PLINK1, DENSE_DOSAGE_VALIDITY, DENSE_DOSAGE_VALIDITY_PLINK1, DecodedRecord,
-    GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into, decode_dense_biallelic_gt,
-    decode_main_track_and_validate, decode_record_and_main, supports_biallelic_gt_fast_path,
-    validated_dense_hardcalls,
+    GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into, decode_common_difflist_into,
+    decode_dense_biallelic_gt, decode_main_track_and_validate, decode_record_and_main,
+    supports_biallelic_gt_fast_path, supports_common_difflist_fast_path, validated_dense_hardcalls,
 };
 use crate::fileset::{PgenFileset, PgenMode};
 
@@ -621,6 +621,23 @@ impl DsBatchBuilder {
         Ok(())
     }
 
+    /// Appends one whole variant from a common category plus its sparse patches.
+    ///
+    /// The fill is a single `resize`, so a sample is written once and never read
+    /// back; `append_codes` on the same record writes a code per sample and then
+    /// reads every one of them again. Patches touch only the samples that differ
+    /// from the common category.
+    fn append_common_difflist(&mut self, common: u8, patches: &[(usize, u8)], sample_count: usize) {
+        let start = self.dosages.len();
+        self.dosages
+            .resize(start + sample_count, dosage_from_code(common));
+        let output = &mut self.dosages[start..];
+        for &(sample, value) in patches {
+            output[sample] = dosage_from_code(value);
+        }
+        append_common_difflist_validity(&mut self.sample_validity, common, patches, sample_count);
+    }
+
     /// Appends one whole variant straight from its packed two-bit hardcalls.
     ///
     /// Walking the bytes here rather than through a per-quad callback keeps the
@@ -790,6 +807,18 @@ impl AltCountBatchBuilder {
         Ok(())
     }
 
+    /// The `ALT_COUNT` counterpart of `DsBatchBuilder::append_common_difflist`.
+    fn append_common_difflist(&mut self, common: u8, patches: &[(usize, u8)], sample_count: usize) {
+        let start = self.counts.len();
+        self.counts
+            .resize(start + sample_count, alt_count_from_code(common));
+        let output = &mut self.counts[start..];
+        for &(sample, value) in patches {
+            output[sample] = alt_count_from_code(value);
+        }
+        append_common_difflist_validity(&mut self.sample_validity, common, patches, sample_count);
+    }
+
     fn append_dense(&mut self, packed: &[u8], sample_count: usize, mode: PgenMode) {
         let (quads, validity_of) = if mode == PgenMode::Plink1 {
             (&DENSE_ALT_COUNT_QUADS_PLINK1, &DENSE_DOSAGE_VALIDITY_PLINK1)
@@ -924,6 +953,31 @@ impl FastFieldBuilder {
         }
     }
 
+    /// Appends one common-value + difflist record to this builder.
+    ///
+    /// Gated by `needs_phase`: the fused decode validates the record's phase
+    /// track but discards its orientation, which `GT` needs.
+    fn append_common_difflist(
+        &mut self,
+        common: u8,
+        patches: &[(usize, u8)],
+        sample_count: usize,
+    ) -> Result<()> {
+        match self {
+            Self::Ds(builder) => {
+                builder.append_common_difflist(common, patches, sample_count);
+                Ok(())
+            }
+            Self::AltCount(builder) => {
+                builder.append_common_difflist(common, patches, sample_count);
+                Ok(())
+            }
+            Self::Gt(_) => Err(DataFusionError::Execution(
+                "PGEN GT projection cannot use the fused common-value decode".to_string(),
+            )),
+        }
+    }
+
     /// Decodes one dense biallelic record directly into this builder.
     ///
     /// `GT` needs the phase pattern, so it goes through the quad callback.
@@ -1004,6 +1058,9 @@ impl FastFieldBuilder {
     }
 }
 
+/// The internal biallelic GT code for a missing call.
+const MISSING_CODE: u8 = 3;
+
 /// ALT allele count for an internal biallelic GT code.
 ///
 /// Codes are 0=`(0,0)`, 1=`(0,1)`, 2=`(1,1)`, 3=missing, 4=`(1,0)`, so the
@@ -1013,6 +1070,44 @@ impl FastFieldBuilder {
 #[inline]
 fn alt_count_from_code(code: u8) -> i8 {
     (code - 3 * u8::from(code >= 3)) as i8
+}
+
+/// ALT dosage for an internal biallelic GT code.
+///
+/// A missing call yields `0.0`; the validity bitmap is what records it, and the
+/// value is never read back.
+#[inline]
+fn dosage_from_code(code: u8) -> f32 {
+    f32::from(alt_count_from_code(code))
+}
+
+/// Validity for a common category plus its sparse patches.
+///
+/// Appends one run for the whole variant and then touches only the samples whose
+/// validity differs from the common category's, so the bitmap work is
+/// proportional to the difflist rather than to the sample count.
+fn append_common_difflist_validity(
+    validity: &mut PackedValidityBuilder,
+    common: u8,
+    patches: &[(usize, u8)],
+    sample_count: usize,
+) {
+    let start = validity.len;
+    if common == MISSING_CODE {
+        validity.append_all_invalid(sample_count);
+        for &(sample, value) in patches {
+            if value != MISSING_CODE {
+                validity.set_valid(start + sample);
+            }
+        }
+    } else {
+        validity.append_all_valid(sample_count);
+        for &(sample, value) in patches {
+            if value == MISSING_CODE {
+                validity.set_invalid(start + sample);
+            }
+        }
+    }
 }
 
 struct PackedValidityBuilder {
@@ -1106,6 +1201,41 @@ impl PackedValidityBuilder {
         if remaining != 0 {
             self.bytes.push((1_u8 << remaining) - 1);
             self.len += remaining;
+        }
+    }
+
+    /// Appends `count` null entries at once.
+    ///
+    /// The mirror of `append_all_valid`, for a variant whose common category is
+    /// the missing one.
+    fn append_all_invalid(&mut self, count: usize) {
+        let len = self.len + count;
+        self.bytes.resize(len.div_ceil(8), 0);
+        self.len = len;
+        self.null_count += count;
+    }
+
+    /// Marks an already-appended entry valid.
+    #[inline]
+    fn set_valid(&mut self, index: usize) {
+        debug_assert!(index < self.len);
+        let mask = 1_u8 << (index % 8);
+        let byte = &mut self.bytes[index / 8];
+        if *byte & mask == 0 {
+            *byte |= mask;
+            self.null_count -= 1;
+        }
+    }
+
+    /// Marks an already-appended entry null.
+    #[inline]
+    fn set_invalid(&mut self, index: usize) {
+        debug_assert!(index < self.len);
+        let mask = 1_u8 << (index % 8);
+        let byte = &mut self.bytes[index / 8];
+        if *byte & mask != 0 {
+            *byte &= !mask;
+            self.null_count += 1;
         }
     }
 
@@ -1224,12 +1354,36 @@ fn execute_single_field(
                     && !retain_main
                     && supports_biallelic_gt_fast_path(record.record_type, allele_count)
                     && (fileset.mode == PgenMode::Plink1 || record.record_type & 7 == 0);
+                // Most of a plink2 fileset is a common category plus a sparse
+                // difflist, which a field needing no phase orientation can build
+                // in one pass. A record that a later LD record uses as its base
+                // is excluded: that needs the full main track anyway.
+                let fused_common_difflist = !batch.needs_phase()
+                    && workspace.has_identity_selection()
+                    && !retain_main
+                    && supports_biallelic_gt_fast_path(record.record_type, allele_count)
+                    && supports_common_difflist_fast_path(fileset.mode, record.record_type);
                 if direct_dense {
                     batch.append_dense_record(
                         payload,
                         fileset.mode,
                         record.record_type,
                         variant_index,
+                        fileset.sample_count,
+                    )?;
+                    batch.finish_variant(variant_index);
+                } else if fused_common_difflist {
+                    let common = decode_common_difflist_into(
+                        &mut workspace,
+                        payload,
+                        fileset.mode,
+                        record.record_type,
+                        variant_index,
+                        fileset.sample_count,
+                    )?;
+                    batch.append_common_difflist(
+                        common,
+                        workspace.patches(),
                         fileset.sample_count,
                     )?;
                     batch.finish_variant(variant_index);
@@ -1744,7 +1898,14 @@ fn build_hds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef
 
 #[cfg(test)]
 mod tests {
-    use super::{estimate_genotype_bytes, initial_batch_row_capacity};
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+
+    use super::{
+        AltCountBatchBuilder, DsBatchBuilder, PackedValidityBuilder, estimate_genotype_bytes,
+        initial_batch_row_capacity,
+    };
 
     #[test]
     fn bounds_gt_builder_capacity_by_the_soft_byte_budget() {
@@ -1761,6 +1922,149 @@ mod tests {
         assert_eq!(
             initial_batch_row_capacity(8192, 3, 64 * 1024 * 1024, estimated_row_bytes),
             3
+        );
+    }
+
+    fn single_field_schema(field: &str, value_type: DataType) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(
+            "genotypes",
+            DataType::Struct(
+                vec![Field::new(
+                    field,
+                    DataType::List(Arc::new(Field::new("sample", value_type, true))),
+                    false,
+                )]
+                .into(),
+            ),
+            false,
+        )]))
+    }
+
+    /// The per-sample codes a common category and its patches stand for.
+    fn expand(common: u8, patches: &[(usize, u8)], sample_count: usize) -> Vec<u8> {
+        let mut codes = vec![common; sample_count];
+        for &(sample, value) in patches {
+            codes[sample] = value;
+        }
+        codes
+    }
+
+    struct Case {
+        common: u8,
+        patches: Vec<(usize, u8)>,
+        samples: usize,
+    }
+
+    /// Cases chosen to exercise every way the fused fill and the two-pass
+    /// expansion could disagree: each common category, patches to and from the
+    /// missing category, an empty difflist, and sample counts that do and do not
+    /// end on a validity-byte boundary.
+    fn common_difflist_cases() -> Vec<Case> {
+        [
+            (0, vec![], 16),
+            (0, vec![(0, 2), (5, 1), (15, 2)], 16),
+            (0, vec![(3, 3)], 16),
+            (0, vec![(2, 1), (9, 3), (10, 3)], 13),
+            (2, vec![], 13),
+            (2, vec![(0, 3), (12, 0)], 13),
+            (3, vec![], 16),
+            (3, vec![(1, 1), (4, 2), (11, 0)], 13),
+            (3, vec![(0, 3)], 5),
+            (0, vec![(0, 1)], 1),
+        ]
+        .into_iter()
+        .map(|(common, patches, samples)| Case {
+            common,
+            patches,
+            samples,
+        })
+        .collect()
+    }
+
+    /// Arrow reads the bitmap, its length and its null count, so all three have
+    /// to match — a bitmap that agrees while the null count drifts still yields a
+    /// wrong array.
+    fn assert_same_validity(
+        fused: &PackedValidityBuilder,
+        expanded: &PackedValidityBuilder,
+        case: &str,
+    ) {
+        assert_eq!(fused.bytes, expanded.bytes, "{case}");
+        assert_eq!(fused.len, expanded.len, "{case}");
+        assert_eq!(fused.null_count, expanded.null_count, "{case}");
+    }
+
+    #[test]
+    fn fused_dosage_fill_matches_the_two_pass_expansion() {
+        let schema = single_field_schema("DS", DataType::Float32);
+        for case in common_difflist_cases() {
+            let Case {
+                common,
+                patches,
+                samples,
+            } = case;
+            let mut fused = DsBatchBuilder::new(&schema, 4, samples).unwrap();
+            let mut expanded = DsBatchBuilder::new(&schema, 4, samples).unwrap();
+            fused.append_common_difflist(common, &patches, samples);
+            fused.finish_variant(0);
+            expanded
+                .append_codes(0, &expand(common, &patches, samples))
+                .unwrap();
+
+            let case = format!("common {common}, patches {patches:?}, {samples} samples");
+            assert_eq!(fused.dosages, expanded.dosages, "{case}");
+            assert_same_validity(&fused.sample_validity, &expanded.sample_validity, &case);
+        }
+    }
+
+    #[test]
+    fn fused_allele_count_fill_matches_the_two_pass_expansion() {
+        let schema = single_field_schema("ALT_COUNT", DataType::Int8);
+        for case in common_difflist_cases() {
+            let Case {
+                common,
+                patches,
+                samples,
+            } = case;
+            let mut fused = AltCountBatchBuilder::new(&schema, 4, samples).unwrap();
+            let mut expanded = AltCountBatchBuilder::new(&schema, 4, samples).unwrap();
+            fused.append_common_difflist(common, &patches, samples);
+            fused.finish_variant(0);
+            expanded
+                .append_codes(0, &expand(common, &patches, samples))
+                .unwrap();
+
+            let case = format!("common {common}, patches {patches:?}, {samples} samples");
+            assert_eq!(fused.counts, expanded.counts, "{case}");
+            assert_same_validity(&fused.sample_validity, &expanded.sample_validity, &case);
+        }
+    }
+
+    /// Variants are appended back to back, so a fused fill has to land on
+    /// whatever bit offset the previous ones left the validity bitmap at.
+    #[test]
+    fn fused_fill_matches_the_two_pass_expansion_across_consecutive_variants() {
+        let samples = 13;
+        let schema = single_field_schema("DS", DataType::Float32);
+        let mut fused = DsBatchBuilder::new(&schema, 16, samples).unwrap();
+        let mut expanded = DsBatchBuilder::new(&schema, 16, samples).unwrap();
+        for (variant, case) in common_difflist_cases().into_iter().enumerate() {
+            let patches = case
+                .patches
+                .into_iter()
+                .filter(|&(sample, _)| sample < samples)
+                .collect::<Vec<_>>();
+            fused.append_common_difflist(case.common, &patches, samples);
+            fused.finish_variant(variant);
+            expanded
+                .append_codes(variant, &expand(case.common, &patches, samples))
+                .unwrap();
+        }
+        assert_eq!(fused.dosages, expanded.dosages);
+        assert_same_validity(
+            &fused.sample_validity,
+            &expanded.sample_validity,
+            "consecutive variants",
         );
     }
 }

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -1068,7 +1068,7 @@ const MISSING_CODE: u8 = 3;
 /// because a table index blocks vectorization of the surrounding loop, and
 /// this runs once per genotype cell.
 #[inline]
-fn alt_count_from_code(code: u8) -> i8 {
+pub(crate) fn alt_count_from_code(code: u8) -> i8 {
     (code - 3 * u8::from(code >= 3)) as i8
 }
 
@@ -1452,7 +1452,7 @@ fn execute_single_field(
     )))
 }
 
-fn record_payload(
+pub(crate) fn record_payload(
     range: ByteRange,
     bytes: &[u8],
     start: u64,

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use async_stream::try_stream;
 use datafusion::arrow::array::{
     ArrayRef, BooleanBuilder, FixedSizeListArray, FixedSizeListBuilder, Float32Array,
-    Float32Builder, ListArray, ListBuilder, StringArray, StringBuilder, StructArray, UInt16Array,
-    UInt16Builder, UInt64Array,
+    Float32Builder, Int8Array, ListArray, ListBuilder, StringArray, StringBuilder, StructArray,
+    UInt16Array, UInt16Builder, UInt64Array,
 };
 use datafusion::arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
 use datafusion::arrow::datatypes::{DataType, FieldRef, Fields, SchemaRef};
@@ -23,10 +23,11 @@ use datafusion_bio_format_core::genotype::{
 use datafusion_bio_format_core::range_planning::ByteRange;
 
 use crate::decode::{
-    DENSE_DOSAGE_QUADS, DENSE_DOSAGE_QUADS_PLINK1, DENSE_DOSAGE_VALIDITY,
-    DENSE_DOSAGE_VALIDITY_PLINK1, DecodedRecord, GenotypeProjection, GtDecodeWorkspace,
-    decode_biallelic_gt_into, decode_dense_biallelic_gt, decode_main_track_and_validate,
-    decode_record_and_main, supports_biallelic_gt_fast_path, validated_dense_hardcalls,
+    DENSE_ALT_COUNT_QUADS, DENSE_ALT_COUNT_QUADS_PLINK1, DENSE_DOSAGE_QUADS,
+    DENSE_DOSAGE_QUADS_PLINK1, DENSE_DOSAGE_VALIDITY, DENSE_DOSAGE_VALIDITY_PLINK1, DecodedRecord,
+    GenotypeProjection, GtDecodeWorkspace, decode_biallelic_gt_into, decode_dense_biallelic_gt,
+    decode_main_track_and_validate, decode_record_and_main, supports_biallelic_gt_fast_path,
+    validated_dense_hardcalls,
 };
 use crate::fileset::{PgenFileset, PgenMode};
 
@@ -197,7 +198,8 @@ impl ExecutionPlan for PgenExec {
         // path instead of going through the generic per-variant intermediates.
         if genotypes_projected
             && !assignment.ranges.is_empty()
-            && matches!(genotype_fields.as_slice(), [field] if field == "GT" || field == "DS")
+            && matches!(genotype_fields.as_slice(), [field]
+                if field == "GT" || field == "DS" || field == "ALT_COUNT")
         {
             return execute_single_field(
                 genotype_fields[0].clone(),
@@ -689,11 +691,168 @@ impl DsBatchBuilder {
     }
 }
 
+/// Batch builder for an `ALT_COUNT`-only projection.
+///
+/// Emits the hardcall ALT allele count as `Int8`, one byte per genotype cell
+/// rather than the four `DS` needs. On a whole chromosome that is 2.53 GB of
+/// output instead of 10.13 GB, and output width is the single largest term in
+/// this scan's cost: PLINK 2's own reader takes 0.827 s to produce the `int8`
+/// matrix and 1.853 s for the `float32` one from the same records.
+struct AltCountBatchBuilder {
+    variant_indices: Vec<usize>,
+    counts: Vec<i8>,
+    sample_validity: PackedValidityBuilder,
+    selected_sample_count: usize,
+    row_capacity: usize,
+    sample_field: FieldRef,
+}
+
+impl AltCountBatchBuilder {
+    fn new(schema: &SchemaRef, row_capacity: usize, selected_sample_count: usize) -> Result<Self> {
+        let genotype_field = schema.field_with_name("genotypes")?;
+        let DataType::Struct(children) = genotype_field.data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN genotypes field is not a struct".to_string(),
+            ));
+        };
+        if children.len() != 1 || children[0].name() != "ALT_COUNT" {
+            return Err(DataFusionError::Execution(
+                "PGEN ALT_COUNT fast path requires an exact ALT_COUNT-only projection".to_string(),
+            ));
+        }
+        let DataType::List(sample_field) = children[0].data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN ALT_COUNT field is not a list".to_string(),
+            ));
+        };
+        let cells = row_capacity.saturating_mul(selected_sample_count);
+        Ok(Self {
+            variant_indices: Vec::with_capacity(row_capacity),
+            counts: Vec::with_capacity(cells),
+            sample_validity: PackedValidityBuilder::new(cells),
+            selected_sample_count,
+            row_capacity,
+            sample_field: sample_field.clone(),
+        })
+    }
+
+    fn append(&mut self, variant_index: usize, calls: &[Option<[u16; 2]>]) {
+        for call in calls {
+            match call {
+                Some(call) => {
+                    let count = u8::from(call[0] == 1) + u8::from(call[1] == 1);
+                    self.counts.push(count as i8);
+                    self.sample_validity.append(true);
+                }
+                None => {
+                    self.counts.push(0);
+                    self.sample_validity.append(false);
+                }
+            }
+        }
+        self.variant_indices.push(variant_index);
+    }
+
+    fn append_codes(&mut self, variant_index: usize, codes: &[u8]) -> Result<()> {
+        const COUNT: [i8; 5] = [0, 1, 2, 0, 1];
+        if let Some(code) = codes.iter().copied().find(|&code| code > 4) {
+            return Err(DataFusionError::Execution(format!(
+                "invalid internal biallelic GT code {code}"
+            )));
+        }
+        self.counts.reserve(codes.len());
+        let mut present = true;
+        for &code in codes {
+            self.counts.push(COUNT[usize::from(code)]);
+            present &= code != 3;
+        }
+        if present {
+            self.sample_validity.append_all_valid(codes.len());
+        } else {
+            for chunk in codes.chunks(8) {
+                let mut bits = 0_u8;
+                for (index, &code) in chunk.iter().enumerate() {
+                    if code != 3 {
+                        bits |= 1 << index;
+                    }
+                }
+                self.sample_validity.append_packed(bits, chunk.len());
+            }
+        }
+        self.finish_variant(variant_index);
+        Ok(())
+    }
+
+    fn append_dense(&mut self, packed: &[u8], sample_count: usize, mode: PgenMode) {
+        let (quads, validity_of) = if mode == PgenMode::Plink1 {
+            (&DENSE_ALT_COUNT_QUADS_PLINK1, &DENSE_DOSAGE_VALIDITY_PLINK1)
+        } else {
+            (&DENSE_ALT_COUNT_QUADS, &DENSE_DOSAGE_VALIDITY)
+        };
+        let full_bytes = sample_count / 4;
+        self.counts.reserve(sample_count);
+        let mut all_present = true;
+        for &byte in &packed[..full_bytes] {
+            self.counts.extend_from_slice(&quads[usize::from(byte)]);
+            all_present &= validity_of[usize::from(byte)] == 0x0f;
+        }
+        let remainder = sample_count % 4;
+        if remainder != 0 {
+            let byte = packed[full_bytes];
+            self.counts
+                .extend_from_slice(&quads[usize::from(byte)][..remainder]);
+        }
+        if all_present && remainder == 0 {
+            self.sample_validity.append_all_valid(sample_count);
+        } else {
+            for &byte in &packed[..full_bytes] {
+                self.sample_validity
+                    .append_packed(validity_of[usize::from(byte)], 4);
+            }
+            if remainder != 0 {
+                let byte = packed[full_bytes];
+                self.sample_validity
+                    .append_packed(validity_of[usize::from(byte)], remainder);
+            }
+        }
+    }
+
+    fn finish_variant(&mut self, variant_index: usize) {
+        self.variant_indices.push(variant_index);
+    }
+
+    fn len(&self) -> usize {
+        self.variant_indices.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.variant_indices.is_empty()
+    }
+
+    fn finish(&mut self, fileset: &PgenFileset, schema: SchemaRef) -> Result<RecordBatch> {
+        let cells = self.row_capacity.saturating_mul(self.selected_sample_count);
+        let validity = self.sample_validity.finish();
+        let counts = std::mem::replace(&mut self.counts, Vec::with_capacity(cells));
+        self.sample_validity = PackedValidityBuilder::new(cells);
+        let values = Arc::new(Int8Array::new(counts.into(), validity)) as ArrayRef;
+        let alt_count = Arc::new(ListArray::new(
+            self.sample_field.clone(),
+            OffsetBuffer::from_repeated_length(self.selected_sample_count, self.len()),
+            values,
+            None,
+        )) as ArrayRef;
+        let batch = build_gt_batch(fileset, schema, &self.variant_indices, alt_count)?;
+        self.variant_indices.clear();
+        Ok(batch)
+    }
+}
+
 /// The single-field fast path builds either `GT` or `DS`; the surrounding scan
 /// loop is identical, so it is shared rather than duplicated.
 enum FastFieldBuilder {
     Gt(GtBatchBuilder),
     Ds(DsBatchBuilder),
+    AltCount(AltCountBatchBuilder),
 }
 
 impl FastFieldBuilder {
@@ -714,6 +873,11 @@ impl FastFieldBuilder {
                 row_capacity,
                 selected_sample_count,
             )?)),
+            "ALT_COUNT" => Ok(Self::AltCount(AltCountBatchBuilder::new(
+                schema,
+                row_capacity,
+                selected_sample_count,
+            )?)),
             other => Err(DataFusionError::Execution(format!(
                 "PGEN fast path does not support genotype field {other}"
             ))),
@@ -724,6 +888,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(builder) => builder.append(variant_index, &decoded.gt),
             Self::Ds(builder) => builder.append(variant_index, &decoded.ds),
+            Self::AltCount(builder) => builder.append(variant_index, &decoded.gt),
         }
     }
 
@@ -740,6 +905,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(_) => GenotypeProjection::gt_only(),
             Self::Ds(_) => GenotypeProjection::from_fields(&["DS".to_string()]),
+            Self::AltCount(_) => GenotypeProjection::alt_count_only(),
         }
     }
 
@@ -747,6 +913,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(builder) => builder.append_codes(variant_index, codes),
             Self::Ds(builder) => builder.append_codes(variant_index, codes),
+            Self::AltCount(builder) => builder.append_codes(variant_index, codes),
         }
     }
 
@@ -772,6 +939,17 @@ impl FastFieldBuilder {
                 sample_count,
                 |alleles, validity, samples| builder.append_chunk(alleles, validity, samples),
             ),
+            Self::AltCount(builder) => {
+                let packed = validated_dense_hardcalls(
+                    payload,
+                    mode,
+                    record_type,
+                    variant_index,
+                    sample_count,
+                )?;
+                builder.append_dense(packed, sample_count, mode);
+                Ok(())
+            }
             Self::Ds(builder) => {
                 let packed = validated_dense_hardcalls(
                     payload,
@@ -790,6 +968,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(builder) => builder.finish_variant(variant_index),
             Self::Ds(builder) => builder.finish_variant(variant_index),
+            Self::AltCount(builder) => builder.finish_variant(variant_index),
         }
     }
 
@@ -797,6 +976,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(builder) => builder.len(),
             Self::Ds(builder) => builder.len(),
+            Self::AltCount(builder) => builder.len(),
         }
     }
 
@@ -804,6 +984,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(builder) => builder.is_empty(),
             Self::Ds(builder) => builder.is_empty(),
+            Self::AltCount(builder) => builder.is_empty(),
         }
     }
 
@@ -811,6 +992,7 @@ impl FastFieldBuilder {
         match self {
             Self::Gt(builder) => builder.finish(fileset, schema),
             Self::Ds(builder) => builder.finish(fileset, schema),
+            Self::AltCount(builder) => builder.finish(fileset, schema),
         }
     }
 }
@@ -1317,6 +1499,7 @@ fn build_genotype_array(
         .map(|(name, field)| match name.as_str() {
             "GT" => build_gt_array(field.data_type(), rows),
             "PHASED" => build_phased_array(field.data_type(), rows),
+            "ALT_COUNT" => build_alt_count_array(field.data_type(), rows),
             "DS" => build_ds_array(field.data_type(), rows),
             "DS_STORED" => build_ds_stored_array(field.data_type(), rows),
             "HDS" => build_hds_array(field.data_type(), rows),
@@ -1381,6 +1564,62 @@ fn build_phased_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<Array
         builder.append(true);
     }
     Ok(Arc::new(builder.finish()))
+}
+
+/// Builds the `ALT_COUNT` child: the hardcall ALT allele count as `Int8`.
+///
+/// One byte per genotype cell rather than the four `DS` uses. Derived from the
+/// hardcall calls, not the dosage track, so a fractional stored dosage is never
+/// silently rounded into a count.
+fn build_alt_count_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {
+    let DataType::List(sample_field) = data_type else {
+        return Err(DataFusionError::Execution(
+            "PGEN ALT_COUNT field is not a list".to_string(),
+        ));
+    };
+    let sample_count = match rows.first() {
+        Some(row) => {
+            let decoded = row.genotypes.as_ref().ok_or_else(|| {
+                DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+            })?;
+            decoded.gt.len()
+        }
+        None => 0,
+    };
+    let total = rows.len().saturating_mul(sample_count);
+    let mut counts: Vec<i8> = Vec::with_capacity(total);
+    let mut validity = PackedValidityBuilder::new(total);
+    for row in rows {
+        let decoded = row.genotypes.as_ref().ok_or_else(|| {
+            DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+        })?;
+        if decoded.gt.len() != sample_count {
+            return Err(DataFusionError::Execution(format!(
+                "PGEN ALT_COUNT row has {} samples; expected {sample_count}",
+                decoded.gt.len()
+            )));
+        }
+        for call in &decoded.gt {
+            match call {
+                Some(call) => {
+                    counts.push((u8::from(call[0] == 1) + u8::from(call[1] == 1)) as i8);
+                    validity.append(true);
+                }
+                None => {
+                    counts.push(0);
+                    validity.append(false);
+                }
+            }
+        }
+    }
+    let nulls = validity.finish();
+    let values = Arc::new(Int8Array::new(counts.into(), nulls)) as ArrayRef;
+    Ok(Arc::new(ListArray::new(
+        sample_field.clone(),
+        OffsetBuffer::from_repeated_length(sample_count, rows.len()),
+        values,
+        None,
+    )))
 }
 
 fn build_ds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -584,19 +584,23 @@ impl DsBatchBuilder {
         // at a time. This is the path almost every record takes: plink2 writes
         // LD-compressed records, which are not eligible for the dense decode,
         // so this runs once per genotype cell across a whole scan.
-        const DOSAGE: [f32; 5] = [0.0, 1.0, 2.0, 0.0, 1.0];
         if let Some(code) = codes.iter().copied().find(|&code| code > 4) {
             return Err(DataFusionError::Execution(format!(
                 "invalid internal biallelic GT code {code}"
             )));
         }
 
-        self.dosages.reserve(codes.len());
-        let mut present = true;
-        for &code in codes {
-            self.dosages.push(DOSAGE[usize::from(code)]);
-            present &= code != 3;
+        // Written as a slice-to-slice loop over plain arithmetic rather than a
+        // table lookup and `Vec::push`, so LLVM can vectorize it: the per-push
+        // capacity check and the indexed table both block that. `alt_dosage`
+        // is branchless, so this compiles to a NEON/SSE2 widening loop.
+        let start = self.dosages.len();
+        self.dosages.resize(start + codes.len(), 0.0);
+        let output = &mut self.dosages[start..];
+        for (slot, &code) in output.iter_mut().zip(codes) {
+            *slot = f32::from(alt_count_from_code(code));
         }
+        let present = !codes.contains(&3);
 
         if present {
             // A variant with no missing call is the common case in a dense
@@ -754,18 +758,21 @@ impl AltCountBatchBuilder {
     }
 
     fn append_codes(&mut self, variant_index: usize, codes: &[u8]) -> Result<()> {
-        const COUNT: [i8; 5] = [0, 1, 2, 0, 1];
         if let Some(code) = codes.iter().copied().find(|&code| code > 4) {
             return Err(DataFusionError::Execution(format!(
                 "invalid internal biallelic GT code {code}"
             )));
         }
-        self.counts.reserve(codes.len());
-        let mut present = true;
-        for &code in codes {
-            self.counts.push(COUNT[usize::from(code)]);
-            present &= code != 3;
+        // Same shape as the DS path: a slice-to-slice loop over branchless
+        // arithmetic, which vectorizes. int8 output means one lane per byte,
+        // so this is the widest of the expansion loops.
+        let start = self.counts.len();
+        self.counts.resize(start + codes.len(), 0);
+        let output = &mut self.counts[start..];
+        for (slot, &code) in output.iter_mut().zip(codes) {
+            *slot = alt_count_from_code(code);
         }
+        let present = !codes.contains(&3);
         if present {
             self.sample_validity.append_all_valid(codes.len());
         } else {
@@ -995,6 +1002,17 @@ impl FastFieldBuilder {
             Self::AltCount(builder) => builder.finish(fileset, schema),
         }
     }
+}
+
+/// ALT allele count for an internal biallelic GT code.
+///
+/// Codes are 0=`(0,0)`, 1=`(0,1)`, 2=`(1,1)`, 3=missing, 4=`(1,0)`, so the
+/// count is 0, 1, 2, 0, 1. Expressed as arithmetic rather than a lookup table
+/// because a table index blocks vectorization of the surrounding loop, and
+/// this runs once per genotype cell.
+#[inline]
+fn alt_count_from_code(code: u8) -> i8 {
+    (code - 3 * u8::from(code >= 3)) as i8
 }
 
 struct PackedValidityBuilder {

--- a/datafusion/bio-format-pgen/src/physical_exec.rs
+++ b/datafusion/bio-format-pgen/src/physical_exec.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanBuilder, FixedSizeListArray, FixedSizeListBuilder, Float32Builder, ListArray,
-    ListBuilder, StringArray, StringBuilder, StructArray, UInt16Array, UInt16Builder, UInt64Array,
+    ArrayRef, BooleanBuilder, FixedSizeListArray, FixedSizeListBuilder, Float32Array,
+    Float32Builder, ListArray, ListBuilder, StringArray, StringBuilder, StructArray, UInt16Array,
+    UInt16Builder, UInt64Array,
 };
 use datafusion::arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
 use datafusion::arrow::datatypes::{DataType, FieldRef, Fields, SchemaRef};
@@ -190,11 +191,22 @@ impl ExecutionPlan for PgenExec {
         let genotype_projection = GenotypeProjection::from_fields(&genotype_fields);
         let genotypes_projected = schema.index_of("genotypes").is_ok();
 
+        // GT and DS both reduce to one value per sample per variant, so both
+        // can be decoded straight into their Arrow buffers by the shared fast
+        // path instead of going through the generic per-variant intermediates.
         if genotypes_projected
             && !assignment.ranges.is_empty()
-            && genotype_fields.as_slice() == ["GT"]
+            && matches!(genotype_fields.as_slice(), [field] if field == "GT" || field == "DS")
         {
-            return execute_gt_only(assignment, fileset, schema, metrics, max_rows, soft_bytes);
+            return execute_single_field(
+                genotype_fields[0].clone(),
+                assignment,
+                fileset,
+                schema,
+                metrics,
+                max_rows,
+                soft_bytes,
+            );
         }
 
         let stream_schema = schema.clone();
@@ -499,6 +511,226 @@ impl GtBatchBuilder {
     }
 }
 
+/// Batch builder for a `DS`-only projection.
+///
+/// Mirrors `GtBatchBuilder`: the decoder writes dosages straight into the Arrow
+/// values buffer and a packed validity bitmap, so a `DS` scan never allocates
+/// the per-variant `Vec<Option<f32>>` the generic path builds. That vector is
+/// eight bytes per genotype cell and one allocation per variant, which on a
+/// whole chromosome is the dominant single-core cost.
+struct DsBatchBuilder {
+    variant_indices: Vec<usize>,
+    dosages: Vec<f32>,
+    sample_validity: PackedValidityBuilder,
+    selected_sample_count: usize,
+    row_capacity: usize,
+    sample_field: FieldRef,
+}
+
+impl DsBatchBuilder {
+    fn new(schema: &SchemaRef, row_capacity: usize, selected_sample_count: usize) -> Result<Self> {
+        let genotype_field = schema.field_with_name("genotypes")?;
+        let DataType::Struct(children) = genotype_field.data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN genotypes field is not a struct".to_string(),
+            ));
+        };
+        if children.len() != 1 || children[0].name() != "DS" {
+            return Err(DataFusionError::Execution(
+                "PGEN DS fast path requires an exact DS-only genotype projection".to_string(),
+            ));
+        }
+        let DataType::List(sample_field) = children[0].data_type() else {
+            return Err(DataFusionError::Execution(
+                "PGEN DS field is not a list".to_string(),
+            ));
+        };
+        let cells = row_capacity.saturating_mul(selected_sample_count);
+        Ok(Self {
+            variant_indices: Vec::with_capacity(row_capacity),
+            dosages: Vec::with_capacity(cells),
+            sample_validity: PackedValidityBuilder::new(cells),
+            selected_sample_count,
+            row_capacity,
+            sample_field: sample_field.clone(),
+        })
+    }
+
+    #[inline]
+    fn alt1_dosage(left: u16, right: u16) -> f32 {
+        f32::from(u8::from(left == 1) + u8::from(right == 1))
+    }
+
+    /// Appends decoded dosages. These must come from the record's dosage
+    /// track when it has one — deriving them from hardcalls would silently
+    /// replace a fractional dosage such as 0.125 with an allele count.
+    fn append(&mut self, variant_index: usize, dosages: &[Option<f32>]) {
+        for dosage in dosages {
+            match dosage {
+                Some(dosage) => {
+                    self.dosages.push(*dosage);
+                    self.sample_validity.append(true);
+                }
+                None => {
+                    self.dosages.push(0.0);
+                    self.sample_validity.append(false);
+                }
+            }
+        }
+        self.variant_indices.push(variant_index);
+    }
+
+    fn append_codes(&mut self, variant_index: usize, codes: &[u8]) -> Result<()> {
+        for &code in codes {
+            let (dosage, valid) = match code {
+                0 => (0.0, true),
+                1 => (1.0, true),
+                2 => (2.0, true),
+                3 => (0.0, false),
+                4 => (1.0, true),
+                _ => {
+                    return Err(DataFusionError::Execution(format!(
+                        "invalid internal biallelic GT code {code}"
+                    )));
+                }
+            };
+            self.dosages.push(dosage);
+            self.sample_validity.append(valid);
+        }
+        self.finish_variant(variant_index);
+        Ok(())
+    }
+
+    #[inline]
+    fn append_chunk(&mut self, alleles: &[u16], validity: u8, sample_count: usize) {
+        for sample in 0..sample_count {
+            let left = alleles[sample * 2];
+            let right = alleles[sample * 2 + 1];
+            self.dosages.push(Self::alt1_dosage(left, right));
+        }
+        self.sample_validity.append_packed(validity, sample_count);
+    }
+
+    fn finish_variant(&mut self, variant_index: usize) {
+        self.variant_indices.push(variant_index);
+    }
+
+    fn len(&self) -> usize {
+        self.variant_indices.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.variant_indices.is_empty()
+    }
+
+    fn finish(&mut self, fileset: &PgenFileset, schema: SchemaRef) -> Result<RecordBatch> {
+        let cells = self.row_capacity.saturating_mul(self.selected_sample_count);
+        let validity = self.sample_validity.finish();
+        let dosages = std::mem::replace(&mut self.dosages, Vec::with_capacity(cells));
+        self.sample_validity = PackedValidityBuilder::new(cells);
+        let values = Arc::new(Float32Array::new(dosages.into(), validity)) as ArrayRef;
+        let ds = Arc::new(ListArray::new(
+            self.sample_field.clone(),
+            OffsetBuffer::from_repeated_length(self.selected_sample_count, self.len()),
+            values,
+            None,
+        )) as ArrayRef;
+        let batch = build_gt_batch(fileset, schema, &self.variant_indices, ds)?;
+        self.variant_indices.clear();
+        Ok(batch)
+    }
+}
+
+/// The single-field fast path builds either `GT` or `DS`; the surrounding scan
+/// loop is identical, so it is shared rather than duplicated.
+enum FastFieldBuilder {
+    Gt(GtBatchBuilder),
+    Ds(DsBatchBuilder),
+}
+
+impl FastFieldBuilder {
+    fn new(
+        field: &str,
+        schema: &SchemaRef,
+        row_capacity: usize,
+        selected_sample_count: usize,
+    ) -> Result<Self> {
+        match field {
+            "GT" => Ok(Self::Gt(GtBatchBuilder::new(
+                schema,
+                row_capacity,
+                selected_sample_count,
+            )?)),
+            "DS" => Ok(Self::Ds(DsBatchBuilder::new(
+                schema,
+                row_capacity,
+                selected_sample_count,
+            )?)),
+            other => Err(DataFusionError::Execution(format!(
+                "PGEN fast path does not support genotype field {other}"
+            ))),
+        }
+    }
+
+    fn append(&mut self, variant_index: usize, decoded: &DecodedRecord) {
+        match self {
+            Self::Gt(builder) => builder.append(variant_index, &decoded.gt),
+            Self::Ds(builder) => builder.append(variant_index, &decoded.ds),
+        }
+    }
+
+    /// The projection the generic fallback must decode for this field.
+    fn projection(&self) -> GenotypeProjection {
+        match self {
+            Self::Gt(_) => GenotypeProjection::gt_only(),
+            Self::Ds(_) => GenotypeProjection::from_fields(&["DS".to_string()]),
+        }
+    }
+
+    fn append_codes(&mut self, variant_index: usize, codes: &[u8]) -> Result<()> {
+        match self {
+            Self::Gt(builder) => builder.append_codes(variant_index, codes),
+            Self::Ds(builder) => builder.append_codes(variant_index, codes),
+        }
+    }
+
+    #[inline]
+    fn append_chunk(&mut self, alleles: &[u16], validity: u8, sample_count: usize) {
+        match self {
+            Self::Gt(builder) => builder.append_chunk(alleles, validity, sample_count),
+            Self::Ds(builder) => builder.append_chunk(alleles, validity, sample_count),
+        }
+    }
+
+    fn finish_variant(&mut self, variant_index: usize) {
+        match self {
+            Self::Gt(builder) => builder.finish_variant(variant_index),
+            Self::Ds(builder) => builder.finish_variant(variant_index),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Gt(builder) => builder.len(),
+            Self::Ds(builder) => builder.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Gt(builder) => builder.is_empty(),
+            Self::Ds(builder) => builder.is_empty(),
+        }
+    }
+
+    fn finish(&mut self, fileset: &PgenFileset, schema: SchemaRef) -> Result<RecordBatch> {
+        match self {
+            Self::Gt(builder) => builder.finish(fileset, schema),
+            Self::Ds(builder) => builder.finish(fileset, schema),
+        }
+    }
+}
+
 struct PackedValidityBuilder {
     bytes: Vec<u8>,
     len: usize,
@@ -575,7 +807,8 @@ impl PackedValidityBuilder {
     }
 }
 
-fn execute_gt_only(
+fn execute_single_field(
+    field: String,
     assignment: PgenPartition,
     fileset: Arc<PgenFileset>,
     schema: SchemaRef,
@@ -596,7 +829,7 @@ fn execute_gt_only(
             estimated_row_bytes,
         );
         let mut batch =
-            GtBatchBuilder::new(&schema, partition_row_capacity, selected_sample_count)?;
+            FastFieldBuilder::new(&field, &schema, partition_row_capacity, selected_sample_count)?;
         let mut workspace = GtDecodeWorkspace::new(fileset.sample_count, selected_samples)?;
 
         let owned = assignment.owned();
@@ -609,7 +842,7 @@ fn execute_gt_only(
         let mut ld_base_index = None;
         let mut ld_base = Vec::with_capacity(fileset.sample_count);
         let mut required = assignment.required().peekable();
-        let genotype_projection = GenotypeProjection::gt_only();
+        let genotype_projection = batch.projection();
         let mut range_reader = fileset.source.range_reader(&fileset.pgen_path).await?;
 
         for range in assignment.ranges.iter().copied() {
@@ -719,7 +952,7 @@ fn execute_gt_only(
                         selected_samples,
                         base,
                     )?;
-                    batch.append(variant_index, &decoded.gt);
+                    batch.append(variant_index, &decoded);
                     if retained_bases.contains(&variant_index) {
                         ld_base = main;
                         ld_base_index = Some(variant_index);
@@ -1058,17 +1291,55 @@ fn build_float_sample_array<'a>(
             "PGEN {name} field is not a list"
         )));
     };
-    let mut builder = ListBuilder::new(Float32Builder::new()).with_field(sample_field.clone());
+    // Every emitted row carries the same selected-sample count, so the values
+    // buffer size is known up front and the offsets are a repeated length.
+    // Building the values and validity buffers directly avoids a per-cell
+    // `append_option`, whose capacity check and bitmap bookkeeping dominated
+    // this function: at whole-chromosome scale it runs billions of times.
+    let sample_count = match rows.first() {
+        Some(row) => {
+            let decoded = row.genotypes.as_ref().ok_or_else(|| {
+                DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
+            })?;
+            values(decoded).len()
+        }
+        None => 0,
+    };
+    let total = rows.len().saturating_mul(sample_count);
+    let mut sample_values: Vec<f32> = Vec::with_capacity(total);
+    let mut sample_validity = PackedValidityBuilder::new(total);
     for row in rows {
         let decoded = row.genotypes.as_ref().ok_or_else(|| {
             DataFusionError::Execution("PGEN genotype row was not decoded".to_string())
         })?;
-        for value in values(decoded) {
-            builder.values().append_option(*value);
+        let row_values = values(decoded);
+        if row_values.len() != sample_count {
+            return Err(DataFusionError::Execution(format!(
+                "PGEN {name} row has {} samples; expected {sample_count}",
+                row_values.len()
+            )));
         }
-        builder.append(true);
+        for value in row_values {
+            match value {
+                Some(value) => {
+                    sample_values.push(*value);
+                    sample_validity.append(true);
+                }
+                None => {
+                    sample_values.push(0.0);
+                    sample_validity.append(false);
+                }
+            }
+        }
     }
-    Ok(Arc::new(builder.finish()))
+    let nulls = sample_validity.finish();
+    let values_array = Arc::new(Float32Array::new(sample_values.into(), nulls)) as ArrayRef;
+    Ok(Arc::new(ListArray::new(
+        sample_field.clone(),
+        OffsetBuffer::from_repeated_length(sample_count, rows.len()),
+        values_array,
+        None,
+    )))
 }
 
 fn build_hds_array(data_type: &DataType, rows: &[DecodedRow]) -> Result<ArrayRef> {

--- a/datafusion/bio-format-pgen/src/source.rs
+++ b/datafusion/bio-format-pgen/src/source.rs
@@ -175,6 +175,17 @@ impl ObjectRangeReader {
         }
     }
 
+    /// The bytes of the most recent [`Self::read_range`].
+    ///
+    /// Lets a caller hand the loaded range to a decoder without copying it out,
+    /// and lets the reader's buffer be reused for the next range.
+    pub(crate) fn bytes(&self) -> &[u8] {
+        match self {
+            Self::Local { buffer, .. } => buffer,
+            Self::Remote { buffer, .. } => buffer,
+        }
+    }
+
     fn into_bytes(self) -> Bytes {
         match self {
             Self::Local { buffer, .. } => Bytes::from(buffer),

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -531,7 +531,7 @@ fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> Result
     }
 }
 
-fn plan_payload_partitions(
+pub(crate) fn plan_payload_partitions(
     selected: Arc<Vec<usize>>,
     fileset: &PgenFileset,
     target_partitions: usize,

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -496,6 +496,18 @@ fn build_schema(
                 "bio.pgen.specification_baseline".to_string(),
                 PGEN_SPEC_BASELINE.to_string(),
             ),
+            // The output shape, known from the companions at registration and
+            // exposed so a caller can allocate its destination before scanning.
+            // Assembling a genotype matrix without this means either growing a
+            // multi-gigabyte buffer or holding every batch to count rows first.
+            (
+                "bio.pgen.variant_count".to_string(),
+                fileset.variants.len().to_string(),
+            ),
+            (
+                "bio.pgen.selected_sample_count".to_string(),
+                fileset.selected_samples.source_indices().len().to_string(),
+            ),
         ]),
     )))
 }

--- a/datafusion/bio-format-pgen/src/table_provider.rs
+++ b/datafusion/bio-format-pgen/src/table_provider.rs
@@ -119,7 +119,7 @@ impl PgenTableProvider {
     /// Opens and validates a local or remote PGEN/PVAR/PSAM fileset.
     pub async fn try_new(pgen_path: impl Into<String>, options: PgenReadOptions) -> Result<Self> {
         validate_options(&options)?;
-        let available = ["GT", "PHASED", "DS", "DS_STORED", "HDS"]
+        let available = ["GT", "ALT_COUNT", "PHASED", "DS", "DS_STORED", "HDS"]
             .into_iter()
             .map(str::to_string)
             .collect::<Vec<_>>();
@@ -359,6 +359,25 @@ fn build_schema(
                 (
                     GENOTYPE_ALLELE_ORDER_KEY.to_string(),
                     "PVAR REF=0, ALT source order=1..n".to_string(),
+                ),
+                (
+                    "bio.pgen.ploidy_semantics".to_string(),
+                    "encoded_diploid".to_string(),
+                ),
+            ])),
+            "ALT_COUNT" => Field::new(
+                "ALT_COUNT",
+                DataType::List(Arc::new(Field::new("sample", DataType::Int8, true))),
+                false,
+            )
+            .with_metadata(HashMap::from([
+                (
+                    GENOTYPE_OUTPUT_MODE_KEY.to_string(),
+                    "hardcall_allele_count".to_string(),
+                ),
+                (
+                    GENOTYPE_COUNTED_ALLELE_KEY.to_string(),
+                    "PVAR ALT allele index 1".to_string(),
                 ),
                 (
                     "bio.pgen.ploidy_semantics".to_string(),

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -1806,8 +1806,26 @@ async fn matrix_alt_count(
     threads: usize,
     samples: Option<Vec<String>>,
 ) -> Vec<i8> {
+    matrix_alt_count_in_ranges(
+        fixture,
+        threads,
+        samples,
+        PgenReadOptions::default().max_range_bytes,
+    )
+    .await
+}
+
+/// The same read with the range planner's byte budget pinned, so a test can
+/// choose how many rounds of input a partition is decoded from.
+async fn matrix_alt_count_in_ranges(
+    fixture: &Fixture,
+    threads: usize,
+    samples: Option<Vec<String>>,
+    max_range_bytes: u64,
+) -> Vec<i8> {
     let options = PgenReadOptions {
         samples,
+        max_range_bytes,
         ..Default::default()
     };
     let shape =
@@ -1873,6 +1891,27 @@ async fn matrix_path_matches_the_scan_on_every_record_representation() {
             expected,
             "threads {threads}"
         );
+    }
+}
+
+#[tokio::test]
+async fn matrix_path_decodes_the_same_matrix_across_many_byte_ranges() {
+    // The decoders keep their state — workspace, retained LD base, row cursor —
+    // between the ranges a partition is fed, because the input arrives a range
+    // at a time rather than all at once. A byte budget this small puts nearly
+    // every record in its own range, so an LD chain crosses rounds and a lost
+    // cursor shows up as shifted rows.
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+    let expected = matrix_alt_count(&fixture, 1, None).await;
+    for threads in [1, 2, 4, 8] {
+        for max_range_bytes in [1_u64, 8, 64] {
+            assert_eq!(
+                matrix_alt_count_in_ranges(&fixture, threads, None, max_range_bytes).await,
+                expected,
+                "threads {threads}, max_range_bytes {max_range_bytes}"
+            );
+        }
     }
 }
 

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -597,6 +597,23 @@ async fn decodes_all_fixed_width_and_plink1_modes() {
                     .map(String::as_str),
                 Some("encoded_diploid")
             );
+            // The output shape a caller allocates against. The sample count is
+            // the selected count, not the cohort's, so a subset scan does not
+            // over-allocate: this fixture holds 4 samples and selects 3.
+            assert_eq!(
+                schema
+                    .metadata()
+                    .get("bio.pgen.variant_count")
+                    .map(String::as_str),
+                Some("2")
+            );
+            assert_eq!(
+                schema
+                    .metadata()
+                    .get("bio.pgen.selected_sample_count")
+                    .map(String::as_str),
+                Some("3")
+            );
         }
         let context = context(1);
         context.register_table("p", Arc::new(provider)).unwrap();

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -1799,3 +1799,194 @@ np.testing.assert_array_equal(observed_unused_alt, unused_alt_alleles)
         vec![Some(0.125), Some(1.0), Some(1.875), None]
     );
 }
+
+/// Reads a genotype field through the matrix path.
+async fn matrix_alt_count(
+    fixture: &Fixture,
+    threads: usize,
+    samples: Option<Vec<String>>,
+) -> Vec<i8> {
+    let options = PgenReadOptions {
+        samples,
+        ..Default::default()
+    };
+    let shape =
+        datafusion_bio_format_pgen::matrix::genotype_matrix_shape(path(&fixture.pgen), &options)
+            .await
+            .unwrap();
+    let mut values = vec![0_i8; shape.variants * shape.samples];
+    datafusion_bio_format_pgen::matrix::read_genotype_matrix(
+        path(&fixture.pgen),
+        &options,
+        datafusion_bio_format_pgen::matrix::MatrixData::AltCount {
+            values: &mut values,
+            missing: -9,
+        },
+        threads,
+    )
+    .await
+    .unwrap();
+    values
+}
+
+#[tokio::test]
+async fn matrix_path_matches_the_scan_on_every_record_representation() {
+    // The same fixture the scan tests use: dense, one-bit, common-value with and
+    // without a phase track, LD-compressed, multiallelic, and a dosage track.
+    // Decoding into a caller's buffer takes different branches than building
+    // Arrow does, so agreement here is what says the branches agree.
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+
+    let provider = PgenTableProvider::try_new(
+        path(&fixture.pgen),
+        PgenReadOptions {
+            genotype_fields: Some(vec!["ALT_COUNT".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1);
+    context.register_table("p", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM p ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let expected = (0..batches[0].num_rows())
+        .flat_map(|row| {
+            alt_count_values(&batches[0], 0, row)
+                .into_iter()
+                .map(|value| value.unwrap_or(-9))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // Every partition count must give the same matrix: partitions own disjoint
+    // row ranges, and an off-by-one in that split would interleave variants.
+    for threads in [1, 2, 4, 8] {
+        assert_eq!(
+            matrix_alt_count(&fixture, threads, None).await,
+            expected,
+            "threads {threads}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn matrix_path_honours_sample_selection() {
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+    let all = matrix_alt_count(&fixture, 1, None).await;
+    let subset =
+        matrix_alt_count(&fixture, 1, Some(vec!["s3".to_string(), "s1".to_string()])).await;
+    assert_eq!(subset.len(), all.len() / 2);
+    for variant in 0..records_len(&all, 4) {
+        assert_eq!(
+            subset[variant * 2],
+            all[variant * 4 + 2],
+            "variant {variant}"
+        );
+        assert_eq!(
+            subset[variant * 2 + 1],
+            all[variant * 4],
+            "variant {variant}"
+        );
+    }
+}
+
+fn records_len(values: &[i8], samples: usize) -> usize {
+    values.len() / samples
+}
+
+#[tokio::test]
+async fn matrix_path_rejects_a_wrongly_sized_destination() {
+    let fixture = fixed_fixture(2);
+    let options = PgenReadOptions::default();
+    let mut values = vec![0_i8; 3];
+    let error = datafusion_bio_format_pgen::matrix::read_genotype_matrix(
+        path(&fixture.pgen),
+        &options,
+        datafusion_bio_format_pgen::matrix::MatrixData::AltCount {
+            values: &mut values,
+            missing: -9,
+        },
+        1,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("expected 8"), "{error}");
+}
+
+#[tokio::test]
+async fn matrix_path_keeps_fractional_dosages() {
+    // The general decoder is the only branch that sees a stored dosage track,
+    // and its values are genuinely fractional. An earlier draft of this path
+    // routed them through the internal-code mapping, which can only say 0, 1
+    // or 2 — every dosage came out as zero and every fast-path fixture still
+    // passed. This is the fixture that disagrees.
+    let (types, records, alleles) = variable_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+
+    let provider = PgenTableProvider::try_new(
+        path(&fixture.pgen),
+        PgenReadOptions {
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1);
+    context.register_table("d", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM d ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let expected = (0..batches[0].num_rows())
+        .flat_map(|row| {
+            ds_values(&batches[0], 0, row)
+                .into_iter()
+                .map(|value| value.unwrap_or(f32::NAN))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        expected.iter().any(|value| value.fract() != 0.0),
+        "fixture must carry a fractional dosage or this proves nothing"
+    );
+
+    let options = PgenReadOptions::default();
+    let shape =
+        datafusion_bio_format_pgen::matrix::genotype_matrix_shape(path(&fixture.pgen), &options)
+            .await
+            .unwrap();
+    for threads in [1, 4] {
+        let mut values = vec![0.0_f32; shape.variants * shape.samples];
+        datafusion_bio_format_pgen::matrix::read_genotype_matrix(
+            path(&fixture.pgen),
+            &options,
+            datafusion_bio_format_pgen::matrix::MatrixData::Dosage {
+                values: &mut values,
+                missing: f32::NAN,
+            },
+            threads,
+        )
+        .await
+        .unwrap();
+        for (index, (observed, want)) in values.iter().zip(&expected).enumerate() {
+            if want.is_nan() {
+                assert!(observed.is_nan(), "cell {index} threads {threads}");
+            } else {
+                assert_eq!(observed, want, "cell {index} threads {threads}");
+            }
+        }
+    }
+}

--- a/datafusion/bio-format-pgen/tests/provider_test.rs
+++ b/datafusion/bio-format-pgen/tests/provider_test.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use datafusion::arrow::array::{
-    Array, BooleanArray, FixedSizeListArray, Float32Array, ListArray, StringArray, StructArray,
-    UInt16Array,
+    Array, BooleanArray, FixedSizeListArray, Float32Array, Int8Array, ListArray, StringArray,
+    StructArray, UInt16Array,
 };
 use datafusion::catalog::TableProvider;
 use datafusion::logical_expr::{TableProviderFilterPushDown, col, lit};
@@ -521,6 +521,24 @@ fn float_sample_values(
         .collect()
 }
 
+fn alt_count_values(
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    column: usize,
+    row: usize,
+) -> Vec<Option<i8>> {
+    let values = genotype_struct(batch, column)
+        .column_by_name("ALT_COUNT")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(row);
+    let values = values.as_any().downcast_ref::<Int8Array>().unwrap();
+    (0..values.len())
+        .map(|index| (!values.is_null(index)).then(|| values.value(index)))
+        .collect()
+}
+
 fn hds_values(
     batch: &datafusion::arrow::record_batch::RecordBatch,
     column: usize,
@@ -778,6 +796,144 @@ async fn decodes_variable_representations_indexes_phase_dosage_and_patches() {
         gt_values(&batches[0], 0, 0),
         vec![Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), None]
     );
+}
+
+/// The common-value + difflist records, in the shapes the fused decode has to
+/// handle: every common category, an LD-compressed record whose base is one of
+/// them, and phase tracks in both the implicit and explicit forms.
+fn common_difflist_records() -> (Vec<u8>, Vec<Vec<u8>>, Vec<usize>) {
+    let records: Vec<(u8, Vec<u8>)> = vec![
+        // Common 0. Record 1 uses this as its LD base, so it must decode its
+        // whole main track rather than take the fused path.
+        (0x04, vec![1, 2, 2]),
+        // LD-compressed against record 0, patching sample 1 to missing.
+        (0x02, vec![1, 1, 3]),
+        // Common 2, with a patch to the missing category.
+        (0x06, vec![1, 3, 3]),
+        // Common 3 and an empty difflist: every call missing.
+        (0x07, vec![0]),
+        // Common 0, two patched heterozygotes, implicit phase track that flips
+        // sample 3 — an orientation GT keeps and the other fields discard.
+        (0x14, vec![2, 1, 5, 2, 0b0000_0100]),
+        // The same with an explicit phase-present bitarray, flipping sample 0.
+        (0x14, vec![2, 0, 5, 1, 0b0000_0011, 0b0000_0001]),
+        // Common 2 with one patched heterozygote, flipped.
+        (0x16, vec![1, 0, 1, 0b0000_0010]),
+        // Common 3 with a phase track, so the heterozygote count the track is
+        // sized by comes from the difflist and not from the common category.
+        (0x17, vec![2, 1, 9, 1, 0]),
+        // Common 0 again, this time not an LD base: the dominant record shape in
+        // a plink2 fileset, and the one the fused decode exists for.
+        (0x04, vec![1, 2, 2]),
+    ];
+    let allele_counts = vec![2; records.len()];
+    let (types, bodies) = records.into_iter().unzip();
+    (types, bodies, allele_counts)
+}
+
+#[tokio::test]
+async fn common_value_difflist_records_agree_across_every_genotype_field() {
+    let (types, records, alleles) = common_difflist_records();
+    let fixture = variable_fixture(0x10, &types, &records, &alleles);
+
+    // GT keeps the hardcall-phase orientation; ALT_COUNT and DS sum the two
+    // alleles, so they take the fused decode that validates the phase track
+    // without applying it. All three must describe the same calls.
+    let expected_gt = vec![
+        vec![
+            Some(vec![0, 0]),
+            Some(vec![0, 0]),
+            Some(vec![1, 1]),
+            Some(vec![0, 0]),
+        ],
+        vec![Some(vec![0, 0]), None, Some(vec![1, 1]), Some(vec![0, 0])],
+        vec![Some(vec![1, 1]), Some(vec![1, 1]), Some(vec![1, 1]), None],
+        vec![None, None, None, None],
+        vec![
+            Some(vec![0, 0]),
+            Some(vec![0, 1]),
+            Some(vec![0, 0]),
+            Some(vec![1, 0]),
+        ],
+        vec![
+            Some(vec![1, 0]),
+            Some(vec![0, 1]),
+            Some(vec![0, 0]),
+            Some(vec![0, 0]),
+        ],
+        vec![
+            Some(vec![1, 0]),
+            Some(vec![1, 1]),
+            Some(vec![1, 1]),
+            Some(vec![1, 1]),
+        ],
+        vec![None, Some(vec![0, 1]), Some(vec![1, 1]), None],
+        vec![
+            Some(vec![0, 0]),
+            Some(vec![0, 0]),
+            Some(vec![1, 1]),
+            Some(vec![0, 0]),
+        ],
+    ];
+    let expected_counts: Vec<Vec<Option<i8>>> = expected_gt
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|call| {
+                    call.as_ref()
+                        .map(|alleles| alleles.iter().filter(|&&allele| allele == 1).count() as i8)
+                })
+                .collect()
+        })
+        .collect();
+
+    for (field, partitions) in [("GT", 1), ("ALT_COUNT", 1), ("ALT_COUNT", 3), ("DS", 1)] {
+        let provider = PgenTableProvider::try_new(
+            path(&fixture.pgen),
+            PgenReadOptions {
+                genotype_fields: Some(vec![field.to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let query_context = context(partitions);
+        query_context
+            .register_table("p", Arc::new(provider))
+            .unwrap();
+        let batches = query_context
+            .sql("SELECT genotypes FROM p ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1, "{field} at {partitions} partitions");
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), expected_gt.len());
+        for row in 0..batch.num_rows() {
+            let case = format!("{field} at {partitions} partitions, row {row}");
+            match field {
+                "GT" => assert_eq!(gt_values(batch, 0, row), expected_gt[row], "{case}"),
+                "ALT_COUNT" => {
+                    assert_eq!(
+                        alt_count_values(batch, 0, row),
+                        expected_counts[row],
+                        "{case}"
+                    )
+                }
+                "DS" => assert_eq!(
+                    ds_values(batch, 0, row),
+                    expected_counts[row]
+                        .iter()
+                        .map(|count| count.map(f32::from))
+                        .collect::<Vec<_>>(),
+                    "{case}"
+                ),
+                other => panic!("unexpected field {other}"),
+            }
+        }
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

A whole-chromosome PGEN scan spent most of its time turning decoded genotypes into Arrow arrays rather than decoding them. This branch removes that overhead layer by layer, ending with a fused decode for the record type that dominates a `plink2 --make-pgen` fileset.

Benchmark throughout: chromosome 22 of 1000 Genomes, 993,881 variants × 2,548 samples = **2,532,408,788 genotypes**, single partition, release build with `-C target-cpu=native`.

The Rust-only scan, no Python and no materialization (`examples/pgen_ds_profile`):

| field | at branch point | now | |
|---|---:|---:|---:|
| `DS` (float32) | ~11.2 s | **1.19 s** | 9.4× |
| `ALT_COUNT` (int8) | — | **0.59 s** | new column |

## What changed

1. **Arrow values/validity buffers built directly** instead of a per-cell `ListBuilder::append_option`. Isolated bench: 352 → 860 Melem/s.
2. **`DS` joined the single-field fast path `GT` already had**, removing a per-variant `Vec<Option<f32>>` — eight bytes per cell and one allocation per variant.
3. **`append_codes` rewritten table-driven** with bulk validity.
4. **Hardcall phase orientation skipped for dosage projections.** A phased heterozygote and an unphased one carry the same dosage, so applying it was a full pass over every sample of every phased record for no change in output.
5. **`ALT_COUNT` column added** — the hardcall ALT allele count as `Int8`, one byte per genotype instead of the four `DS` needs. 2.53 GB of output instead of 10.13 GB on this chromosome.
6. **Expansion loops made auto-vectorizable.** The ALT count for codes 0..=4 is `0,1,2,0,1`, which is `code - 3 * (code >= 3)` — no lookup table, no `Vec::push`, so LLVM emits NEON.
7. **Difflist buffer reused** across variants instead of allocated per record (~10⁶ allocations per chromosome).
8. **The common-value + difflist branch fused into the output buffer** — the largest single win, below.
9. **Output shape reported in the schema metadata**, so a caller can preallocate.
10. **The `.pvar` parsed across threads** — the scan's serial prologue, below.

## The fused decode (8)

81% of a `plink2 --make-pgen` fileset is main-track representation 4, 6 or 7: one common category for every sample plus a sparse difflist of exceptions. Unlike every other representation it has **no per-sample base to unpack**, so the two passes it went through — fill a `Vec<u8>` of codes, then read that buffer back to write the `f32`/`i8` — were one pass more than the record needs.

`DS` and `ALT_COUNT` now fill their Arrow values slice from the common category and patch the difflist straight into it. Validity is one run for the whole variant plus a bit per patch, so bitmap work is proportional to the difflist rather than the sample count.

| field | before | after | |
|---|---:|---:|---:|
| `DS` | 2.31 s | **1.19 s** | 1.94× |
| `ALT_COUNT` | 1.65 s | **0.59 s** | 2.80× |

**The obstacle was the hardcall-phase track.** It must still be validated and consumed — its length depends on the heterozygote count, so misparsing it would silently shift every following track — but that count came from scanning the per-sample buffer fusion removes. It is derivable from the difflist alone: every unpatched sample carries the common category, so it is heterozygous exactly when that category is. Phase validation is now shared with the dense path via `validate_phase_track`.

Three exclusions, each load-bearing: `GT` (it distinguishes `(0,1)` from `(1,0)`, and the fused decode discards the orientation), LD bases (`retain_main` — those need the full main track anyway, ~13% of records), and anything with a dosage/HDS/multiallelic track.

### Issue #233 proposes the wrong optimization

#233 argues for keeping the decoded main track 2-bit packed the way pgenlib does. That reading came from the LD-compressed branch (13% of records). The dominant branch has no per-sample base to pack: pgenlib's `vecset` + `Expand2bitTo8` writes `sample_ct/4 + sample_ct` bytes, while a fused fill writes `sample_ct` and nothing else. Packing would make us **slower** here. Corrected in a comment on the issue.

## The parallel `.pvar` parse (10)

Opening a fileset parses the whole `.pvar` before any partition runs, so it is a
fixed serial prologue under every scan — on chromosome 22, 108 MB of text and
**0.257 s**, which was 20% of a four-partition read and did not shrink when
partitions were added. The body is now split on line boundaries and parsed on
scoped threads that borrow the text directly, so nothing is copied and no runtime
is involved. **0.257 s → 0.068 s, 3.8×.**

Two behaviours had to survive being parsed out of order:

- **Error messages carry file line numbers**, but a chunk only knows its own. Each
  chunk reports where it stopped in local lines and the caller adds the offset,
  counting newlines ahead of that chunk only on the error path.
- **The row limit is enforced before the offending line is read**, so on a file
  that is both over the limit and malformed, the limit wins — there is an
  existing test asserting exactly that. A chunk cannot see the running total, so
  it applies the limit to itself as a memory bound and the caller reconciles the
  counts as chunks are joined, taking whichever condition comes first in the
  file.

The chunk count is injectable so tests can pin the split; inheriting the host's
core count would make those boundary cases untestable. My first attempt at these
tests passed under mutation — deleting either half of the reconciliation left
them green, because they reached the same error by another route. The tests now
in the branch fail when either half is removed.

## Scaling

`examples/pgen_scaling_probe.rs` measures the scan against partition count with
no Python in the way, and reports `DependencyRecords` alongside — the count of
records a partition decodes to reconstruct an LD chain but never emits, which is
the obvious suspect for parallel work that duplicates rather than divides.

| Partitions | `DS` scan | speedup | `DependencyRecords` |
|---:|---:|---:|---:|
| 1 | 1.250 s | 1.00× | 0 |
| 4 | 0.386 s | 3.24× | 0 |
| 8 | 0.248 s | **5.05×** | 0 |

The scan divides cleanly and LD chains cost nothing. End-to-end scaling is much
lower (1.99× at four partitions) because the scan is only a third of a
materializing read; the rest is a copy that saturates memory bandwidth. That
analysis lives in `bioformats-benchmark/PGEN_BENCHMARK.md`.

## Correctness

- **`ALT_COUNT` and `DS` match the `GT` scan across all 2,532,408,788 cells of chr22.** `GT` never takes the fused path, so this is a real oracle on real records at full scale. New `examples/pgen_field_parity` does it; it exits nonzero on disagreement and was verified to fail on a deliberately corrupted patch.
- The **pgenlib and snputils differential oracles** stay green, run against the real libraries (`PGEN_REQUIRE_REFERENCE_ORACLES=1`), not the skip path.
- Unit tests compare the fused fill against the two-pass expansion **buffer for buffer and bitmap for bitmap**, and check the fused decode reconstructs exactly the main track the existing decoder produces.
- **Never narrow `DS` from `Float32`.** PGEN dosages are genuinely fractional; on a dosage fileset the two tracks disagree completely:
  ```
  dosages   : [ 0.125  1.0  1.875  missing ]
  hardcalls : [ missing  1  missing  missing ]
  ```
  An intermediate version of the fast path returned hardcalls where dosages were asked for, and the differential oracles caught it.

## End to end

Through polars-bio (which needs biodatageeks/polars-bio#436 for the matrix reader), all readers interleaved in one session, one thread each — pgenlib and snputils are serial:

| | polars-bio at branch point | now | snputils | pgenlib |
|---|---:|---:|---:|---:|
| dosage (float32) | 4.338 s | **1.285 s** | 3.558 s | 1.863 s |
| hardcall (int8) | 2.959 s | **0.689 s** | 1.538 s | 0.862 s |

**polars-bio is now faster than pgenlib on both workloads at equal core count** —
1.45× on dosage and 1.25× on hardcalls — having started this branch 2.46× and
3.56× slower. At four and eight partitions it is 3.65× and 4.75× pgenlib on dosage.

Two qualifications. pgenlib drifted by up to 4.6% between sessions earlier in this
branch, though not in the run these figures come from — it landed within 1% of
the previous one — so the margins stand as measured. Still prefer "faster" to a
third decimal place across sessions. And **pgenlib still uses slightly less memory** — 12.1 GB against 12.6 GB
on dosage — though that gap is down from 65% to 4%.

## Decoding into the caller's buffer

The scan builds Arrow batches and something else copies them into whatever the
caller actually wanted. For a dense matrix that copy is pure overhead — 10 GB
read and 10 GB written on a whole chromosome — and it is what stopped a
materializing read from scaling, because it saturates memory bandwidth long
before it runs out of threads.

`matrix::read_genotype_matrix` skips it: decoders write genotypes at their final
address, so the values are touched once, by the threads that produced them.
`GenotypeMatrixReader` holds the opened fileset across the shape query and the
decode, because a caller must learn the shape before it can allocate and asking
must not cost a second parse of the 108 MB PVAR — an earlier revision paid it
twice and briefly made the hardcall workload *slower* than the Arrow path.

Two things made this simpler here than in the Arrow path rather than harder. A
matrix has no validity bitmap, so a missing call is a sentinel the caller picks.
And a full-file read gives every variant a row index equal to its position in the
selection, so partitions own disjoint contiguous row ranges: the destination
splits with `split_at_mut` and workers never share a byte. Partition planning,
including LD base chains, is the existing planner's rather than a second
implementation.

The general decoder needed care the fast paths did not. It is the only branch
that sees a stored dosage track, and those values are genuinely fractional; an
earlier draft routed them through the internal-code mapping, which can only say
0, 1 or 2, so every dosage came out as zero while every fast-path fixture still
passed. There is a test on the fixture whose dosage and hardcall tracks
disagree, and it fails when that mapping is reinstated.

Tests compare the matrix against the scan cell for cell on the fixture holding
every record representation, at one, two, four and eight threads, plus sample
subsetting and a wrongly sized destination.

pgenlib and snputils reproduced their earlier figures to within 1% in the same session, so the deltas are the change and not machine drift. Zero bitwise differences against pgenlib across all 2,532,408,788 cells in both workloads, with the single-cell corruption self-test confirming the comparison can still fail.



