### PR TITLE
perf(bgen): inline the two per-sample helpers, 1.23x the one-partition scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ dependencies = [
  "datafusion",
  "datafusion-bio-format-core",
  "flate2",
+ "futures",
  "libdeflater",
  "log",
  "opendal",

--- a/datafusion/bio-format-bgen/Cargo.toml
+++ b/datafusion/bio-format-bgen/Cargo.toml
@@ -26,7 +26,9 @@ zstd = "0.13"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
+futures.workspace = true
 tempfile = "3"
+tokio = { workspace = true, features = ["fs", "io-util", "rt-multi-thread", "macros"] }
 
 [[bench]]
 name = "bgen_scan"

--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -1,0 +1,178 @@
+//! Splits a BGEN scan into the two costs it is made of: decompressing the
+//! probability blocks, and turning them into output.
+//!
+//! The decompression phase walks the variant records itself and calls
+//! libdeflate on each payload, which is the same work any reader of this file
+//! must do, in the same library the C readers use. Whatever the full scan costs
+//! beyond that is this provider's own.
+//!
+//! Usage:
+//!   cargo run --release -p datafusion-bio-format-bgen --example bgen_decode_profile \
+//!     -- <path.bgen> [partitions...]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_format_bgen::{BgenOutputMode, BgenReadOptions, BgenTableProvider};
+use futures::StreamExt;
+
+fn u16le(b: &[u8], o: usize) -> usize {
+    u16::from_le_bytes([b[o], b[o + 1]]) as usize
+}
+fn u32le(b: &[u8], o: usize) -> usize {
+    u32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]]) as usize
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: bgen_decode_profile <path.bgen> [partitions...]");
+
+    let bytes = std::fs::read(&path).expect("read bgen");
+    let start_of_data = u32le(&bytes, 0) + 4;
+    let header_len = u32le(&bytes, 4);
+    let variant_count = u32le(&bytes, 8);
+    let sample_count = u32le(&bytes, 12);
+    let flags = u32le(&bytes, 4 + header_len - 4);
+    let compression = flags & 3;
+    let layout = (flags >> 2) & 0xf;
+    println!(
+        "{variant_count} variants x {sample_count} samples, layout {layout}, compression {compression}, {} MB",
+        bytes.len() / 1_000_000
+    );
+    assert_eq!(layout, 2, "this probe only walks layout 2");
+
+    // --- Phase A: walk the records and decompress every payload ---
+    let mut decompressor = libdeflater::Decompressor::new();
+    let mut out = vec![0_u8; 64 << 20];
+    let mut cursor = start_of_data;
+    let mut walked = 0_usize;
+    let mut compressed_total = 0_usize;
+    let mut decompressed_total = 0_usize;
+    let mut payload_spans: Vec<(usize, usize, usize)> = Vec::with_capacity(variant_count);
+
+    let walk_started = Instant::now();
+    for _ in 0..variant_count {
+        for _ in 0..3 {
+            let n = u16le(&bytes, cursor);
+            cursor += 2 + n;
+        }
+        cursor += 4; // position
+        let alleles = u16le(&bytes, cursor);
+        cursor += 2;
+        for _ in 0..alleles {
+            let n = u32le(&bytes, cursor);
+            cursor += 4 + n;
+        }
+        let stored = u32le(&bytes, cursor);
+        cursor += 4;
+        let (data_start, data_len, expanded) = if compression == 0 {
+            (cursor, stored, stored)
+        } else {
+            (cursor + 4, stored - 4, u32le(&bytes, cursor))
+        };
+        payload_spans.push((data_start, data_len, expanded));
+        compressed_total += data_len;
+        decompressed_total += expanded;
+        cursor += stored;
+        walked += 1;
+    }
+    let walk = walk_started.elapsed();
+    assert_eq!(walked, variant_count);
+
+    let inflate_started = Instant::now();
+    let mut checksum = 0_u64;
+    for &(data_start, data_len, expanded) in &payload_spans {
+        if out.len() < expanded {
+            out.resize(expanded, 0);
+        }
+        let written = decompressor
+            .zlib_decompress(
+                &bytes[data_start..data_start + data_len],
+                &mut out[..expanded],
+            )
+            .expect("inflate");
+        // Touch the output so the decompression cannot be optimized away.
+        checksum += written as u64 + out[written - 1] as u64;
+    }
+    let inflate = inflate_started.elapsed();
+
+    println!(
+        "\nrecord walk      {:>8.3} s   ({variant_count} records)",
+        walk.as_secs_f64()
+    );
+    println!(
+        "zlib inflate     {:>8.3} s   {:.2} GB out from {:.2} GB in, {:.2} GB/s produced  [checksum {checksum}]",
+        inflate.as_secs_f64(),
+        decompressed_total as f64 / 1e9,
+        compressed_total as f64 / 1e9,
+        decompressed_total as f64 / 1e9 / inflate.as_secs_f64()
+    );
+    println!(
+        "walk + inflate   {:>8.3} s   <- the floor any reader of this file pays",
+        (walk + inflate).as_secs_f64()
+    );
+
+    // --- Phase B: the provider's own scan, no Python, batches dropped ---
+    let partitions: Vec<usize> = std::env::args()
+        .skip(2)
+        .map(|value| value.parse().expect("partition count"))
+        .collect();
+    let partitions = if partitions.is_empty() {
+        vec![1]
+    } else {
+        partitions
+    };
+
+    println!();
+    for target in partitions {
+        let provider = BgenTableProvider::try_new(
+            path.clone(),
+            BgenReadOptions {
+                output_mode: BgenOutputMode::Dosage,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("open bgen");
+        let context =
+            SessionContext::new_with_config(SessionConfig::new().with_target_partitions(target));
+        context.register_table("b", Arc::new(provider)).unwrap();
+
+        let started = Instant::now();
+        let mut stream = context
+            .sql("SELECT genotypes FROM b")
+            .await
+            .unwrap()
+            .execute_stream()
+            .await
+            .unwrap();
+        let mut rows = 0_usize;
+        let mut batches = 0_usize;
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            rows += batch.num_rows();
+            batches += 1;
+        }
+        let scan = started.elapsed();
+        // The floor above was measured on one thread, so subtracting it only
+        // says anything about a one-partition scan; a parallel scan divides the
+        // decompression too and the difference would be meaningless.
+        if target == 1 {
+            println!(
+                "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}   \
+                 inflate floor {:>6.3} s, everything else {:>6.3} s",
+                scan.as_secs_f64(),
+                inflate.as_secs_f64(),
+                scan.as_secs_f64() - inflate.as_secs_f64()
+            );
+        } else {
+            println!(
+                "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}",
+                scan.as_secs_f64()
+            );
+        }
+    }
+}

--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -43,6 +43,15 @@ async fn main() {
         bytes.len() / 1_000_000
     );
     assert_eq!(layout, 2, "this probe only walks layout 2");
+    // Layout 2 defines three compression modes and the reader supports all of
+    // them; this probe only inflates. Dispatching on the flag lands one commit
+    // later in the stack, and until then a clear refusal beats handing a zstd
+    // or uncompressed block to libdeflate and reporting its complaint.
+    assert_eq!(
+        compression, 1,
+        "this probe only handles zlib (flag 1); see perf/bgen-projectable-ploidy \
+         for full dispatch"
+    );
 
     // --- Phase A: walk the records and decompress every payload ---
     let mut decompressor = libdeflater::Decompressor::new();

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -122,6 +122,12 @@ impl GenotypeBuffers {
         self.close_sample(false)
     }
 
+    // Called once per sample, from a caller large enough that LLVM will not
+    // inline it on a hint alone — `finish_sample` and `finish_missing_sample`
+    // carry `#[inline]`, but they only delegate here, so the hint stopped one
+    // level short of the work. Out of line this was 18% of a whole-chromosome
+    // scan.
+    #[inline(always)]
     fn close_sample(&mut self, valid: bool) -> Result<()> {
         match self.layout {
             BufferLayout::FixedProbability(width) => {

--- a/datafusion/bio-format-bgen/src/decode.rs
+++ b/datafusion/bio-format-bgen/src/decode.rs
@@ -985,7 +985,11 @@ static EIGHT_BIT_PROBABILITY: std::sync::LazyLock<[f32; 256]> = std::sync::LazyL
 /// Returns `None` when an unphased stored sum exceeds `denominator`, which is
 /// the same input the general path rejects. A byte can never exceed an 8-bit
 /// denominator, so the per-haplotype phased bound cannot be violated here.
-#[inline]
+// `#[inline]` alone is not enough here: the caller is the whole layout-2 decode
+// body, and LLVM declines to inline into it. Left as a plain hint, this function
+// stays an out-of-line call taken once per sample — 15% of a whole-chromosome
+// scan in a profile of one.
+#[inline(always)]
 fn byte_dosage_numerator(values: &[u8], denominator: u64, ploidy: u8, phased: bool) -> Option<u64> {
     if phased {
         let sum: u64 = values.iter().map(|&value| value as u64).sum();


### PR DESCRIPTION
## Summary

A whole-chromosome BGEN scan spent a third of its time in call overhead. Two
functions are called once per sample — 2,532,408,788 times on chromosome 22 —
and neither was being inlined.

| | before | after | |
|---|---:|---:|---:|
| scan, 1 partition | 24.29 s | **19.76 s** | 1.23× |
| of which not decompression | 14.83 s | **10.28 s** | 1.44× |
| scan, 8 partitions | 3.70 s | **3.03 s** | 1.22× |

Medians of three interleaved runs, chr22 (993,881 × 2,548), dosage output,
release with `-C target-cpu=native`. The decompression floor is the control:
9.45 s before and 9.48 s after, because it is libdeflate either way.

## How this was found

The [BGEN writeup](https://github.com/biodatageeks/bioformats-benchmark/blob/main/BGEN_BENCHMARK.md)
explained the one-thread gap against snputils and the `bgen` package as
polars-bio "building Arrow arrays and handing them to Polars". That is wrong,
and measuring it is what produced this change. On a one-partition scan:

| Phase | Time | Share |
|---|---:|---:|
| zlib inflate | 9.50 s | 39% |
| `decode_layout2_block` | 14.39 s | 60% |
| **Arrow batch build** | **0.004 s** | ~0% |
| I/O, planning, record parsing | 0.20 s | 1% |

Arrow construction is four milliseconds — the decoder writes Arrow's layout as
it goes, so `build_batch` only wraps buffers. Decompression is not the gap
either: it is a floor every reader of this file pays, in the same library.
`bgen` reads the file in 15.06 s of which ~8.9 s is inflate, so its own work is
~6.2 s against this provider's ~14.8 s.

All 993,881 variants take the intended biallelic 8-bit fast path; none fall back
to the general bit reader. Inside it, the per-sample loop was 13.0 s — 5.15
ns/sample. Three reconstructions of that loop in isolation all came out near
2 ns/sample, which is why this was profiled rather than reasoned about. The
profile showed why:

| Frame | Share of scan |
|---|---:|
| `byte_dosage_numerator` — out-of-line call | 15% |
| `GenotypeBuffers::close_sample` — out-of-line call | 18% |

## Why an attribute was needed

`byte_dosage_numerator` already carried `#[inline]` and LLVM still declined it,
because the caller is the whole layout-2 decode body. `close_sample` had no
attribute: `finish_sample` and `finish_missing_sample` are both marked, but they
only delegate to it, so the hint stopped one level short of the work.

Adding plain `#[inline]` to `close_sample` changed nothing measurable — 24.12 s
against a 23.48 s baseline, inside the noise. Both need `#[inline(always)]`;
together they are worth the 1.44× on non-decompression work above.

## The probe

`examples/bgen_decode_profile` is how the figures were taken and is included so
they can be reproduced. It walks the variant records itself and inflates every
payload with the same library the reader uses — the floor any reader of the file
pays — then runs the provider's own scan against it:

```
cargo run --release -p datafusion-bio-format-bgen --example bgen_decode_profile \
  -- chr22.full.bgen 1 8
```

## What is deliberately left

Two structural costs remain in the same loop, both needing a real change to the
decode path rather than an attribute:

- **Every sample is reached through the `selected_samples` index array**, even
  when the scan wants the whole cohort — a gather where PGEN has an
  identity-selection fast path. This blocks vectorization outright.
- **`PLOIDY` is materialized unconditionally.** The `genotypes` struct always
  carries both children, so no projection can drop it; `push_ploidy` runs per
  sample and the column is 2.53 GB of output on this file that neither
  comparison reader produces.

Measured on the real decompressed blocks, a contiguous branch-free fill does the
same arithmetic about 4× faster than the shipped loop shape, so there is
meaningful headroom left here.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -p datafusion-bio-format-bgen
--all-targets` and the 77 BGEN tests are clean. This change cannot alter output
— it is two inlining attributes — and the scan emits the same 993,881 rows in
the same 340 batches before and after.