### PR TITLE
feat(bgen): decode dosages straight into a caller-owned matrix, 6.0x scaling

### DIFF
--- a/datafusion/bio-format-bgen/examples/bgen_matrix_profile.rs
+++ b/datafusion/bio-format-bgen/examples/bgen_matrix_profile.rs
@@ -1,0 +1,62 @@
+//! Times the matrix path against the Arrow scan it replaces.
+//!
+//! Usage:
+//!   cargo run --release -p datafusion-bio-format-bgen --example bgen_matrix_profile \
+//!     -- <path.bgen> [threads...]
+
+use std::time::Instant;
+
+use datafusion_bio_format_bgen::matrix::{genotype_matrix_shape, read_genotype_matrix};
+use datafusion_bio_format_bgen::{BgenOutputMode, BgenReadOptions};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: bgen_matrix_profile <path.bgen> [threads...]");
+    let threads: Vec<usize> = {
+        let rest: Vec<usize> = std::env::args()
+            .skip(2)
+            .map(|value| value.parse().expect("thread count"))
+            .collect();
+        if rest.is_empty() {
+            vec![1, 2, 4, 8]
+        } else {
+            rest
+        }
+    };
+    let options = BgenReadOptions {
+        output_mode: BgenOutputMode::Dosage,
+        genotype_fields: Some(vec!["DS".to_string()]),
+        ..Default::default()
+    };
+    let shape = genotype_matrix_shape(path.clone(), options.clone())
+        .await
+        .expect("shape");
+    println!(
+        "{} variants x {} samples = {} cells",
+        shape.variants,
+        shape.samples,
+        shape.variants * shape.samples
+    );
+    println!(
+        "{:>8} {:>10} {:>9} {:>14}",
+        "threads", "seconds", "speedup", "checksum"
+    );
+    let mut base = None;
+    for count in threads {
+        let mut values = vec![0.0_f32; shape.variants * shape.samples];
+        let started = Instant::now();
+        read_genotype_matrix(path.clone(), options.clone(), &mut values, f32::NAN, count)
+            .await
+            .expect("matrix");
+        let elapsed = started.elapsed().as_secs_f64();
+        // Outside the timer: reading 10 GB back would dominate the figure.
+        let checksum: f64 = values.iter().step_by(9_973).map(|v| *v as f64).sum();
+        let first = *base.get_or_insert(elapsed);
+        println!(
+            "{count:>8} {elapsed:>10.3} {:>8.2}x {checksum:>14.1}",
+            first / elapsed
+        );
+    }
+}

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -185,10 +185,13 @@ impl GenotypeBuffers {
         &self.values
     }
 
-    /// Drops everything written, keeping the allocations.
+    /// Drops everything a variant wrote, keeping the allocations.
     ///
     /// The matrix path decodes one variant at a time and moves its row into the
-    /// caller's array, so the buffer is a scratch pad rather than a batch.
+    /// caller's array, so the buffer is a scratch pad rather than a batch. Row
+    /// bookkeeping — `variant_offsets` and the ploidy offsets — is untouched,
+    /// because that path never calls [`Self::finish_variant`]; this resets what
+    /// a variant writes, not the batch it would have belonged to.
     pub(crate) fn reset(&mut self) {
         self.values.clear();
         self.sample_offsets.clear();

--- a/datafusion/bio-format-bgen/src/buffers.rs
+++ b/datafusion/bio-format-bgen/src/buffers.rs
@@ -180,6 +180,26 @@ impl GenotypeBuffers {
         Ok(())
     }
 
+    /// The values written so far.
+    pub(crate) fn values(&self) -> &[f32] {
+        &self.values
+    }
+
+    /// Drops everything written, keeping the allocations.
+    ///
+    /// The matrix path decodes one variant at a time and moves its row into the
+    /// caller's array, so the buffer is a scratch pad rather than a batch.
+    pub(crate) fn reset(&mut self) {
+        self.values.clear();
+        self.sample_offsets.clear();
+        if self.layout == BufferLayout::NestedProbability {
+            self.sample_offsets.push(0);
+        }
+        self.valid = None;
+        self.samples = 0;
+        self.sample_start = 0;
+    }
+
     #[inline]
     pub(crate) fn push_ploidy(&mut self, ploidy: u8) {
         if self.collect_ploidy {

--- a/datafusion/bio-format-bgen/src/lib.rs
+++ b/datafusion/bio-format-bgen/src/lib.rs
@@ -8,6 +8,7 @@ mod catalog;
 mod decode;
 mod filter;
 mod header;
+pub mod matrix;
 mod physical_exec;
 mod source;
 mod table_provider;

--- a/datafusion/bio-format-bgen/src/matrix.rs
+++ b/datafusion/bio-format-bgen/src/matrix.rs
@@ -22,7 +22,7 @@ use datafusion::common::{DataFusionError, Result};
 use crate::buffers::{BufferLayout, GenotypeBuffers};
 use crate::catalog::resolve_variant;
 use crate::decode::{DecodeScratch, decode_variant};
-use crate::physical_exec::{BgenPartition, slice_from_range};
+use crate::physical_exec::{BgenReadRange, slice_from_range};
 use crate::table_provider::{
     BgenFileset, BgenOutputMode, BgenReadOptions, BgenTableProvider, plan_payload_partitions,
 };
@@ -75,13 +75,19 @@ impl GenotypeMatrixReader {
     }
 
     /// The variant start positions, in row order.
+    ///
+    /// These are the `start` the scan emits, which the configured coordinate
+    /// system has already adjusted — not the raw one-based BGEN position, which
+    /// would label every row one base later than the DataFrame path under the
+    /// zero-based default. Allocated per call; a caller that wants them once
+    /// should keep the result rather than ask again.
     pub fn positions(&self) -> Vec<u64> {
         self.provider
             .fileset()
             .catalog
             .variants
             .iter()
-            .map(|variant| variant.position as u64)
+            .map(|variant| variant.start)
             .collect()
     }
 
@@ -146,7 +152,11 @@ impl GenotypeMatrixReader {
                 .flat_map(|range| range.variants.iter())
                 .copied()
                 .min()
-                .unwrap_or(cursor);
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "BGEN matrix partition reports rows but names no variants".to_string(),
+                    )
+                })?;
             if first != cursor {
                 return Err(DataFusionError::Execution(
                     "BGEN matrix partitions are not contiguous in variant order".to_string(),
@@ -162,60 +172,93 @@ impl GenotypeMatrixReader {
             )));
         }
 
-        // The ranges are fetched here because the object source is async;
-        // decoding is what runs in parallel afterwards. Input is bounded by the
-        // range planner rather than by the file.
-        let mut loaded = Vec::with_capacity(partitions.len());
-        for partition in &partitions {
-            let mut ranges = Vec::with_capacity(partition.ranges.len());
-            for range in &partition.ranges {
-                let bytes = fileset
-                    .source
-                    .read_range(&fileset.path, range.range.start..range.range.end)
-                    .await?;
-                ranges.push((range.range, bytes.to_vec()));
-            }
-            loaded.push(ranges);
-        }
-
-        let mut rest = values;
+        // Precomputed so a range carries no state from the one before it: a
+        // range's rows are its variants, in order, so where each starts is
+        // known before any of them is read. That is what lets the input be
+        // fetched a round at a time rather than all at once.
         let mut slices = Vec::with_capacity(partitions.len());
+        let mut rest = values;
         for rows in &owned {
             let (head, tail) = rest.split_at_mut(rows * shape.samples);
             slices.push(head);
             rest = tail;
         }
-
-        std::thread::scope(|scope| {
-            let handles = partitions
-                .iter()
-                .zip(loaded.iter())
-                .zip(slices)
-                .map(|((partition, ranges), slice)| {
-                    let fileset = Arc::clone(&fileset);
-                    let options = self.options.clone();
-                    scope.spawn(move || {
-                        decode_partition(
-                            &fileset,
-                            &options,
-                            partition,
-                            ranges,
-                            slice,
-                            shape.samples,
-                            missing,
-                        )
+        let starts = partitions
+            .iter()
+            .map(|partition| {
+                partition
+                    .ranges
+                    .iter()
+                    .scan(0_usize, |row, range| {
+                        let start = *row;
+                        *row += range.variants.len();
+                        Some(start)
                     })
-                })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        // One range per partition per round. Buffering every range of every
+        // partition first would hold the whole compressed file — and on a
+        // sample subset the destination is the small half — so resident input
+        // is bounded by the range planner instead.
+        let rounds = partitions
+            .iter()
+            .map(|partition| partition.ranges.len())
+            .max()
+            .unwrap_or(0);
+        for round in 0..rounds {
+            // `Bytes` is Arc-backed, so a range is shared with the decoder
+            // rather than copied out of the read.
+            let mut loaded: Vec<Option<(&BgenReadRange, bytes::Bytes)>> =
+                Vec::with_capacity(partitions.len());
+            for partition in &partitions {
+                match partition.ranges.get(round) {
+                    Some(planned) => {
+                        let bytes = fileset
+                            .source
+                            .read_range(&fileset.path, planned.range.start..planned.range.end)
+                            .await?;
+                        loaded.push(Some((planned, bytes)));
+                    }
+                    None => loaded.push(None),
+                }
+            }
+            let borrowed = loaded
+                .iter()
+                .map(|slot| slot.as_ref().map(|(planned, bytes)| (*planned, &bytes[..])))
                 .collect::<Vec<_>>();
-            handles
-                .into_iter()
-                .map(|handle| {
-                    handle.join().map_err(|_| {
-                        DataFusionError::Execution("BGEN matrix decoder panicked".to_string())
-                    })?
-                })
-                .collect::<Result<Vec<_>>>()
-        })?;
+
+            std::thread::scope(|scope| {
+                let handles = borrowed
+                    .iter()
+                    .zip(slices.iter_mut())
+                    .zip(&starts)
+                    .filter_map(|((slot, slice), partition_starts)| {
+                        slot.map(|(planned, bytes)| {
+                            let fileset = Arc::clone(&fileset);
+                            let options = self.options.clone();
+                            let start = partition_starts[round];
+                            let samples = shape.samples;
+                            scope.spawn(move || {
+                                decode_range(
+                                    &fileset, &options, planned, bytes, slice, samples, missing,
+                                    start,
+                                )
+                            })
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                handles
+                    .into_iter()
+                    .map(|handle| {
+                        handle.join().map_err(|_| {
+                            DataFusionError::Execution("BGEN matrix decoder panicked".to_string())
+                        })?
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })?;
+        }
         Ok(shape)
     }
 }
@@ -242,80 +285,81 @@ pub async fn read_genotype_matrix(
     Ok((shape, positions))
 }
 
-type LoadedRanges = Vec<(
-    datafusion_bio_format_core::range_planning::ByteRange,
-    Vec<u8>,
-)>;
-
-/// Decodes one partition's variants into its own slice of the matrix.
-fn decode_partition(
+/// Decodes one byte range's variants into the partition's slice of the matrix.
+///
+/// Carries nothing between calls: `start` is where this range's rows begin, and
+/// a range's variants are contiguous rows in order, so the input can be fetched
+/// a round at a time without a resumable decoder.
+#[allow(clippy::too_many_arguments)]
+fn decode_range(
     fileset: &BgenFileset,
     options: &BgenReadOptions,
-    partition: &BgenPartition,
-    ranges: &LoadedRanges,
+    planned: &BgenReadRange,
+    bytes: &[u8],
     values: &mut [f32],
     samples: usize,
     missing: f32,
+    start: usize,
 ) -> Result<()> {
     let selected_samples = fileset.selected_samples.source_indices();
     let mut scratch = DecodeScratch::new();
     // Dosage layout, no PLOIDY: this path emits one value per sample and
     // nothing else, so the buffer holds exactly one row at a time.
     let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage, false);
-    let mut row = 0_usize;
 
-    for ((range, bytes), planned) in ranges.iter().zip(&partition.ranges) {
-        for &variant_index in &planned.variants {
-            let catalogued = &fileset.catalog.variants[variant_index];
-            let span = catalogued.scan_span();
-            let record = slice_from_range(bytes, range.start, span, variant_index)?;
-            let owned;
-            let resolved = if catalogued.is_resolved() {
-                catalogued
-            } else {
-                owned =
-                    resolve_variant(&fileset.path, catalogued, record, &fileset.header, options)?;
-                &owned
-            };
-            let payload_span = resolved.payload_span().ok_or_else(|| {
-                DataFusionError::Internal(
-                    "BGEN variant stayed unresolved after being parsed".to_string(),
-                )
+    for (offset, &variant_index) in planned.variants.iter().enumerate() {
+        let catalogued = &fileset.catalog.variants[variant_index];
+        let record = slice_from_range(
+            bytes,
+            planned.range.start,
+            catalogued.scan_span(),
+            variant_index,
+        )?;
+        let owned;
+        let resolved = if catalogued.is_resolved() {
+            catalogued
+        } else {
+            owned = resolve_variant(&fileset.path, catalogued, record, &fileset.header, options)?;
+            &owned
+        };
+        let payload_span = resolved.payload_span().ok_or_else(|| {
+            DataFusionError::Internal(
+                "BGEN variant stayed unresolved after being parsed".to_string(),
+            )
+        })?;
+        let payload = slice_from_range(bytes, planned.range.start, payload_span, variant_index)?;
+
+        buffers.reset();
+        decode_variant(
+            &fileset.path,
+            resolved,
+            &fileset.header,
+            payload,
+            selected_samples,
+            options,
+            &mut scratch,
+            &mut buffers,
+        )?;
+
+        let row = start + offset;
+        let out = values
+            .get_mut(row * samples..(row + 1) * samples)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "BGEN variant {variant_index} row {row} is outside the matrix"
+                ))
             })?;
-            let payload = slice_from_range(bytes, range.start, payload_span, variant_index)?;
-
-            buffers.reset();
-            decode_variant(
-                &fileset.path,
-                resolved,
-                &fileset.header,
-                payload,
-                selected_samples,
-                options,
-                &mut scratch,
-                &mut buffers,
-            )?;
-
-            let out = values
-                .get_mut(row * samples..(row + 1) * samples)
-                .ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "BGEN variant {variant_index} row {row} is outside the matrix"
-                    ))
-                })?;
-            let decoded = buffers.values();
-            if decoded.len() != samples {
-                return Err(DataFusionError::Execution(format!(
-                    "BGEN variant {variant_index} decoded {} values; expected {samples}",
-                    decoded.len()
-                )));
-            }
-            // A missing dosage is NaN in the buffer; the caller chooses what it
-            // wants to see instead.
-            for (slot, &value) in out.iter_mut().zip(decoded) {
-                *slot = if value.is_nan() { missing } else { value };
-            }
-            row += 1;
+        let decoded = buffers.values();
+        if decoded.len() != samples {
+            return Err(DataFusionError::Execution(format!(
+                "BGEN variant {variant_index} decoded {} values; expected {samples}",
+                decoded.len()
+            )));
+        }
+        // A missing dosage is NaN in the buffer; the caller chooses what it
+        // wants to see instead.
+        for (slot, &value) in out.iter_mut().zip(decoded) {
+            *slot = if value.is_nan() { missing } else { value };
         }
     }
     Ok(())

--- a/datafusion/bio-format-bgen/src/matrix.rs
+++ b/datafusion/bio-format-bgen/src/matrix.rs
@@ -1,0 +1,322 @@
+//! Decoding BGEN dosages straight into a caller-owned matrix.
+//!
+//! The scan builds Arrow batches, and a caller that wants one dense array then
+//! consolidates them. On a whole chromosome that consolidation is a serial pass
+//! over 10 GB — measured at 1.2–1.8 s, against a scan that divides 6.3× across
+//! eight partitions — so it becomes the ceiling as partitions are added.
+//!
+//! This path removes it. Each partition decodes its variants and writes each
+//! row at its final address, so the values cross one buffer that stays in cache
+//! rather than a 10 GB one that does not.
+//!
+//! The decode itself is the scan's, variant for variant: a matrix row is one
+//! variant's dosages, so the existing per-variant buffer is filled and moved
+//! into the destination rather than accumulated into a batch. Every layout,
+//! codec and fast path the scan supports is therefore supported here without a
+//! second implementation to keep in step.
+
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, Result};
+
+use crate::buffers::{BufferLayout, GenotypeBuffers};
+use crate::catalog::resolve_variant;
+use crate::decode::{DecodeScratch, decode_variant};
+use crate::physical_exec::{BgenPartition, slice_from_range};
+use crate::table_provider::{
+    BgenFileset, BgenOutputMode, BgenReadOptions, BgenTableProvider, plan_payload_partitions,
+};
+
+/// The shape a fileset will produce, reported before any genotype is read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MatrixShape {
+    /// Rows, one per variant.
+    pub variants: usize,
+    /// Columns, one per selected sample.
+    pub samples: usize,
+}
+
+/// An opened BGEN, ready to decode into a destination.
+///
+/// Opening reads the header and builds or validates the catalog, which for a
+/// file without a usable index is a walk of every record. A caller must learn
+/// the shape before it can allocate, and asking must not cost that twice.
+pub struct GenotypeMatrixReader {
+    provider: BgenTableProvider,
+    options: BgenReadOptions,
+}
+
+impl GenotypeMatrixReader {
+    /// Opens a fileset and reads its metadata.
+    pub async fn open(path: impl Into<String>, options: BgenReadOptions) -> Result<Self> {
+        if options.output_mode != BgenOutputMode::Dosage {
+            return Err(DataFusionError::Plan(
+                "BGEN matrix reads are dosage only; probabilities are variable width and have \
+                 no single dense shape"
+                    .to_string(),
+            ));
+        }
+        let provider = BgenTableProvider::try_new(path, options.clone()).await?;
+        Ok(Self { provider, options })
+    }
+
+    /// The shape a decode will produce.
+    pub fn shape(&self) -> MatrixShape {
+        let fileset = self.provider.fileset();
+        MatrixShape {
+            variants: fileset.catalog.variants.len(),
+            samples: fileset.selected_samples.source_indices().len(),
+        }
+    }
+
+    /// The selected sample names, in column order.
+    pub fn sample_names(&self) -> &[String] {
+        self.provider.fileset().selected_samples.names()
+    }
+
+    /// The variant start positions, in row order.
+    pub fn positions(&self) -> Vec<u64> {
+        self.provider
+            .fileset()
+            .catalog
+            .variants
+            .iter()
+            .map(|variant| variant.position as u64)
+            .collect()
+    }
+
+    /// Decodes every variant's dosages into `values`, row-major.
+    ///
+    /// `values` must be exactly `variants * samples` long; `missing` is written
+    /// where a sample has no called genotype.
+    pub async fn read_into(
+        &self,
+        values: &mut [f32],
+        missing: f32,
+        threads: usize,
+    ) -> Result<MatrixShape> {
+        let shape = self.shape();
+        let expected = shape
+            .variants
+            .checked_mul(shape.samples)
+            .ok_or_else(|| DataFusionError::Execution("BGEN matrix size overflowed".to_string()))?;
+        if values.len() != expected {
+            return Err(DataFusionError::Execution(format!(
+                "BGEN matrix destination has {} values; expected {expected} ({} variants x {} samples)",
+                values.len(),
+                shape.variants,
+                shape.samples
+            )));
+        }
+        if expected == 0 {
+            return Ok(shape);
+        }
+
+        let fileset = Arc::clone(self.provider.fileset());
+        let selected = (0..shape.variants).collect::<Vec<_>>();
+        let partitions = plan_payload_partitions(
+            &selected,
+            &fileset.catalog,
+            threads.max(1),
+            self.options.max_range_gap,
+            self.options.max_range_bytes,
+        )?;
+
+        // A whole-file read gives every variant a row index equal to its
+        // position, so a partition owns a contiguous row range and the
+        // destination splits into pieces the workers never share.
+        // A partition's variants hang off its ranges rather than the partition,
+        // because a range is what the scan fetches and a variant belongs to
+        // exactly one of them.
+        let mut cursor = 0_usize;
+        let mut owned = Vec::with_capacity(partitions.len());
+        for partition in &partitions {
+            let rows: usize = partition
+                .ranges
+                .iter()
+                .map(|range| range.variants.len())
+                .sum();
+            if rows == 0 {
+                owned.push(0);
+                continue;
+            }
+            let first = partition
+                .ranges
+                .iter()
+                .flat_map(|range| range.variants.iter())
+                .copied()
+                .min()
+                .unwrap_or(cursor);
+            if first != cursor {
+                return Err(DataFusionError::Execution(
+                    "BGEN matrix partitions are not contiguous in variant order".to_string(),
+                ));
+            }
+            cursor += rows;
+            owned.push(rows);
+        }
+        if cursor != shape.variants {
+            return Err(DataFusionError::Execution(format!(
+                "BGEN matrix partitions cover {cursor} of {} variants",
+                shape.variants
+            )));
+        }
+
+        // The ranges are fetched here because the object source is async;
+        // decoding is what runs in parallel afterwards. Input is bounded by the
+        // range planner rather than by the file.
+        let mut loaded = Vec::with_capacity(partitions.len());
+        for partition in &partitions {
+            let mut ranges = Vec::with_capacity(partition.ranges.len());
+            for range in &partition.ranges {
+                let bytes = fileset
+                    .source
+                    .read_range(&fileset.path, range.range.start..range.range.end)
+                    .await?;
+                ranges.push((range.range, bytes.to_vec()));
+            }
+            loaded.push(ranges);
+        }
+
+        let mut rest = values;
+        let mut slices = Vec::with_capacity(partitions.len());
+        for rows in &owned {
+            let (head, tail) = rest.split_at_mut(rows * shape.samples);
+            slices.push(head);
+            rest = tail;
+        }
+
+        std::thread::scope(|scope| {
+            let handles = partitions
+                .iter()
+                .zip(loaded.iter())
+                .zip(slices)
+                .map(|((partition, ranges), slice)| {
+                    let fileset = Arc::clone(&fileset);
+                    let options = self.options.clone();
+                    scope.spawn(move || {
+                        decode_partition(
+                            &fileset,
+                            &options,
+                            partition,
+                            ranges,
+                            slice,
+                            shape.samples,
+                            missing,
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle.join().map_err(|_| {
+                        DataFusionError::Execution("BGEN matrix decoder panicked".to_string())
+                    })?
+                })
+                .collect::<Result<Vec<_>>>()
+        })?;
+        Ok(shape)
+    }
+}
+
+/// Reports the shape a fileset would produce, without decoding anything.
+pub async fn genotype_matrix_shape(
+    path: impl Into<String>,
+    options: BgenReadOptions,
+) -> Result<MatrixShape> {
+    Ok(GenotypeMatrixReader::open(path, options).await?.shape())
+}
+
+/// Decodes a whole fileset's dosages into `values`.
+pub async fn read_genotype_matrix(
+    path: impl Into<String>,
+    options: BgenReadOptions,
+    values: &mut [f32],
+    missing: f32,
+    threads: usize,
+) -> Result<(MatrixShape, Vec<u64>)> {
+    let reader = GenotypeMatrixReader::open(path, options).await?;
+    let positions = reader.positions();
+    let shape = reader.read_into(values, missing, threads).await?;
+    Ok((shape, positions))
+}
+
+type LoadedRanges = Vec<(
+    datafusion_bio_format_core::range_planning::ByteRange,
+    Vec<u8>,
+)>;
+
+/// Decodes one partition's variants into its own slice of the matrix.
+fn decode_partition(
+    fileset: &BgenFileset,
+    options: &BgenReadOptions,
+    partition: &BgenPartition,
+    ranges: &LoadedRanges,
+    values: &mut [f32],
+    samples: usize,
+    missing: f32,
+) -> Result<()> {
+    let selected_samples = fileset.selected_samples.source_indices();
+    let mut scratch = DecodeScratch::new();
+    // Dosage layout, no PLOIDY: this path emits one value per sample and
+    // nothing else, so the buffer holds exactly one row at a time.
+    let mut buffers = GenotypeBuffers::new(BufferLayout::Dosage, false);
+    let mut row = 0_usize;
+
+    for ((range, bytes), planned) in ranges.iter().zip(&partition.ranges) {
+        for &variant_index in &planned.variants {
+            let catalogued = &fileset.catalog.variants[variant_index];
+            let span = catalogued.scan_span();
+            let record = slice_from_range(bytes, range.start, span, variant_index)?;
+            let owned;
+            let resolved = if catalogued.is_resolved() {
+                catalogued
+            } else {
+                owned =
+                    resolve_variant(&fileset.path, catalogued, record, &fileset.header, options)?;
+                &owned
+            };
+            let payload_span = resolved.payload_span().ok_or_else(|| {
+                DataFusionError::Internal(
+                    "BGEN variant stayed unresolved after being parsed".to_string(),
+                )
+            })?;
+            let payload = slice_from_range(bytes, range.start, payload_span, variant_index)?;
+
+            buffers.reset();
+            decode_variant(
+                &fileset.path,
+                resolved,
+                &fileset.header,
+                payload,
+                selected_samples,
+                options,
+                &mut scratch,
+                &mut buffers,
+            )?;
+
+            let out = values
+                .get_mut(row * samples..(row + 1) * samples)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "BGEN variant {variant_index} row {row} is outside the matrix"
+                    ))
+                })?;
+            let decoded = buffers.values();
+            if decoded.len() != samples {
+                return Err(DataFusionError::Execution(format!(
+                    "BGEN variant {variant_index} decoded {} values; expected {samples}",
+                    decoded.len()
+                )));
+            }
+            // A missing dosage is NaN in the buffer; the caller chooses what it
+            // wants to see instead.
+            for (slot, &value) in out.iter_mut().zip(decoded) {
+                *slot = if value.is_nan() { missing } else { value };
+            }
+            row += 1;
+        }
+    }
+    Ok(())
+}

--- a/datafusion/bio-format-bgen/src/physical_exec.rs
+++ b/datafusion/bio-format-bgen/src/physical_exec.rs
@@ -26,7 +26,7 @@ use crate::decode::{DecodeScratch, decode_variant};
 use crate::table_provider::{BgenFileset, BgenOutputMode};
 
 /// Returns the bytes of `span` from a buffer that starts at `buffer_start`.
-fn slice_from_range(
+pub(crate) fn slice_from_range(
     bytes: &[u8],
     buffer_start: u64,
     span: std::ops::Range<u64>,

--- a/datafusion/bio-format-bgen/src/table_provider.rs
+++ b/datafusion/bio-format-bgen/src/table_provider.rs
@@ -269,6 +269,11 @@ pub struct BgenTableProvider {
 }
 
 impl BgenTableProvider {
+    /// The opened fileset, for the matrix path.
+    pub(crate) fn fileset(&self) -> &Arc<BgenFileset> {
+        &self.fileset
+    }
+
     /// Opens a local or remote BGEN file and builds its validated metadata catalog.
     pub async fn try_new(path: impl Into<String>, options: BgenReadOptions) -> Result<Self> {
         validate_options(&options)?;
@@ -1222,7 +1227,7 @@ async fn resolve_variant_metadata(
     Ok((resolved, cost))
 }
 
-fn plan_payload_partitions(
+pub(crate) fn plan_payload_partitions(
     selected: &[usize],
     catalog: &BgenCatalog,
     target_partitions: usize,

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -3459,3 +3459,50 @@ async fn the_matrix_reader_matches_the_scan_cell_for_cell() {
         }
     }
 }
+
+#[tokio::test]
+async fn the_matrix_positions_follow_the_coordinate_system() {
+    // The matrix labels its rows, and those labels have to be the `start` the
+    // scan emits. Reading the raw one-based BGEN position instead puts every
+    // row one base later than the DataFrame path under a zero-based read, which
+    // no assertion about values would catch.
+    let fixture = fixture_with_variants(Codec::Zlib, true, &fully_called_variants());
+    for zero_based in [false, true] {
+        let options = BgenReadOptions {
+            output_mode: BgenOutputMode::Dosage,
+            genotype_fields: Some(vec!["DS".to_string()]),
+            coordinate_system: if zero_based {
+                datafusion_bio_format_core::genotype::CoordinateSystem::ZeroBasedHalfOpen
+            } else {
+                datafusion_bio_format_core::genotype::CoordinateSystem::OneBasedClosed
+            },
+            ..Default::default()
+        };
+        let provider = BgenTableProvider::try_new(path(&fixture.bgen), options.clone())
+            .await
+            .unwrap();
+        let context = context(1024);
+        context.register_table("b", Arc::new(provider)).unwrap();
+        let batches = context
+            .sql("SELECT start FROM b ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let scanned = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt64Array>()
+            .unwrap();
+        let scanned: Vec<u64> = (0..scanned.len()).map(|i| scanned.value(i)).collect();
+
+        let reader = datafusion_bio_format_bgen::matrix::GenotypeMatrixReader::open(
+            path(&fixture.bgen),
+            options,
+        )
+        .await
+        .unwrap();
+        assert_eq!(reader.positions(), scanned, "zero_based {zero_based}");
+    }
+}

--- a/datafusion/bio-format-bgen/tests/provider_test.rs
+++ b/datafusion/bio-format-bgen/tests/provider_test.rs
@@ -3392,3 +3392,70 @@ async fn preliminary_header_reads_are_counted() {
          {primary} bytes reported for a {object_size}-byte object"
     );
 }
+
+#[tokio::test]
+async fn the_matrix_reader_matches_the_scan_cell_for_cell() {
+    // The matrix path exists to avoid the consolidation the scan's consumer
+    // does, not to decode differently. It reuses the scan's per-variant decode,
+    // and this is the check that it stays that way: the same fixture read both
+    // ways, compared as bit patterns, at every partition count.
+    // Biallelic throughout: the shared fixture carries a multiallelic variant
+    // that dosage mode rejects, and an error is not something to compare a
+    // matrix against.
+    let fixture = fixture_with_variants(Codec::Zlib, true, &fully_called_variants());
+    let options = BgenReadOptions {
+        output_mode: BgenOutputMode::Dosage,
+        genotype_fields: Some(vec!["DS".to_string()]),
+        ..Default::default()
+    };
+
+    let provider = BgenTableProvider::try_new(path(&fixture.bgen), options.clone())
+        .await
+        .unwrap();
+    let context = context(1024);
+    context.register_table("b", Arc::new(provider)).unwrap();
+    let batches = context
+        .sql("SELECT genotypes FROM b ORDER BY start")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let expected: Vec<Vec<Option<f32>>> = (0..batches[0].num_rows())
+        .map(|row| dosage_values(&batches[0], 0, row))
+        .collect();
+
+    let shape = datafusion_bio_format_bgen::matrix::genotype_matrix_shape(
+        path(&fixture.bgen),
+        options.clone(),
+    )
+    .await
+    .unwrap();
+    for threads in [1_usize, 2, 4] {
+        let mut values = vec![0.0_f32; shape.variants * shape.samples];
+        let (produced, positions) = datafusion_bio_format_bgen::matrix::read_genotype_matrix(
+            path(&fixture.bgen),
+            options.clone(),
+            &mut values,
+            f32::NAN,
+            threads,
+        )
+        .await
+        .unwrap();
+        assert_eq!(produced, shape, "threads {threads}");
+        assert_eq!(positions.len(), shape.variants);
+        for (row, want) in expected.iter().enumerate() {
+            for (column, cell) in want.iter().enumerate() {
+                let got = values[row * shape.samples + column];
+                match cell {
+                    Some(value) => assert_eq!(
+                        got.to_bits(),
+                        value.to_bits(),
+                        "threads {threads} row {row} column {column}"
+                    ),
+                    None => assert!(got.is_nan(), "threads {threads} row {row} column {column}"),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #236 (which is on #235, on #234).

## Why

A caller wanting one dense array gets Arrow batches and consolidates them, and that consolidation is a **serial pass over 10 GB**. Measured stage by stage on chr22:

| Stage | t=1 | t=8 | scaling |
|---|---:|---:|---:|
| `collect()` — the scan | 11.54 s | 2.05 s | **5.6×** |
| `combine_chunks()` | 1.81 s | 1.17 s | **1.5×** |
| total | 13.37 s | 3.22 s | 4.15× |

The provider already scales 6.34× at eight partitions and 9.8× at sixteen. The consolidation was the ceiling — 36% of an eight-partition read.

## What

`matrix::read_genotype_matrix` writes each variant's dosages at their final address. Partitions own contiguous row ranges, so workers never share a byte.

| threads | matrix | speedup |
|---:|---:|---:|
| 1 | 12.491 s | 1.00× |
| 2 | 6.498 s | 1.92× |
| 4 | 3.701 s | 3.37× |
| 8 | **2.074 s** | **6.02×** |

chr22, 993,881 × 2,548 = 2,532,408,788 cells, release with `-C target-cpu=native`. The scaling is the result; the path now tracks the decoder instead of the copy.

## The decode is the scan's

A matrix row is one variant's dosages, so this fills the same per-variant buffer the scan fills and moves it into the destination rather than accumulating a batch. Every layout, codec and fast path is supported with **no second implementation to keep in step** — which is the main design choice here and the reason the diff is small.

`the_matrix_reader_matches_the_scan_cell_for_cell` reads the same fixture both ways and compares as `f32` bit patterns at one, two and four threads.

## Scope

**Dosage only**, refused at open rather than part way through a decode: probabilities are variable width and have no single dense shape.

**No binding yet.** A caller sees this through `polars_bio.read_bgen_matrix`, which is a separate change in that repo — mirroring `read_pgen_matrix`. This PR is the provider half.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -p datafusion-bio-format-bgen --all-targets`, and 85 BGEN tests clean.