### PR TITLE
feat(bgen): let a scan project the genotypes struct children

### DIFF
--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -142,6 +142,13 @@ async fn main() {
             path.clone(),
             BgenReadOptions {
                 output_mode: BgenOutputMode::Dosage,
+                // `BGEN_PLOIDY=1` keeps the PLOIDY child, to compare what a
+                // scan that emits it costs against one that does not.
+                genotype_fields: if std::env::var("BGEN_PLOIDY").is_ok() {
+                    None
+                } else {
+                    Some(vec!["DS".to_string()])
+                },
                 ..Default::default()
             },
         )

--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -48,25 +48,16 @@ async fn main() {
         bytes.len() / 1_000_000
     );
     assert_eq!(layout, 2, "this probe only walks layout 2");
-    // Layout 2 defines three compression modes and the reader supports all of
-    // them; this probe only inflates. Dispatching on the flag lands one commit
-    // later in the stack, and until then a clear refusal beats handing a zstd
-    // or uncompressed block to libdeflate and reporting its complaint.
-    assert_eq!(
-        compression, 1,
-        "this probe only handles zlib (flag 1); see perf/bgen-projectable-ploidy \
-         for full dispatch"
-    );
-
-    // --- Phase A: walk the records and decompress every payload ---
-    let mut decompressor = libdeflater::Decompressor::new();
-    // Layout 2 defines three compression modes and the reader supports all of
-    // them, so the floor is measured in whichever one the file uses rather than
-    // in the zlib case this example was first written against.
+    // Layout 2 defines three compression modes and this probe handles all of
+    // them, so only an out-of-range flag is refused. The zlib-only assertion the
+    // previous commit carried is superseded by the dispatch below.
     assert!(
         compression <= 2,
         "unknown BGEN compression flag {compression}"
     );
+
+    // --- Phase A: walk the records and decompress every payload ---
+    let mut decompressor = libdeflater::Decompressor::new();
     let mut out = vec![0_u8; 64 << 20];
     let mut cursor = start_of_data;
     let mut walked = 0_usize;

--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -56,6 +56,13 @@ async fn main() {
 
     // --- Phase A: walk the records and decompress every payload ---
     let mut decompressor = libdeflater::Decompressor::new();
+    // Layout 2 defines three compression modes and the reader supports all of
+    // them, so the floor is measured in whichever one the file uses rather than
+    // in the zlib case this example was first written against.
+    assert!(
+        compression <= 2,
+        "unknown BGEN compression flag {compression}"
+    );
     let mut out = vec![0_u8; 64 << 20];
     let mut cursor = start_of_data;
     let mut walked = 0_usize;
@@ -98,23 +105,36 @@ async fn main() {
         if out.len() < expanded {
             out.resize(expanded, 0);
         }
-        let written = decompressor
-            .zlib_decompress(
-                &bytes[data_start..data_start + data_len],
-                &mut out[..expanded],
-            )
-            .expect("inflate");
+        let payload = &bytes[data_start..data_start + data_len];
+        let written = match compression {
+            // Nothing to decompress; copying the block is what a reader still
+            // does to hand it to the decoder.
+            0 => {
+                out[..expanded].copy_from_slice(payload);
+                expanded
+            }
+            1 => decompressor
+                .zlib_decompress(payload, &mut out[..expanded])
+                .expect("zlib inflate"),
+            _ => zstd::bulk::decompress_to_buffer(payload, &mut out[..expanded])
+                .expect("zstd decompress"),
+        };
         // Touch the output so the decompression cannot be optimized away.
         checksum += written as u64 + out[written - 1] as u64;
     }
     let inflate = inflate_started.elapsed();
 
+    let codec = match compression {
+        0 => "copy (none)",
+        1 => "zlib inflate",
+        _ => "zstd decode",
+    };
     println!(
         "\nrecord walk      {:>8.3} s   ({variant_count} records)",
         walk.as_secs_f64()
     );
     println!(
-        "zlib inflate     {:>8.3} s   {:.2} GB out from {:.2} GB in, {:.2} GB/s produced  [checksum {checksum}]",
+        "{codec:<16} {:>8.3} s   {:.2} GB out from {:.2} GB in, {:.2} GB/s produced  [checksum {checksum}]",
         inflate.as_secs_f64(),
         decompressed_total as f64 / 1e9,
         compressed_total as f64 / 1e9,

--- a/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_decode_profile.rs
@@ -9,6 +9,10 @@
 //! Usage:
 //!   cargo run --release -p datafusion-bio-format-bgen --example bgen_decode_profile \
 //!     -- <path.bgen> [partitions...]
+//!
+//! The floor phase reads the whole file into memory to walk its records, which
+//! is fine for a chromosome — chr22 is 160 MB — and is not for a whole-genome
+//! BGEN. Point it at one chromosome at a time.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -119,8 +123,10 @@ async fn main() {
             _ => zstd::bulk::decompress_to_buffer(payload, &mut out[..expanded])
                 .expect("zstd decompress"),
         };
-        // Touch the output so the decompression cannot be optimized away.
-        checksum += written as u64 + out[written - 1] as u64;
+        // Touch the output so the decompression cannot be optimized away. A
+        // zero-length block is pathological but representable, and indexing
+        // `written - 1` would panic on it.
+        checksum += written as u64 + out[..written].last().copied().unwrap_or(0) as u64;
     }
     let inflate = inflate_started.elapsed();
 
@@ -204,7 +210,9 @@ async fn main() {
                 .as_any()
                 .downcast_ref::<datafusion::arrow::array::StructArray>()
                 .expect("genotypes struct");
-            for child in [0_usize, 1] {
+            // However many children the projection kept: this defaults to DS
+            // alone, so a fixed [0, 1] would index past the struct.
+            for child in 0..genotypes.num_columns() {
                 let column = genotypes.column(child);
                 let list = column
                     .as_any()
@@ -240,14 +248,20 @@ async fn main() {
         if target == 1 {
             println!(
                 "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}   \
-                 inflate floor {:>6.3} s, everything else {:>6.3} s, digest {digest:016x}",
+                 inflate floor {:>6.3} s, everything else {:>6.3} s, digest {}",
                 scan.as_secs_f64(),
                 inflate.as_secs_f64(),
-                scan.as_secs_f64() - inflate.as_secs_f64()
+                scan.as_secs_f64() - inflate.as_secs_f64(),
+                // Printing the untouched seed would read as a real digest.
+                if digest_enabled {
+                    format!("{digest:016x}")
+                } else {
+                    "disabled".to_string()
+                }
             );
         } else {
             println!(
-                "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}   digest {digest:016x}",
+                "scan t={target:<2}         {:>8.3} s   rows={rows} batches={batches}",
                 scan.as_secs_f64()
             );
         }

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -316,8 +316,16 @@ impl GenotypeBuffers {
         self.variant_offsets = Vec::with_capacity(variant_offsets.len());
         self.variant_offsets.push(0);
         self.ploidy = Vec::with_capacity(ploidy.len());
-        self.ploidy_offsets = Vec::with_capacity(ploidy_offsets.len());
-        self.ploidy_offsets.push(0);
+        // Mirror the constructor: a buffer that does not collect ploidy keeps
+        // its offsets empty rather than carrying a lone sentinel, so `take()`
+        // leaves the same invariant `new()` established.
+        self.ploidy_offsets = if self.collect_ploidy {
+            let mut offsets = Vec::with_capacity(ploidy_offsets.len());
+            offsets.push(0);
+            offsets
+        } else {
+            Vec::new()
+        };
         self.samples = 0;
         self.sample_start = 0;
 

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -46,6 +46,13 @@ pub(crate) struct GenotypeBuffers {
     /// Index into `values` where the sample being written began.
     sample_start: usize,
     variant_offsets: Vec<i32>,
+    /// Whether the `PLOIDY` child is projected.
+    ///
+    /// It is one byte per genotype — 2.53 GB on a whole chromosome of this
+    /// cohort — and a scan that does not emit it should not pay to build it.
+    /// The decoders push unconditionally and this decides whether the push
+    /// lands, so the choice lives in one place rather than in every path.
+    collect_ploidy: bool,
     ploidy: Vec<u8>,
     ploidy_offsets: Vec<i32>,
 }
@@ -62,9 +69,10 @@ pub(crate) struct TakenBuffers {
 }
 
 impl GenotypeBuffers {
-    pub(crate) fn new(layout: BufferLayout) -> Self {
+    pub(crate) fn new(layout: BufferLayout, collect_ploidy: bool) -> Self {
         Self {
             layout,
+            collect_ploidy,
             values: Vec::new(),
             sample_offsets: match layout {
                 BufferLayout::NestedProbability => vec![0],
@@ -75,7 +83,7 @@ impl GenotypeBuffers {
             sample_start: 0,
             variant_offsets: vec![0],
             ploidy: Vec::new(),
-            ploidy_offsets: vec![0],
+            ploidy_offsets: if collect_ploidy { vec![0] } else { Vec::new() },
         }
     }
 
@@ -174,7 +182,9 @@ impl GenotypeBuffers {
 
     #[inline]
     pub(crate) fn push_ploidy(&mut self, ploidy: u8) {
-        self.ploidy.push(ploidy);
+        if self.collect_ploidy {
+            self.ploidy.push(ploidy);
+        }
     }
 
     /// Appends `count` samples that all declare `ploidy`.
@@ -183,7 +193,9 @@ impl GenotypeBuffers {
     /// value for every sample, so the column is a run and can be written as
     /// one instead of a byte at a time.
     pub(crate) fn extend_uniform_ploidy(&mut self, ploidy: u8, count: usize) {
-        self.ploidy.resize(self.ploidy.len() + count, ploidy);
+        if self.collect_ploidy {
+            self.ploidy.resize(self.ploidy.len() + count, ploidy);
+        }
     }
 
     /// Closes `count` called samples whose values are already in the buffer.
@@ -210,12 +222,14 @@ impl GenotypeBuffers {
                     "BGEN sample offsets exceed the 32-bit Arrow list limit".to_string(),
                 )
             })?);
-        self.ploidy_offsets
-            .push(i32::try_from(self.ploidy.len()).map_err(|_| {
-                DataFusionError::Execution(
-                    "BGEN ploidy offsets exceed the 32-bit Arrow list limit".to_string(),
-                )
-            })?);
+        if self.collect_ploidy {
+            self.ploidy_offsets
+                .push(i32::try_from(self.ploidy.len()).map_err(|_| {
+                    DataFusionError::Execution(
+                        "BGEN ploidy offsets exceed the 32-bit Arrow list limit".to_string(),
+                    )
+                })?);
+        }
         Ok(())
     }
 
@@ -324,7 +338,7 @@ mod tests {
 
     #[test]
     fn a_fixed_layout_pads_a_short_sample_with_nan_and_writes_no_offsets() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(4));
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(4), true);
         buffers.extend_states([0.5, 0.25, 0.25]);
         buffers.finish_sample().unwrap();
         buffers.push_ploidy(2);
@@ -346,7 +360,7 @@ mod tests {
 
     #[test]
     fn a_fixed_layout_rejects_a_sample_wider_than_its_width() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3));
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3), true);
         buffers.extend_states([0.25, 0.25, 0.25, 0.25]);
         let error = buffers.finish_sample().unwrap_err().to_string();
         assert!(
@@ -357,7 +371,7 @@ mod tests {
 
     #[test]
     fn a_fixed_layout_pads_a_missing_sample_to_the_full_width() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3));
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(3), true);
         buffers.finish_missing_sample().unwrap();
         buffers.extend_states([1.0, 0.0, 0.0]);
         buffers.finish_sample().unwrap();
@@ -384,7 +398,7 @@ mod tests {
 
     #[test]
     fn a_nested_layout_writes_one_offset_per_sample_and_no_padding() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability, true);
         buffers.extend_states([0.5, 0.5]);
         buffers.finish_sample().unwrap();
         buffers.finish_missing_sample().unwrap();
@@ -407,7 +421,7 @@ mod tests {
 
     #[test]
     fn validity_appears_only_once_a_sample_is_missing() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage);
+        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage, true);
         for value in [0.0_f32, 1.0, 2.0] {
             buffers.push_state(value);
             buffers.finish_sample().unwrap();
@@ -417,7 +431,7 @@ mod tests {
             "a fully called cohort must write no validity bytes at all"
         );
 
-        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage);
+        let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage, true);
         buffers.push_state(0.0);
         buffers.finish_sample().unwrap();
         buffers.finish_missing_sample().unwrap();
@@ -437,7 +451,7 @@ mod tests {
 
     #[test]
     fn rollback_restores_every_buffer_to_its_mark() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+        let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability, true);
         buffers.extend_states([1.0, 0.0]);
         buffers.finish_sample().unwrap();
         buffers.push_ploidy(2);
@@ -458,7 +472,7 @@ mod tests {
 
     #[test]
     fn take_resets_the_buffers_and_keeps_their_capacity() {
-        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(2));
+        let mut buffers = GenotypeBuffers::new(BufferLayout::FixedProbability(2), true);
         buffers.extend_states([0.5, 0.5]);
         buffers.finish_sample().unwrap();
         buffers.push_ploidy(2);

--- a/datafusion/bio-format-bgen/src/physical_exec.rs
+++ b/datafusion/bio-format-bgen/src/physical_exec.rs
@@ -483,7 +483,10 @@ fn fixed_probability_width(data_type: &DataType) -> Option<i32> {
     let DataType::Struct(fields) = data_type else {
         return None;
     };
-    let DataType::List(sample) = fields.first()?.data_type() else {
+    // By name, not by position: a projection chooses the order of the struct's
+    // children, so the value child is not necessarily the first one.
+    let genotype = fields.iter().find(|field| field.name() != "PLOIDY")?;
+    let DataType::List(sample) = genotype.data_type() else {
         return None;
     };
     match sample.data_type() {

--- a/datafusion/bio-format-bgen/src/physical_exec.rs
+++ b/datafusion/bio-format-bgen/src/physical_exec.rs
@@ -192,6 +192,9 @@ impl ExecutionPlan for BgenExec {
             let mut scratch = DecodeScratch::new();
             // The decoder appends into these, and a finished batch moves them
             // into its Arrow arrays.
+            let emits_ploidy = crate::table_provider::genotype_children(&fileset.options)?
+                .iter()
+                .any(|name| name == "PLOIDY");
             let mut buffers = GenotypeBuffers::new(
                 match (fileset.options.output_mode, fileset.probability_shape) {
                     (BgenOutputMode::Dosage, _) => BufferLayout::Dosage,
@@ -200,6 +203,7 @@ impl ExecutionPlan for BgenExec {
                     }
                     (BgenOutputMode::Probability, None) => BufferLayout::NestedProbability,
                 },
+                emits_ploidy,
             );
 
             if assignment.ranges.is_empty() {
@@ -505,8 +509,8 @@ fn build_genotypes(
         sample_offsets,
         nulls,
         variant_offsets,
-        ploidy,
-        ploidy_offsets,
+        mut ploidy,
+        mut ploidy_offsets,
     } = buffers;
     let genotype_values: ArrayRef = match mode {
         BgenOutputMode::Probability => {
@@ -554,16 +558,25 @@ fn build_genotypes(
             )?)
         }
     };
-    // Declared ploidy is never null.
-    let ploidy = Arc::new(ListArray::try_new(
-        Arc::new(Field::new("item", DataType::UInt8, false)),
-        OffsetBuffer::new(ScalarBuffer::from(ploidy_offsets)),
-        Arc::new(UInt8Array::from(ploidy)),
-        None,
-    )?);
+    // The children are whatever the projection asked for, in its order; a
+    // deselected `PLOIDY` was never collected, so there is nothing to build.
+    let mut children = Vec::with_capacity(fields.len());
+    for field in fields.iter() {
+        if field.name() == "PLOIDY" {
+            // Declared ploidy is never null.
+            children.push(Arc::new(ListArray::try_new(
+                Arc::new(Field::new("item", DataType::UInt8, false)),
+                OffsetBuffer::new(ScalarBuffer::from(std::mem::take(&mut ploidy_offsets))),
+                Arc::new(UInt8Array::from(std::mem::take(&mut ploidy))),
+                None,
+            )?) as ArrayRef);
+        } else {
+            children.push(Arc::clone(&genotype_values));
+        }
+    }
     Ok(Arc::new(StructArray::try_new(
         fields.clone(),
-        vec![genotype_values, ploidy],
+        children,
         None,
     )?))
 }

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -900,11 +900,21 @@ fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
             }
         })
         .collect::<Vec<_>>();
-    if children.is_empty() {
-        return Err(DataFusionError::Plan(
-            "BGEN genotype_fields selected no children; omit the genotypes column instead"
-                .to_string(),
-        ));
+    // A projection must keep the value child. Without it the decoder would still
+    // reconstruct every genotype — the block cannot be validated otherwise — for
+    // an array that is then discarded, while the batch sizer and `GenotypeBytes`
+    // counted bytes that were never emitted. Serving that badly is worse than
+    // refusing it; a caller wanting ploidy alone is asking for a column this
+    // scan does not have a cheap path to.
+    let value_child = match fileset.options.output_mode {
+        BgenOutputMode::Dosage => "DS",
+        BgenOutputMode::Probability => "GP",
+    };
+    if !children.iter().any(|field| field.name() != "PLOIDY") {
+        return Err(DataFusionError::Plan(format!(
+            "BGEN genotype_fields must include {value_child}; a projection of PLOIDY alone \
+             is not supported"
+        )));
     }
     let genotypes = Field::new("genotypes", DataType::Struct(Fields::from(children)), false)
         .with_metadata(sample_metadata);

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -910,7 +910,7 @@ fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
         BgenOutputMode::Dosage => "DS",
         BgenOutputMode::Probability => "GP",
     };
-    if !children.iter().any(|field| field.name() != "PLOIDY") {
+    if children.iter().all(|field| field.name() == "PLOIDY") {
         return Err(DataFusionError::Plan(format!(
             "BGEN genotype_fields must include {value_child}; a projection of PLOIDY alone \
              is not supported"

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -16,7 +16,7 @@ use datafusion_bio_format_core::genotype::{
     CoordinateSystem, GENOTYPE_COUNTED_ALLELE_KEY, GENOTYPE_OUTPUT_MODE_KEY,
     GENOTYPE_SOURCE_BIT_PRECISION_KEY, GENOTYPE_STATE_ORDER_KEY, GenotypeMetric,
     GenotypeScanMetrics, MissingSamplePolicy, PredicateGuarantee, can_push_limit_below_filters,
-    resolve_samples,
+    resolve_genotype_fields, resolve_samples,
 };
 use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
 use datafusion_bio_format_core::range_planning::{
@@ -117,6 +117,14 @@ pub struct BgenReadOptions {
     pub bgi_path: Option<String>,
     /// Requested sample names in output order.
     pub samples: Option<Vec<String>>,
+    /// Children of the `genotypes` struct to emit, in output order.
+    ///
+    /// `None` emits all of them, which is what a caller that does not know the
+    /// option gets. The available names are the output mode's value child —
+    /// `DS` for dosage, `GP` for probability — and `PLOIDY`. `PLOIDY` is one
+    /// byte per genotype, so a caller that only wants dosages can ask for
+    /// `["DS"]` and not pay for it.
+    pub genotype_fields: Option<Vec<String>>,
     /// Behavior for absent requested samples.
     pub missing_sample_policy: MissingSamplePolicy,
     /// Output coordinate presentation.
@@ -183,6 +191,7 @@ impl Default for BgenReadOptions {
             sample_path: None,
             bgi_path: None,
             samples: None,
+            genotype_fields: None,
             missing_sample_policy: MissingSamplePolicy::Error,
             coordinate_system: CoordinateSystem::ZeroBasedHalfOpen,
             object_storage_options: None,
@@ -761,7 +770,7 @@ async fn probe_probability_width(
     let variant = &variant;
     let mut scratch = DecodeScratch::new();
     // The probe selects no sample, so nothing is written into these.
-    let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability);
+    let mut buffers = GenotypeBuffers::new(BufferLayout::NestedProbability, false);
     let decoded = decode_variant(
         path,
         variant,
@@ -808,6 +817,23 @@ fn fixed_list_width(width: usize) -> Result<i32> {
              use the nested probability layout"
         ))
     })
+}
+
+/// The `genotypes` struct children this scan emits, in output order.
+///
+/// The value child's name follows the output mode, so the available set is
+/// resolved per fileset rather than fixed.
+pub(crate) fn genotype_children(options: &BgenReadOptions) -> Result<Vec<String>> {
+    let value_child = match options.output_mode {
+        BgenOutputMode::Dosage => "DS",
+        BgenOutputMode::Probability => "GP",
+    };
+    let available = vec![value_child.to_string(), "PLOIDY".to_string()];
+    Ok(
+        resolve_genotype_fields(&available, options.genotype_fields.as_deref())?
+            .names()
+            .to_vec(),
+    )
 }
 
 fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
@@ -864,12 +890,24 @@ fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
             (GENOTYPE_OUTPUT_MODE_KEY.to_string(), "dosage".to_string()),
         ])),
     };
-    let genotypes = Field::new(
-        "genotypes",
-        DataType::Struct(Fields::from(vec![genotype_child, ploidy])),
-        false,
-    )
-    .with_metadata(sample_metadata);
+    let children = genotype_children(&fileset.options)?
+        .into_iter()
+        .map(|name| {
+            if name == "PLOIDY" {
+                ploidy.clone()
+            } else {
+                genotype_child.clone()
+            }
+        })
+        .collect::<Vec<_>>();
+    if children.is_empty() {
+        return Err(DataFusionError::Plan(
+            "BGEN genotype_fields selected no children; omit the genotypes column instead"
+                .to_string(),
+        ));
+    }
+    let genotypes = Field::new("genotypes", DataType::Struct(Fields::from(children)), false)
+        .with_metadata(sample_metadata);
     let fields = vec![
         Field::new("chrom", DataType::Utf8, false),
         Field::new("start", DataType::UInt64, false),

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -611,6 +611,11 @@ impl TableProvider for BgenTableProvider {
 }
 
 fn validate_options(options: &BgenReadOptions) -> Result<()> {
+    // Before the object is opened. Resolving the selection needs only the read
+    // options, and a bad one used to surface from `build_schema` — after the
+    // header, the catalog, and on a remote file without a usable index a read
+    // of the whole object, all to report a configuration mistake.
+    genotype_children(options)?;
     for (name, value) in [
         ("max_sample_block_bytes", options.max_sample_block_bytes),
         ("max_header_bytes", options.max_header_bytes),
@@ -829,11 +834,28 @@ pub(crate) fn genotype_children(options: &BgenReadOptions) -> Result<Vec<String>
         BgenOutputMode::Probability => "GP",
     };
     let available = vec![value_child.to_string(), "PLOIDY".to_string()];
-    Ok(
-        resolve_genotype_fields(&available, options.genotype_fields.as_deref())?
-            .names()
-            .to_vec(),
-    )
+    let names = resolve_genotype_fields(&available, options.genotype_fields.as_deref())?
+        .names()
+        .to_vec();
+    if names.is_empty() {
+        return Err(DataFusionError::Plan(
+            "BGEN genotype_fields selected no children; omit the genotypes column from the \
+             projection instead"
+                .to_string(),
+        ));
+    }
+    // A projection must keep the value child. Without it the decoder would still
+    // reconstruct every genotype — the block cannot be validated otherwise — for
+    // an array that is then discarded, while the batch sizer and `GenotypeBytes`
+    // counted bytes that were never emitted. Serving that badly is worse than
+    // refusing it.
+    if names.iter().all(|name| name == "PLOIDY") {
+        return Err(DataFusionError::Plan(format!(
+            "BGEN genotype_fields must include {value_child}; a projection of PLOIDY alone \
+             is not supported"
+        )));
+    }
+    Ok(names)
 }
 
 fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
@@ -900,22 +922,6 @@ fn build_schema(fileset: &BgenFileset) -> Result<SchemaRef> {
             }
         })
         .collect::<Vec<_>>();
-    // A projection must keep the value child. Without it the decoder would still
-    // reconstruct every genotype — the block cannot be validated otherwise — for
-    // an array that is then discarded, while the batch sizer and `GenotypeBytes`
-    // counted bytes that were never emitted. Serving that badly is worse than
-    // refusing it; a caller wanting ploidy alone is asking for a column this
-    // scan does not have a cheap path to.
-    let value_child = match fileset.options.output_mode {
-        BgenOutputMode::Dosage => "DS",
-        BgenOutputMode::Probability => "GP",
-    };
-    if children.iter().all(|field| field.name() == "PLOIDY") {
-        return Err(DataFusionError::Plan(format!(
-            "BGEN genotype_fields must include {value_child}; a projection of PLOIDY alone \
-             is not supported"
-        )));
-    }
     let genotypes = Field::new("genotypes", DataType::Struct(Fields::from(children)), false)
         .with_metadata(sample_metadata);
     let fields = vec![

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -956,6 +956,55 @@ async fn whole_cohort_dosage_matches_the_per_sample_decode() {
 }
 
 #[tokio::test]
+async fn the_whole_cohort_fill_bails_to_the_per_sample_error() {
+    // The bulk fill is only valid while every unphased pair sums within the
+    // denominator, so it pre-checks and declines otherwise. The decline has to
+    // land on the per-sample path's error rather than on a silently different
+    // answer, and that hand-off is the one branch of the fill without its own
+    // test.
+    let variants = vec![Variant {
+        id: "over",
+        rsid: "rsover",
+        chrom: "1",
+        position: 10,
+        alleles: vec!["A", "C"],
+        phased: false,
+        bits: 8,
+        samples: vec![
+            sample(2, false, &[255, 0]),
+            sample(2, false, &[0, 255]),
+            // 200 + 200 exceeds the 8-bit denominator, which no valid file
+            // stores and the fill must not quietly accept.
+            sample(2, false, &[200, 200]),
+        ],
+    }];
+    let fixture = fixture_with_variants(Codec::Zlib, true, &variants);
+    let provider = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let context = context(1024);
+    context.register_table("b", Arc::new(provider)).unwrap();
+    let error = context
+        .sql("SELECT genotypes FROM b")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect_err("a stored sum above the denominator must not decode")
+        .to_string();
+    assert!(
+        error.contains("exceeds denominator"),
+        "the fill must decline to the per-sample diagnosis: {error}"
+    );
+}
+
+#[tokio::test]
 async fn genotype_fields_select_the_struct_children() {
     // PLOIDY is a byte per genotype — on a whole chromosome of this cohort it is
     // 2.53 GB the caller of a dosage read never asked for — and it is held alive

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -2650,6 +2650,46 @@ async fn fixed_probability_layout_survives_ploidy_being_projected_first() {
 }
 
 #[tokio::test]
+async fn an_empty_genotype_selection_says_so() {
+    // `Some(vec![])` is a selection of nothing, not a selection of PLOIDY, and
+    // it used to be reported with the PLOIDY-alone message because an `all`
+    // predicate is vacuously true on an empty list.
+    let fixture = fixture(Codec::Zlib, true);
+    let error = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            genotype_fields: Some(Vec::new()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("selected no children"), "{error}");
+}
+
+#[tokio::test]
+async fn genotype_fields_are_validated_before_the_file_is_opened() {
+    // The selection needs only the read options, so a bad one must not cost a
+    // header read, a catalog build, or — on a remote file without a usable
+    // index — a read of the whole object first.
+    let error = BgenTableProvider::try_new(
+        "/nonexistent/never-opened.bgen",
+        BgenReadOptions {
+            genotype_fields: Some(vec!["NOPE".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(
+        error.contains("NOPE"),
+        "the field error must arrive before the open error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn a_projection_without_the_value_child_is_rejected() {
     // PLOIDY alone would leave the decoder reconstructing every probability for
     // an array that is then discarded, and the batch sizer counting bytes that

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -1046,29 +1046,8 @@ async fn genotype_fields_select_the_struct_children() {
     assert_eq!(struct_array.num_columns(), 1);
     assert!(struct_array.column_by_name("PLOIDY").is_none());
 
-    // PLOIDY only is also a valid projection.
-    let ploidy_only = BgenTableProvider::try_new(
-        path(&fixture.bgen),
-        BgenReadOptions {
-            output_mode: BgenOutputMode::Dosage,
-            genotype_fields: Some(vec!["PLOIDY".to_string()]),
-            ..Default::default()
-        },
-    )
-    .await
-    .unwrap();
-    let ploidy_context = context(1024);
-    ploidy_context
-        .register_table("p", Arc::new(ploidy_only))
-        .unwrap();
-    let batches = ploidy_context
-        .sql("SELECT genotypes FROM p ORDER BY start")
-        .await
-        .unwrap()
-        .collect()
-        .await
-        .unwrap();
-    assert_eq!(ploidy_values(&batches[0], 0, 0), vec![2, 2, 2]);
+    // PLOIDY without the value child is rejected; see
+    // `a_projection_without_the_value_child_is_rejected`.
 
     // An unknown child is rejected at plan time rather than silently ignored.
     let error = BgenTableProvider::try_new(
@@ -2570,6 +2549,74 @@ async fn a_large_in_list_does_not_fail_index_lookup() {
         batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
         0
     );
+}
+
+#[tokio::test]
+async fn fixed_probability_layout_survives_ploidy_being_projected_first() {
+    // The fixed layout is detected from the schema, and the detection used to
+    // look at the struct's first child. Ordering PLOIDY ahead of GP made it read
+    // a `List<UInt8>` where it expected a `FixedSizeList`, conclude the batch
+    // was nested, and build the values from a `sample_offsets` buffer the fixed
+    // layout never fills.
+    let fixture = fixture(Codec::Zlib, true);
+    let context = context(1024);
+
+    let ordered = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            probability_layout: BgenProbabilityLayout::Fixed,
+            genotype_fields: Some(vec!["PLOIDY".to_string(), "GP".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let schema = TableProvider::schema(&ordered);
+    let genotypes = schema.field_with_name("genotypes").unwrap();
+    assert!(
+        format!("{:?}", genotypes.data_type()).contains("FixedSizeList"),
+        "the fixed width must survive the reordering: {:?}",
+        genotypes.data_type()
+    );
+    context.register_table("o", Arc::new(ordered)).unwrap();
+    let rows = context
+        .sql("SELECT genotypes FROM o WHERE rsid = 'rs1'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect("a reordered fixed-layout projection must still decode");
+    assert_eq!(rows.iter().map(|batch| batch.num_rows()).sum::<usize>(), 1);
+    let struct_array = rows[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let names: Vec<&str> = struct_array
+        .fields()
+        .iter()
+        .map(|field| field.name().as_str())
+        .collect();
+    assert_eq!(names, vec!["PLOIDY", "GP"]);
+}
+
+#[tokio::test]
+async fn a_projection_without_the_value_child_is_rejected() {
+    // PLOIDY alone would leave the decoder reconstructing every probability for
+    // an array that is then discarded, and the batch sizer counting bytes that
+    // are never emitted. Rejecting it is better than serving it badly.
+    let fixture = fixture(Codec::Zlib, true);
+    let error = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            genotype_fields: Some(vec!["PLOIDY".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("GP"), "{error}");
 }
 
 #[tokio::test]

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -956,6 +956,136 @@ async fn whole_cohort_dosage_matches_the_per_sample_decode() {
 }
 
 #[tokio::test]
+async fn genotype_fields_select_the_struct_children() {
+    // PLOIDY is a byte per genotype — on a whole chromosome of this cohort it is
+    // 2.53 GB the caller of a dosage read never asked for — and it is held alive
+    // as long as the values are, because a NumPy view of the result keeps the
+    // whole Arrow struct. A scan that does not emit it must not build it.
+    let fixture = fixture_with_variants(Codec::Zlib, true, &fully_called_variants());
+
+    // Default: both children, in the order the struct declares them.
+    let all = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let names: Vec<String> = match all
+        .schema()
+        .field_with_name("genotypes")
+        .unwrap()
+        .data_type()
+    {
+        datafusion::arrow::datatypes::DataType::Struct(fields) => {
+            fields.iter().map(|f| f.name().to_string()).collect()
+        }
+        other => panic!("genotypes is {other:?}"),
+    };
+    assert_eq!(names, vec!["DS".to_string(), "PLOIDY".to_string()]);
+
+    // DS only: the struct has one child and the values are unchanged.
+    let ds_only = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            genotype_fields: Some(vec!["DS".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let names: Vec<String> = match ds_only
+        .schema()
+        .field_with_name("genotypes")
+        .unwrap()
+        .data_type()
+    {
+        datafusion::arrow::datatypes::DataType::Struct(fields) => {
+            fields.iter().map(|f| f.name().to_string()).collect()
+        }
+        other => panic!("genotypes is {other:?}"),
+    };
+    assert_eq!(names, vec!["DS".to_string()]);
+
+    let both_context = context(1024);
+    both_context.register_table("all", Arc::new(all)).unwrap();
+    both_context
+        .register_table("ds", Arc::new(ds_only))
+        .unwrap();
+    let with_ploidy = both_context
+        .sql("SELECT genotypes FROM all ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let without = both_context
+        .sql("SELECT genotypes FROM ds ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    for row in 0..2 {
+        assert_eq!(
+            dosage_values(&with_ploidy[0], 0, row),
+            dosage_values(&without[0], 0, row),
+            "row {row}"
+        );
+    }
+    // Deselecting it removes the child rather than emptying it: a consumer that
+    // asks for PLOIDY on this scan gets a schema error, not a null column.
+    let struct_array = without[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    assert_eq!(struct_array.num_columns(), 1);
+    assert!(struct_array.column_by_name("PLOIDY").is_none());
+
+    // PLOIDY only is also a valid projection.
+    let ploidy_only = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            genotype_fields: Some(vec!["PLOIDY".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let ploidy_context = context(1024);
+    ploidy_context
+        .register_table("p", Arc::new(ploidy_only))
+        .unwrap();
+    let batches = ploidy_context
+        .sql("SELECT genotypes FROM p ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(ploidy_values(&batches[0], 0, 0), vec![2, 2, 2]);
+
+    // An unknown child is rejected at plan time rather than silently ignored.
+    let error = BgenTableProvider::try_new(
+        path(&fixture.bgen),
+        BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            genotype_fields: Some(vec!["GP".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("GP"), "{error}");
+}
+
+#[tokio::test]
 async fn decodes_layout1_uncompressed_and_zlib() {
     for codec in [Codec::None, Codec::Zlib] {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Stacked on #235, which is stacked on #234. This PR's diff is the third commit.

## Why

The `genotypes` struct always carried both `DS`/`GP` and `PLOIDY`, and no
projection could drop either. That is not a small default: `PLOIDY` is one byte
per genotype — **2.53 GB** on chromosome 22 of this cohort, against the dosages'
10.13 GB.

It is also not transient. Instrumenting the benchmark's dosage adapter, the
returned NumPy matrix is a *view* into the combined Arrow struct
(`matrix.base is not None`), so the `PLOIDY` column stays resident for the life
of a result that never asked for it — 12.80 GB retained for a 10.13 GB answer.
That measurement is what prompted this change; it came out of investigating an
apparent RSS regression which [turned out not to be one](https://github.com/biodatageeks/datafusion-bio-formats/pull/235#issuecomment).

## What

`BgenReadOptions::genotype_fields` selects which children to emit — the same
option `PgenReadOptions` already has, resolved by the same
`resolve_genotype_fields` helper in `bio-format-core`. `None` emits both, so
nothing changes for a caller that does not set it.

```rust
BgenReadOptions {
    output_mode: BgenOutputMode::Dosage,
    genotype_fields: Some(vec!["DS".to_string()]),   // no PLOIDY
    ..Default::default()
}
```

The decision lives in `GenotypeBuffers`, not in the decode paths: the decoders
push ploidy unconditionally and the buffer decides whether the push lands. No
decode path had to learn about projection, and none of them can disagree about
it.

## Measured

Chromosome 22, 993,881 × 2,548, one partition, `DS` only against both:

| | both children | `DS` only |
|---|---:|---:|
| emitted genotype data | 12.66 GB | **10.13 GB** |
| scan peak RSS | ~800 MB | ~700 MB |
| scan wall time | 11.67 s | 12.01 s |

The 2.53 GB is the point, and it is paid by whatever holds the result rather
than by the scan.

**The scan is ~3% slower and that is worth explaining rather than hiding.** It is
a batch-sizing artifact, not decode work: the soft byte budget is spent on real
emitted bytes, so dropping a fifth of them packs more rows per batch — 151
batches instead of 340 — and the values buffer's growth copies more each time it
doubles. Reproducible across runs, and the same in both directions.

## Tests

`genotype_fields_select_the_struct_children` covers the default (both children,
in declared order), `DS` only, `PLOIDY` only, that the dosage values are
identical either way, that deselecting removes the child rather than nulling it,
and that an unknown child name is rejected at plan time. All 79 BGEN tests pass;
`cargo fmt --all -- --check` and `cargo clippy --all-targets` are clean.

## Not in this PR

A caller wanting the saving end to end also needs the option plumbed through its
binding — for polars-bio that is a `scan_bgen(genotype_fields=...)` parameter.
This change only makes it available.