### PR TITLE
perf(bgen): fill a whole-cohort dosage read without going per sample, 4.4x the decode

### DIFF
--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -13,6 +13,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use datafusion::arrow::array::Array;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_bio_format_bgen::{BgenOutputMode, BgenReadOptions, BgenTableProvider};
 use futures::StreamExt;
@@ -160,10 +161,50 @@ async fn main() {
             .unwrap();
         let mut rows = 0_usize;
         let mut batches = 0_usize;
+        let digest_enabled = std::env::var("BGEN_DIGEST").is_ok();
+        let mut digest = 0xcbf29ce484222325_u64;
         while let Some(batch) = stream.next().await {
             let batch = batch.unwrap();
             rows += batch.num_rows();
             batches += 1;
+            // FNV over every emitted dosage bit pattern and every ploidy byte,
+            // so two builds can be compared cell for cell rather than by total.
+            if !digest_enabled {
+                continue;
+            }
+            let genotypes = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StructArray>()
+                .expect("genotypes struct");
+            for child in [0_usize, 1] {
+                let column = genotypes.column(child);
+                let list = column
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::ListArray>()
+                    .expect("list child");
+                let values = list.values();
+                if let Some(floats) = values
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::Float32Array>()
+                {
+                    for index in 0..floats.len() {
+                        let bits = if floats.is_null(index) {
+                            0xffff_ffff_u32
+                        } else {
+                            floats.value(index).to_bits()
+                        };
+                        digest = (digest ^ bits as u64).wrapping_mul(0x100000001b3);
+                    }
+                } else if let Some(bytes) = values
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::UInt8Array>()
+                {
+                    for index in 0..bytes.len() {
+                        digest = (digest ^ bytes.value(index) as u64).wrapping_mul(0x100000001b3);
+                    }
+                }
+            }
         }
         let scan = started.elapsed();
         // The floor above was measured on one thread, so subtracting it only
@@ -172,14 +213,14 @@ async fn main() {
         if target == 1 {
             println!(
                 "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}   \
-                 inflate floor {:>6.3} s, everything else {:>6.3} s",
+                 inflate floor {:>6.3} s, everything else {:>6.3} s, digest {digest:016x}",
                 scan.as_secs_f64(),
                 inflate.as_secs_f64(),
                 scan.as_secs_f64() - inflate.as_secs_f64()
             );
         } else {
             println!(
-                "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}",
+                "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}   digest {digest:016x}",
                 scan.as_secs_f64()
             );
         }

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -177,6 +177,31 @@ impl GenotypeBuffers {
         self.ploidy.push(ploidy);
     }
 
+    /// Appends `count` samples that all declare `ploidy`.
+    ///
+    /// A uniform-ploidy variant has already been checked to declare the same
+    /// value for every sample, so the column is a run and can be written as
+    /// one instead of a byte at a time.
+    pub(crate) fn extend_uniform_ploidy(&mut self, ploidy: u8, count: usize) {
+        self.ploidy.resize(self.ploidy.len() + count, ploidy);
+    }
+
+    /// Closes `count` called samples whose values are already in the buffer.
+    ///
+    /// The dosage layout writes exactly one value per called sample and keeps
+    /// no per-sample offsets, so closing a run of them is bookkeeping that does
+    /// not have to be repeated per sample. Only valid for
+    /// [`BufferLayout::Dosage`]; the caller has established that every one of
+    /// the `count` samples is called.
+    pub(crate) fn close_called_dosage_run(&mut self, count: usize) {
+        debug_assert_eq!(self.layout, BufferLayout::Dosage);
+        if let Some(builder) = self.valid.as_mut() {
+            builder.append_n(count, true);
+        }
+        self.samples += count;
+        self.sample_start = self.values.len();
+    }
+
     /// Closes a variant's samples into one output row.
     pub(crate) fn finish_variant(&mut self) -> Result<()> {
         self.variant_offsets

--- a/datafusion/bio-format-bgen/src/decode.rs
+++ b/datafusion/bio-format-bgen/src/decode.rs
@@ -36,6 +36,12 @@ pub(crate) struct DecodeScratch {
     stored: Vec<u64>,
     complete: Vec<u64>,
     offsets: Vec<u64>,
+    /// Whether the scan selects the whole cohort in file order, answered once.
+    ///
+    /// The selection is fixed for a partition, so asking per variant would walk
+    /// the cohort an extra time for every one of them to learn something that
+    /// cannot have changed.
+    identity_selection: Option<bool>,
 }
 
 impl DecodeScratch {
@@ -46,7 +52,19 @@ impl DecodeScratch {
             stored: Vec::new(),
             complete: Vec::new(),
             offsets: Vec::new(),
+            identity_selection: None,
         }
+    }
+
+    /// Whether `selected` is `0..sample_count`, computed on first use.
+    fn identity_selection(&mut self, selected: &[usize], sample_count: usize) -> bool {
+        *self.identity_selection.get_or_insert_with(|| {
+            selected.len() == sample_count
+                && selected
+                    .iter()
+                    .enumerate()
+                    .all(|(index, &sample)| index == sample)
+        })
     }
 }
 
@@ -306,12 +324,15 @@ fn decode_layout2(
     scratch: &mut DecodeScratch,
     buffers: &mut GenotypeBuffers,
 ) -> Result<DecodedGenotypes> {
+    let identity_selection =
+        scratch.identity_selection(selected_samples, header.sample_count as usize);
     let DecodeScratch {
         zlib,
         block: block_buffer,
         stored,
         complete,
         offsets: sample_bit_offsets,
+        identity_selection: _,
     } = scratch;
     let block_length = read_u32(payload, 0)? as usize;
     if payload.len() != block_length.saturating_add(4) {
@@ -387,6 +408,7 @@ fn decode_layout2(
         stored,
         complete,
         sample_bit_offsets,
+        identity_selection,
         buffers,
     )
 }
@@ -402,6 +424,7 @@ fn decode_layout2_block(
     stored: &mut Vec<u64>,
     complete: &mut Vec<u64>,
     sample_bit_offsets: &mut Vec<u64>,
+    identity_selection: bool,
     buffers: &mut GenotypeBuffers,
 ) -> Result<DecodedGenotypes> {
     let sample_count = read_u32(block, 0)?;
@@ -534,25 +557,40 @@ fn decode_layout2_block(
         .transpose()
         .map_err(|_| execution_error(path, variant, "state count does not fit usize"))?;
 
+    // Every sample of a uniform-ploidy variant must declare exactly `min_ploidy`
+    // with no reserved bit, which is one comparison per sample over the whole
+    // cohort of every variant in the file. Folding it into an OR lets it
+    // vectorize; the per-sample diagnosis is rebuilt by a second walk only when
+    // the fold reports a violation, which is the path that ends in an error
+    // anyway. `any_missing` falls out of the same pass, and the dosage fill
+    // below needs it.
+    let mut uniform_violation = 0_u8;
+    let mut any_missing = 0_u8;
     sample_bit_offsets.clear();
     if uniform_stride_bits.is_some() {
-        for (sample, &ploidy_missing) in ploidy_bytes.iter().enumerate() {
-            if ploidy_missing & 0x40 != 0 {
-                return Err(execution_error(
-                    path,
-                    variant,
-                    &format!("sample {sample} has a non-zero reserved ploidy bit"),
-                ));
-            }
-            if ploidy_missing & 0x3f != min_ploidy {
-                return Err(execution_error(
-                    path,
-                    variant,
-                    &format!(
-                        "sample {sample} ploidy {} is outside declared range",
-                        ploidy_missing & 0x3f
-                    ),
-                ));
+        for &ploidy_missing in ploidy_bytes.iter() {
+            uniform_violation |= (ploidy_missing & 0x7f) ^ min_ploidy;
+            any_missing |= ploidy_missing & 0x80;
+        }
+        if uniform_violation != 0 {
+            for (sample, &ploidy_missing) in ploidy_bytes.iter().enumerate() {
+                if ploidy_missing & 0x40 != 0 {
+                    return Err(execution_error(
+                        path,
+                        variant,
+                        &format!("sample {sample} has a non-zero reserved ploidy bit"),
+                    ));
+                }
+                if ploidy_missing & 0x3f != min_ploidy {
+                    return Err(execution_error(
+                        path,
+                        variant,
+                        &format!(
+                            "sample {sample} ploidy {} is outside declared range",
+                            ploidy_missing & 0x3f
+                        ),
+                    ));
+                }
             }
         }
     } else {
@@ -695,6 +733,67 @@ fn decode_layout2_block(
     // lookups; the general path below still handles every other encoding.
     if allele_count == 2 && bits == 8 && min_ploidy == max_ploidy && min_ploidy > 0 {
         let stride = min_ploidy as usize;
+
+        // A whole-cohort dosage read of a diploid, fully called, uniform-ploidy
+        // variant is what a `plink2 --export bgen` file is almost entirely made
+        // of, and it is the one shape with nothing to decide per sample: the
+        // selection is the cohort in order, so the stored bytes are walked
+        // rather than gathered; every sample declares the same ploidy, so that
+        // column is a run; and none is missing, so no sample needs its own
+        // validity. What is left is two bytes in and one `f32` out, which is a
+        // shape the compiler can vectorize.
+        //
+        // The dosages are written by the same expression the per-sample path
+        // uses, so this produces bit-identical values rather than merely close
+        // ones — the differential oracles compare every cell.
+        if identity_selection
+            && any_missing == 0
+            && stride == 2
+            && options.output_mode == BgenOutputMode::Dosage
+            && let Some(pairs) = probability_bytes.get(..2 * selected_samples.len())
+        {
+            let count = selected_samples.len();
+            let ploidy_numerator = min_ploidy as u64 * denominator;
+            let sum_bound_exceeded = if phased {
+                // Each haplotype stores its own probability, so a byte can never
+                // exceed the 8-bit denominator and the bound cannot be broken.
+                false
+            } else {
+                // Unphased stores P(AA) and P(AB); their sum is a probability
+                // and must not exceed the denominator. Checked in its own pass
+                // so the fill below stays branch-free.
+                pairs
+                    .chunks_exact(2)
+                    .any(|pair| pair[0] as u64 + pair[1] as u64 > denominator)
+            };
+            if !sum_bound_exceeded {
+                let values = buffers.values_mut();
+                values.reserve(count);
+                if phased {
+                    values.extend(pairs.chunks_exact(2).map(|pair| {
+                        (ploidy_numerator - (pair[0] as u64 + pair[1] as u64)) as f32
+                            / denominator as f32
+                    }));
+                } else {
+                    values.extend(pairs.chunks_exact(2).map(|pair| {
+                        let sum = pair[0] as u64 + pair[1] as u64;
+                        (pair[1] as u64 + min_ploidy as u64 * (denominator - sum)) as f32
+                            / denominator as f32
+                    }));
+                }
+                buffers.close_called_dosage_run(count);
+                buffers.extend_uniform_ploidy(min_ploidy, count);
+
+                return Ok(DecodedGenotypes {
+                    phased,
+                    bits,
+                    decompressed_bytes: block.len(),
+                    state_width: uniform_state_width,
+                    declared_ploidy: uniform_stride_bits.map(|_| min_ploidy),
+                });
+            }
+        }
+
         for &sample in selected_samples {
             let ploidy_missing = ploidy_bytes[sample];
             buffers.push_ploidy(ploidy_missing & 0x3f);

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -822,6 +822,139 @@ async fn emits_biallelic_dosage_and_rejects_multiallelic_selection() {
     assert_eq!(flags.iter().map(|batch| batch.num_rows()).sum::<usize>(), 1);
 }
 
+/// Fully called biallelic 8-bit variants, phased and unphased, which is the
+/// shape the whole-cohort dosage fill claims.
+fn fully_called_variants() -> Vec<Variant> {
+    vec![
+        Variant {
+            id: "u1",
+            rsid: "rsu1",
+            chrom: "1",
+            position: 10,
+            alleles: vec!["A", "C"],
+            phased: false,
+            bits: 8,
+            samples: vec![
+                sample(2, false, &[255, 0]),
+                sample(2, false, &[0, 255]),
+                sample(2, false, &[13, 200]),
+            ],
+        },
+        Variant {
+            id: "p1",
+            rsid: "rsp1",
+            chrom: "1",
+            position: 20,
+            alleles: vec!["G", "T"],
+            phased: true,
+            bits: 8,
+            samples: vec![
+                sample(2, false, &[255, 0]),
+                sample(2, false, &[0, 0]),
+                sample(2, false, &[7, 191]),
+            ],
+        },
+    ]
+}
+
+#[tokio::test]
+async fn whole_cohort_dosage_matches_the_per_sample_decode() {
+    // A whole-cohort scan of a fully called variant takes the bulk fill; asking
+    // for the same samples in a different order does not, because the selection
+    // is no longer the cohort in file order. The two must agree cell for cell —
+    // the fill exists to be faster, not to be different.
+    let fixture = fixture_with_variants(Codec::Zlib, true, &fully_called_variants());
+
+    let whole = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let whole_context = context(1024);
+    whole_context
+        .register_table("whole", Arc::new(whole))
+        .unwrap();
+    let whole_batches = whole_context
+        .sql("SELECT genotypes FROM whole ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let reordered = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            samples: Some(vec!["s3".to_string(), "s2".to_string(), "s1".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let reordered_context = context(1024);
+    reordered_context
+        .register_table("reordered", Arc::new(reordered))
+        .unwrap();
+    let reordered_batches = reordered_context
+        .sql("SELECT genotypes FROM reordered ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    for row in 0..2 {
+        let bulk = dosage_values(&whole_batches[0], 0, row);
+        let mut per_sample = dosage_values(&reordered_batches[0], 0, row);
+        per_sample.reverse();
+        assert_eq!(bulk.len(), 3, "row {row}");
+        assert_eq!(bulk, per_sample, "row {row}");
+        // Bit-identical, not merely close: the differential oracles compare
+        // every cell against pgenlib and the `bgen` package.
+        for (left, right) in bulk.iter().zip(per_sample.iter()) {
+            assert_eq!(
+                left.map(f32::to_bits),
+                right.map(f32::to_bits),
+                "row {row} bit pattern"
+            );
+        }
+        // Every sample declares ploidy 2 and the column is written as a run.
+        assert_eq!(ploidy_values(&whole_batches[0], 0, row), vec![2, 2, 2]);
+    }
+
+    // A missing sample keeps the variant off the bulk fill; it must still decode.
+    let with_missing = fixture_with_variants(Codec::Zlib, true, &variants());
+    let provider = BgenTableProvider::try_new(
+        path(&with_missing.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let missing_context = context(1024);
+    missing_context
+        .register_table("m", Arc::new(provider))
+        .unwrap();
+    let batches = missing_context
+        .sql("SELECT genotypes FROM m WHERE chrom = '1' ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        dosage_values(&batches[0], 0, 0),
+        vec![Some(0.0), Some(1.0), None]
+    );
+}
+
 #[tokio::test]
 async fn decodes_layout1_uncompressed_and_zlib() {
     for codec in [Codec::None, Codec::Zlib] {


### PR DESCRIPTION
Stacked on #234. Review that one first; this PR's diff is the second commit.

## Summary

After #234 inlined the per-sample helpers, a one-partition whole-chromosome scan
was still 10.2 s of work on top of the 9.4 s decompression floor, and all of it
was the loop turning a decompressed block into output.

| | before #234 | after #234 | **this PR** |
|---|---:|---:|---:|
| scan, 1 partition | 24.29 s | 19.62 s | **11.72 s** |
| of which not decompression | 14.83 s | 10.15 s | **2.30 s** |

Decompression is now **80%** of a one-partition scan, against 39% when this
started. chr22, 993,881 × 2,548 = 2,532,408,788 genotypes, dosage, release with
`-C target-cpu=native`, medians of three interleaved runs.

## What the loop was doing

It decided three things per sample that a whole-cohort read of a
`plink2 --export bgen` file has already decided for every sample at once:

- **which sample to read** — it gathers through `selected_samples` even when the
  selection is the cohort in file order, which blocks vectorization outright;
- **what ploidy to record** — uniform, and already validated as uniform;
- **whether the sample is called** — it isn't missing.

A read that is whole-cohort, diploid, dosage, uniform-ploidy and fully called
now fills the values buffer straight from the stored byte pairs, writes the
ploidy column as a run, and closes the samples once. Two bytes in, one `f32`
out. Everything else keeps the per-sample path.

The ploidy validation pass is folded into an OR reduction as well — it runs over
the whole cohort of every variant, and only its failure needs to know which
sample was at fault, so the branchy walk now happens only when the fold reports
a violation.

## Bit-identical, and checked as such

The dosages are written by the same expression the per-sample path uses, so the
two produce the same `f32` bit patterns rather than merely close ones. That
matters because the benchmark compares every cell against the `bgen` package.

An FNV digest over every emitted dosage and every ploidy byte matches between
the two builds on all four fixtures — chr22 phased and unphased, whole
chromosome and 25,000-variant slice — 2,532,408,788 cells each.

`whole_cohort_dosage_matches_the_per_sample_decode` pins it in the suite: the
same fixture read whole-cohort and read with the samples reordered, which
defeats the identity selection and takes the per-sample path, compared cell for
cell and bit pattern for bit pattern. It fails when the unphased branch is given
the phased formula.

## End to end

Through polars-bio, whole chromosome, one thread, all readers interleaved in one
session:

| Reader | Time |
|---|---:|
| **polars-bio** | **14.142 s** |
| bgen | 15.680 s |
| snputils | 21.807 s |

polars-bio's three runs were 13.600/14.181/14.142 s, all below the `bgen`
package's slowest, so the ranges do not overlap. It was 25.804 s and last of the
three before #234.

One thing moved the wrong way: peak RSS at one partition went 22,238 → 24,291 MB,
19% above the `bgen` package. That is recorded rather than explained — a scan
producing batches twice as fast plausibly keeps more in flight ahead of a Python
consumer that did not get faster, but I have not measured it.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -p datafusion-bio-format-bgen
--all-targets`, and 78 BGEN tests all clean.