### PR TITLE
feat(bbi): parallelize BigWig and BigBed scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=3ff8c923ce94c16b45f612df98f08e55d34e19ab#3ff8c923ce94c16b45f612df98f08e55d34e19ab"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=f2e0dd3b7e16df688ecda540dbeb060e149393b2#f2e0dd3b7e16df688ecda540dbeb060e149393b2"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=9e1213b7f288141d4267e800fe94a0d6df055bef#9e1213b7f288141d4267e800fe94a0d6df055bef"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=ce7e23a529247a6da78e44f8c69caab6c01093f7#ce7e23a529247a6da78e44f8c69caab6c01093f7"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=17e425e65d528038fdbc9d47e31eca437536906f#17e425e65d528038fdbc9d47e31eca437536906f"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=7ce5f99e2e538b2a770acbb1a3d9c30edda68264#7ce5f99e2e538b2a770acbb1a3d9c30edda68264"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=2b8e2304a3eb81efc389557e20186add430b319b#2b8e2304a3eb81efc389557e20186add430b319b"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=3ff8c923ce94c16b45f612df98f08e55d34e19ab#3ff8c923ce94c16b45f612df98f08e55d34e19ab"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=04025b24479847d34dbd20797cc70065b8b88262#04025b24479847d34dbd20797cc70065b8b88262"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=2b8e2304a3eb81efc389557e20186add430b319b#2b8e2304a3eb81efc389557e20186add430b319b"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -527,9 +527,8 @@ dependencies = [
 
 [[package]]
 name = "bigtools"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1b9bbf6596d602e472a23ed5aa5d611fb04f14e7772226fb61c720e806202e"
+version = "0.5.9-dev"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=17e425e65d528038fdbc9d47e31eca437536906f#17e425e65d528038fdbc9d47e31eca437536906f"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2413,7 +2412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3140,7 +3139,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3187,7 +3186,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4694,7 +4693,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5142,7 +5141,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5199,7 +5198,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5513,7 +5512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5683,7 +5682,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6495,15 +6494,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6550,28 +6540,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6593,12 +6566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6615,12 +6582,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6641,22 +6602,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6677,12 +6626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6699,12 +6642,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6725,12 +6662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,12 +6678,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=1029e674bcb5774c4a4912fda464caa887b6c17e#1029e674bcb5774c4a4912fda464caa887b6c17e"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=9e1213b7f288141d4267e800fe94a0d6df055bef#9e1213b7f288141d4267e800fe94a0d6df055bef"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=2abdd9ddfc9aeae0962f549a5e616530b492b9c0#2abdd9ddfc9aeae0962f549a5e616530b492b9c0"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=1029e674bcb5774c4a4912fda464caa887b6c17e#1029e674bcb5774c4a4912fda464caa887b6c17e"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=7ce7e9b615260e45b87ab863af1cf85475cbc77d#7ce7e9b615260e45b87ab863af1cf85475cbc77d"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=04025b24479847d34dbd20797cc70065b8b88262#04025b24479847d34dbd20797cc70065b8b88262"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=f9cfe3f0ad117b362c1e77c8dd0f6643f3688382#f9cfe3f0ad117b362c1e77c8dd0f6643f3688382"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=7ce7e9b615260e45b87ab863af1cf85475cbc77d#7ce7e9b615260e45b87ab863af1cf85475cbc77d"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=7ce5f99e2e538b2a770acbb1a3d9c30edda68264#7ce5f99e2e538b2a770acbb1a3d9c30edda68264"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=90925ff5e4e274987d603e30def30506836ee2e7#90925ff5e4e274987d603e30def30506836ee2e7"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5#126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=9255813739071febe102384ce9d988a31cae0e14#9255813739071febe102384ce9d988a31cae0e14"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2412,7 +2412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3139,7 +3139,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3186,7 +3186,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3889,7 +3889,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4693,7 +4693,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5141,7 +5141,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5198,7 +5198,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5569,6 +5569,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5682,7 +5683,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=f2e0dd3b7e16df688ecda540dbeb060e149393b2#f2e0dd3b7e16df688ecda540dbeb060e149393b2"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=2abdd9ddfc9aeae0962f549a5e616530b492b9c0#2abdd9ddfc9aeae0962f549a5e616530b492b9c0"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=2b17d454fb2d0663a55fcc8806eb9b98be373f31#2b17d454fb2d0663a55fcc8806eb9b98be373f31"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5#126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=90925ff5e4e274987d603e30def30506836ee2e7#90925ff5e4e274987d603e30def30506836ee2e7"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=f9cfe3f0ad117b362c1e77c8dd0f6643f3688382#f9cfe3f0ad117b362c1e77c8dd0f6643f3688382"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=9255813739071febe102384ce9d988a31cae0e14#9255813739071febe102384ce9d988a31cae0e14"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=0d7a5728eb39ee97fddef59cd3da469186bec90d#0d7a5728eb39ee97fddef59cd3da469186bec90d"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "bigtools"
 version = "0.5.9-dev"
-source = "git+https://github.com/biodatageeks/bigtools.git?rev=ce7e23a529247a6da78e44f8c69caab6c01093f7#ce7e23a529247a6da78e44f8c69caab6c01093f7"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=2b17d454fb2d0663a55fcc8806eb9b98be373f31#2b17d454fb2d0663a55fcc8806eb9b98be373f31"
 dependencies = [
  "bincode",
  "byteorder",

--- a/README.md
+++ b/README.md
@@ -642,6 +642,15 @@ cargo doc --no-deps --all-features --open
 
 This project uses a forked version of [noodles](https://github.com/zaeleus/noodles) from [biodatageeks/noodles](https://github.com/biodatageeks/noodles) for enhanced support of certain file formats (CRAM, FASTA, VCF, GFF).
 
+The `datafusion-bio-format-bbi` crate temporarily pins
+[`biodatageeks/bigtools`](https://github.com/biodatageeks/bigtools) revision
+`0d7a5728eb39ee97fddef59cd3da469186bec90d`. It provides primary cir-tree block
+metadata, bounded unclipped BigWig reads, and traversal-limit classification for
+block-aware BigWig/BigBed source partitions. This will move back to an upstream
+release after [bigtools#106](https://github.com/jackh726/bigtools/pull/106) is
+published. Cargo fetches git dependencies during builds, which requires Git and
+network access.
+
 ## Related Projects
 
 - [polars-bio](https://github.com/biodatageeks/polars-bio) - Polars extensions for bioinformatics

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "04025b24479847d34dbd20797cc70065b8b88262", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b8e2304a3eb81efc389557e20186add430b319b", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "04025b24479847d34dbd20797cc70065b8b88262", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b8e2304a3eb81efc389557e20186add430b319b", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce5f99e2e538b2a770acbb1a3d9c30edda68264", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "90925ff5e4e274987d603e30def30506836ee2e7", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce5f99e2e538b2a770acbb1a3d9c30edda68264", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "90925ff5e4e274987d603e30def30506836ee2e7", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "ce7e23a529247a6da78e44f8c69caab6c01093f7", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b17d454fb2d0663a55fcc8806eb9b98be373f31", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "ce7e23a529247a6da78e44f8c69caab6c01093f7", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b17d454fb2d0663a55fcc8806eb9b98be373f31", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9e1213b7f288141d4267e800fe94a0d6df055bef", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "ce7e23a529247a6da78e44f8c69caab6c01093f7", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9e1213b7f288141d4267e800fe94a0d6df055bef", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "ce7e23a529247a6da78e44f8c69caab6c01093f7", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce7e9b615260e45b87ab863af1cf85475cbc77d", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "04025b24479847d34dbd20797cc70065b8b88262", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce7e9b615260e45b87ab863af1cf85475cbc77d", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "04025b24479847d34dbd20797cc70065b8b88262", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "17e425e65d528038fdbc9d47e31eca437536906f", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce5f99e2e538b2a770acbb1a3d9c30edda68264", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "17e425e65d528038fdbc9d47e31eca437536906f", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce5f99e2e538b2a770acbb1a3d9c30edda68264", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "3ff8c923ce94c16b45f612df98f08e55d34e19ab", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f2e0dd3b7e16df688ecda540dbeb060e149393b2", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "3ff8c923ce94c16b45f612df98f08e55d34e19ab", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f2e0dd3b7e16df688ecda540dbeb060e149393b2", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9255813739071febe102384ce9d988a31cae0e14", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9255813739071febe102384ce9d988a31cae0e14", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b17d454fb2d0663a55fcc8806eb9b98be373f31", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b17d454fb2d0663a55fcc8806eb9b98be373f31", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "126b34d5563bd1ffc3a62cba04acbb0dbfeeecc5", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9255813739071febe102384ce9d988a31cae0e14", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "0d7a5728eb39ee97fddef59cd3da469186bec90d", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9255813739071febe102384ce9d988a31cae0e14", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "0d7a5728eb39ee97fddef59cd3da469186bec90d", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2abdd9ddfc9aeae0962f549a5e616530b492b9c0", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "1029e674bcb5774c4a4912fda464caa887b6c17e", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2abdd9ddfc9aeae0962f549a5e616530b492b9c0", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "1029e674bcb5774c4a4912fda464caa887b6c17e", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { version = "0.5.8", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "17e425e65d528038fdbc9d47e31eca437536906f", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { version = "0.5.8", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "17e425e65d528038fdbc9d47e31eca437536906f", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "1029e674bcb5774c4a4912fda464caa887b6c17e", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9e1213b7f288141d4267e800fe94a0d6df055bef", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "1029e674bcb5774c4a4912fda464caa887b6c17e", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "9e1213b7f288141d4267e800fe94a0d6df055bef", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f2e0dd3b7e16df688ecda540dbeb060e149393b2", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2abdd9ddfc9aeae0962f549a5e616530b492b9c0", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f2e0dd3b7e16df688ecda540dbeb060e149393b2", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2abdd9ddfc9aeae0962f549a5e616530b492b9c0", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f9cfe3f0ad117b362c1e77c8dd0f6643f3688382", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce7e9b615260e45b87ab863af1cf85475cbc77d", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f9cfe3f0ad117b362c1e77c8dd0f6643f3688382", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "7ce7e9b615260e45b87ab863af1cf85475cbc77d", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b8e2304a3eb81efc389557e20186add430b319b", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "3ff8c923ce94c16b45f612df98f08e55d34e19ab", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "2b8e2304a3eb81efc389557e20186add430b319b", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "3ff8c923ce94c16b45f612df98f08e55d34e19ab", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/Cargo.toml
+++ b/datafusion/bio-format-bbi/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 datafusion.workspace = true
 async-trait.workspace = true
 datafusion-bio-format-core = { path = "../bio-format-core" }
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "90925ff5e4e274987d603e30def30506836ee2e7", default-features = false, features = ["read"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f9cfe3f0ad117b362c1e77c8dd0f6643f3688382", default-features = false, features = ["read"] }
 futures-util.workspace = true
 
 [dev-dependencies]
-bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "90925ff5e4e274987d603e30def30506836ee2e7", default-features = false, features = ["read", "write"] }
+bigtools = { git = "https://github.com/biodatageeks/bigtools.git", rev = "f9cfe3f0ad117b362c1e77c8dd0f6643f3688382", default-features = false, features = ["read", "write"] }
 tempfile = "3"
 tokio.workspace = true

--- a/datafusion/bio-format-bbi/README.md
+++ b/datafusion/bio-format-bbi/README.md
@@ -1,3 +1,16 @@
 # datafusion-bio-format-bbi
 
 BigWig and BigBed table providers for Apache DataFusion.
+
+## Git dependency
+
+This crate temporarily pins
+[`biodatageeks/bigtools`](https://github.com/biodatageeks/bigtools) at revision
+`0d7a5728eb39ee97fddef59cd3da469186bec90d`. The fork exposes the primary
+cir-tree block layout, bounded unclipped BigWig reads, and traversal-limit
+classification needed for safe block-aware source partitioning. The changes are
+proposed upstream in [bigtools#106](https://github.com/jackh726/bigtools/pull/106);
+the git pin should be replaced by a released upstream version after publication.
+
+Cargo fetches this dependency during the build, so Git and network access are
+required.

--- a/datafusion/bio-format-bbi/examples/partition_profile.rs
+++ b/datafusion/bio-format-bbi/examples/partition_profile.rs
@@ -1,0 +1,98 @@
+//! Profile source-partition balance for a local BigWig or BigBed file.
+//!
+//! Usage: `cargo run -p datafusion-bio-format-bbi --example partition_profile
+//! --release -- <bigwig|bigbed> <path> <partitions> [count|decode|aggregate]`
+
+use std::env;
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::catalog::TableProvider;
+use datafusion::execution::context::{SessionConfig, SessionContext};
+use datafusion::physical_plan::ExecutionPlanProperties;
+use datafusion_bio_format_bbi::bigbed::{BigBedSchemaMode, BigBedTableProvider};
+use datafusion_bio_format_bbi::bigwig::BigWigTableProvider;
+use futures_util::StreamExt;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut args = env::args().skip(1);
+    let format = args.next().ok_or("missing format")?;
+    let path = args.next().ok_or("missing path")?;
+    let target_partitions = args
+        .next()
+        .ok_or("missing partition count")?
+        .parse::<usize>()?;
+    let workload = args.next().unwrap_or_else(|| "count".to_string());
+    if args.next().is_some() {
+        return Err("unexpected extra argument".into());
+    }
+
+    let provider: Arc<dyn TableProvider> = match format.as_str() {
+        "bigwig" => Arc::new(BigWigTableProvider::new(path, true)?),
+        "bigbed" => Arc::new(BigBedTableProvider::new(
+            path,
+            true,
+            BigBedSchemaMode::Rest,
+        )?),
+        _ => return Err(format!("unsupported format: {format}").into()),
+    };
+    let context = SessionContext::new_with_config(
+        SessionConfig::new().with_target_partitions(target_partitions),
+    );
+    if workload == "aggregate" {
+        context.register_table("bbi", provider)?;
+        let dataframe = context.sql("SELECT count(*) AS rows FROM bbi").await?;
+        let plan = dataframe.create_physical_plan().await?;
+        println!("plan={plan:?}");
+        let started = Instant::now();
+        let batches = datafusion::physical_plan::collect(plan, context.task_ctx()).await?;
+        println!(
+            "aggregate_output_batches={} aggregate_output_rows={} elapsed_seconds={:.6}",
+            batches.len(),
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            started.elapsed().as_secs_f64()
+        );
+        return Ok(());
+    }
+    let projection = match workload.as_str() {
+        "count" => Some(Vec::new()),
+        "decode" => None,
+        _ => return Err(format!("unsupported workload: {workload}").into()),
+    };
+    let plan = provider
+        .scan(&context.state(), projection.as_ref(), &[], None)
+        .await?;
+    println!("plan={plan:?}");
+
+    let overall_started = Instant::now();
+    let mut tasks = tokio::task::JoinSet::new();
+    for partition in 0..plan.output_partitioning().partition_count() {
+        let mut stream = plan.execute(partition, context.task_ctx())?;
+        tasks.spawn(async move {
+            let started = Instant::now();
+            let mut rows = 0;
+            while let Some(batch) = stream.next().await {
+                rows += batch?.num_rows();
+            }
+            Ok::<_, datafusion::error::DataFusionError>((partition, rows, started.elapsed()))
+        });
+    }
+
+    let mut results = Vec::new();
+    while let Some(result) = tasks.join_next().await {
+        results.push(result??);
+    }
+    results.sort_unstable_by_key(|(partition, _, _)| *partition);
+    for (partition, rows, elapsed) in results {
+        println!(
+            "partition={partition} rows={rows} elapsed_seconds={:.6}",
+            elapsed.as_secs_f64()
+        );
+    }
+    println!(
+        "overall_elapsed_seconds={:.6}",
+        overall_started.elapsed().as_secs_f64()
+    );
+    Ok(())
+}

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -27,7 +27,7 @@ use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
 use crate::common::{
-    BBI_BATCH_ROWS, BBI_EMPTY_PROJECTION_BATCH_ROWS, BbiBlockWork, BbiScanRegion, bbi_block_work,
+    BBI_BATCH_ROWS, BBI_EMPTY_PROJECTION_BATCH_ROWS, BbiBlockIndex, BbiScanRegion, bbi_block_index,
     build_batch, normalize_local_path, partition_estimated_bytes, plan_bbi_partitions,
     plan_bbi_scan_regions, project_schema, projected_indices, projection_display, region_display,
     to_external_error,
@@ -84,7 +84,7 @@ pub struct BigBedTableProvider {
     file_path: String,
     schema: SchemaRef,
     chroms: Vec<(String, u32)>,
-    block_work: Vec<BbiBlockWork>,
+    block_index: Option<BbiBlockIndex>,
     extra_columns: Vec<BigBedExtraColumn>,
     coordinate_system_zero_based: bool,
 }
@@ -102,8 +102,11 @@ impl BigBedTableProvider {
                 "Failed to open BigBed file '{file_path}': {error}"
             ))))
         })?;
-        let blocks = reader.data_blocks().map_err(to_external_error)?;
-        let block_work = bbi_block_work(reader.chroms(), &blocks);
+        let block_index = match reader.data_blocks() {
+            Ok(blocks) => Some(bbi_block_index(reader.chroms(), &blocks)),
+            Err(error) if error.is_data_block_traversal_limit_exceeded() => None,
+            Err(error) => return Err(to_external_error(error)),
+        };
         let chroms = reader
             .chroms()
             .iter()
@@ -115,7 +118,7 @@ impl BigBedTableProvider {
             file_path,
             schema,
             chroms,
-            block_work,
+            block_index,
             extra_columns,
             coordinate_system_zero_based,
         })
@@ -164,22 +167,16 @@ impl TableProvider for BigBedTableProvider {
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = project_schema(&self.schema, projection);
-        // `widen_to_chromosome = false`: BigBedRead returns full overlapping BED
-        // entries (coordinates are never clipped), so positional pruning is safe.
-        let scan_plan = plan_bbi_scan_regions(
-            filters,
-            &self.chroms,
-            self.coordinate_system_zero_based,
-            false,
-        );
+        let scan_plan =
+            plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
         let partitions = plan_bbi_partitions(
             scan_plan.regions,
             state.config().target_partitions(),
             !scan_plan.has_explicit_region,
-            false,
-            &self.block_work,
+            self.block_index.as_ref(),
         );
-        let partition_estimated_bytes = partition_estimated_bytes(&partitions, &self.block_work);
+        let partition_estimated_bytes =
+            partition_estimated_bytes(&partitions, self.block_index.as_ref());
         let partition_count = partitions.len();
         Ok(Arc::new(BigBedExec {
             file_path: self.file_path.clone(),
@@ -187,6 +184,7 @@ impl TableProvider for BigBedTableProvider {
             projection: projection.cloned(),
             partitions,
             partition_estimated_bytes,
+            block_layout_available: self.block_index.is_some(),
             extra_columns: self.extra_columns.clone(),
             coordinate_system_zero_based: self.coordinate_system_zero_based,
             cache: Arc::new(PlanProperties::new(
@@ -206,6 +204,7 @@ pub struct BigBedExec {
     projection: Option<Vec<usize>>,
     partitions: Vec<Vec<BbiScanRegion>>,
     partition_estimated_bytes: Vec<u64>,
+    block_layout_available: bool,
     extra_columns: Vec<BigBedExtraColumn>,
     coordinate_system_zero_based: bool,
     cache: Arc<PlanProperties>,
@@ -223,9 +222,10 @@ impl DisplayAs for BigBedExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "BigBedExec: projection=[{}], partitions={}, estimated_data_bytes={:?}, regions=[{}]",
+            "BigBedExec: projection=[{}], partitions={}, block_layout_available={}, estimated_data_bytes={:?}, regions=[{}]",
             projection_display(&self.schema),
             self.partitions.len(),
+            self.block_layout_available,
             self.partition_estimated_bytes,
             self.partitions
                 .iter()

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -166,16 +166,16 @@ impl TableProvider for BigBedTableProvider {
         let schema = project_schema(&self.schema, projection);
         // `widen_to_chromosome = false`: BigBedRead returns full overlapping BED
         // entries (coordinates are never clipped), so positional pruning is safe.
-        let regions = plan_bbi_scan_regions(
+        let scan_plan = plan_bbi_scan_regions(
             filters,
             &self.chroms,
             self.coordinate_system_zero_based,
             false,
         );
         let partitions = plan_bbi_partitions(
-            regions,
+            scan_plan.regions,
             state.config().target_partitions(),
-            !filters.iter().any(is_genomic_coordinate_filter),
+            !scan_plan.has_explicit_region,
             false,
             &self.block_work,
         );

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -223,7 +223,7 @@ impl DisplayAs for BigBedExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "BigBedExec: projection=[{}], partitions={}, estimated_compressed_bytes={:?}, regions=[{}]",
+            "BigBedExec: projection=[{}], partitions={}, estimated_data_bytes={:?}, regions=[{}]",
             projection_display(&self.schema),
             self.partitions.len(),
             self.partition_estimated_bytes,

--- a/datafusion/bio-format-bbi/src/bigbed.rs
+++ b/datafusion/bio-format-bbi/src/bigbed.rs
@@ -27,8 +27,10 @@ use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
 use crate::common::{
-    BBI_BATCH_ROWS, BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions,
-    project_schema, projected_indices, projection_display, region_display, to_external_error,
+    BBI_BATCH_ROWS, BBI_EMPTY_PROJECTION_BATCH_ROWS, BbiBlockWork, BbiScanRegion, bbi_block_work,
+    build_batch, normalize_local_path, partition_estimated_bytes, plan_bbi_partitions,
+    plan_bbi_scan_regions, project_schema, projected_indices, projection_display, region_display,
+    to_external_error,
 };
 
 /// BigBed schema discovery mode.
@@ -82,6 +84,7 @@ pub struct BigBedTableProvider {
     file_path: String,
     schema: SchemaRef,
     chroms: Vec<(String, u32)>,
+    block_work: Vec<BbiBlockWork>,
     extra_columns: Vec<BigBedExtraColumn>,
     coordinate_system_zero_based: bool,
 }
@@ -99,6 +102,8 @@ impl BigBedTableProvider {
                 "Failed to open BigBed file '{file_path}': {error}"
             ))))
         })?;
+        let blocks = reader.data_blocks().map_err(to_external_error)?;
+        let block_work = bbi_block_work(reader.chroms(), &blocks);
         let chroms = reader
             .chroms()
             .iter()
@@ -110,6 +115,7 @@ impl BigBedTableProvider {
             file_path,
             schema,
             chroms,
+            block_work,
             extra_columns,
             coordinate_system_zero_based,
         })
@@ -150,7 +156,7 @@ impl TableProvider for BigBedTableProvider {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         // `_limit` is intentionally ignored: BBI scans have no cheap row cap, so
@@ -166,16 +172,26 @@ impl TableProvider for BigBedTableProvider {
             self.coordinate_system_zero_based,
             false,
         );
+        let partitions = plan_bbi_partitions(
+            regions,
+            state.config().target_partitions(),
+            !filters.iter().any(is_genomic_coordinate_filter),
+            false,
+            &self.block_work,
+        );
+        let partition_estimated_bytes = partition_estimated_bytes(&partitions, &self.block_work);
+        let partition_count = partitions.len();
         Ok(Arc::new(BigBedExec {
             file_path: self.file_path.clone(),
             schema: schema.clone(),
             projection: projection.cloned(),
-            regions,
+            partitions,
+            partition_estimated_bytes,
             extra_columns: self.extra_columns.clone(),
             coordinate_system_zero_based: self.coordinate_system_zero_based,
             cache: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(schema),
-                Partitioning::UnknownPartitioning(1),
+                Partitioning::UnknownPartitioning(partition_count),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
             )),
@@ -188,7 +204,8 @@ pub struct BigBedExec {
     file_path: String,
     schema: SchemaRef,
     projection: Option<Vec<usize>>,
-    regions: Vec<BbiScanRegion>,
+    partitions: Vec<Vec<BbiScanRegion>>,
+    partition_estimated_bytes: Vec<u64>,
     extra_columns: Vec<BigBedExtraColumn>,
     coordinate_system_zero_based: bool,
     cache: Arc<PlanProperties>,
@@ -206,9 +223,15 @@ impl DisplayAs for BigBedExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "BigBedExec: projection=[{}], regions=[{}]",
+            "BigBedExec: projection=[{}], partitions={}, estimated_compressed_bytes={:?}, regions=[{}]",
             projection_display(&self.schema),
-            region_display(&self.regions)
+            self.partitions.len(),
+            self.partition_estimated_bytes,
+            self.partitions
+                .iter()
+                .map(|regions| region_display(regions))
+                .collect::<Vec<_>>()
+                .join(" | ")
         )
     }
 }
@@ -239,7 +262,7 @@ impl ExecutionPlan for BigBedExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         // The stream opens a reader per region and pulls intervals in fixed-size
@@ -249,11 +272,22 @@ impl ExecutionPlan for BigBedExec {
             .extra_columns
             .iter()
             .any(BigBedExtraColumn::needs_split_fields);
+        let regions = self.partitions.get(partition).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "BigBedExec partition {partition} is out of range for {} partitions",
+                self.partitions.len()
+            ))
+        })?;
         let stream = futures_util::stream::iter(BigBedRegionStream {
             file_path: self.file_path.clone(),
             schema: self.schema.clone(),
             projection: self.projection.clone(),
-            regions: self.regions.clone().into_iter(),
+            batch_rows: if self.schema.fields().is_empty() {
+                BBI_EMPTY_PROJECTION_BATCH_ROWS
+            } else {
+                BBI_BATCH_ROWS
+            },
+            regions: regions.clone().into_iter(),
             extra_columns: self.extra_columns.clone(),
             needs_split_fields,
             coordinate_system_zero_based: self.coordinate_system_zero_based,
@@ -281,6 +315,8 @@ struct BigBedRow {
 struct CurrentRegion {
     chrom: String,
     iter: BigBedIntervalIter<ReopenableFile, BigBedRead<ReopenableFile>>,
+    ownership_start: Option<u32>,
+    ownership_end: Option<u32>,
 }
 
 /// Lazily yields fixed-size [`RecordBatch`]es across all scan regions, opening a
@@ -289,6 +325,7 @@ struct BigBedRegionStream {
     file_path: String,
     schema: SchemaRef,
     projection: Option<Vec<usize>>,
+    batch_rows: usize,
     regions: std::vec::IntoIter<BbiScanRegion>,
     extra_columns: Vec<BigBedExtraColumn>,
     needs_split_fields: bool,
@@ -316,6 +353,8 @@ impl BigBedRegionStream {
             Ok(iter) => Some(Ok(CurrentRegion {
                 chrom: region.chrom,
                 iter,
+                ownership_start: region.ownership_start,
+                ownership_end: region.ownership_end,
             })),
             Err(error) => Some(Err(to_external_error(error))),
         }
@@ -356,43 +395,74 @@ impl Iterator for BigBedRegionStream {
             }
 
             let current = self.current.as_mut().expect("current region is set");
-            let mut rows: Vec<BigBedRow> = Vec::with_capacity(BBI_BATCH_ROWS);
+            let ownership_start = current.ownership_start;
+            let ownership_end = current.ownership_end;
+            let empty_projection = self.schema.fields().is_empty();
+            let mut rows: Vec<BigBedRow> = if empty_projection {
+                Vec::new()
+            } else {
+                Vec::with_capacity(self.batch_rows)
+            };
+            let mut row_count = 0;
+            let mut region_done = false;
             for entry in current.iter.by_ref() {
                 let entry = match entry {
                     Ok(entry) => entry,
                     Err(error) => return Some(Err(to_external_error(error))),
                 };
-                let start = if self.coordinate_system_zero_based {
-                    entry.start
-                } else {
-                    entry.start + 1
-                };
-                // Only allocate the split-field view or the `rest` string when a
-                // column actually consumes it; the other is left empty.
-                let fields = if self.needs_split_fields {
-                    entry.rest.split('\t').map(ToString::to_string).collect()
-                } else {
-                    Vec::new()
-                };
-                rows.push(BigBedRow {
-                    chrom: current.chrom.clone(),
-                    start,
-                    end: entry.end,
-                    rest: entry.rest,
-                    fields,
-                });
-                if rows.len() >= BBI_BATCH_ROWS {
+                if let Some(ownership_end) = ownership_end
+                    && entry.start >= ownership_end
+                {
+                    region_done = true;
+                    break;
+                }
+                if let Some(ownership_start) = ownership_start
+                    && entry.start < ownership_start
+                {
+                    continue;
+                }
+                row_count += 1;
+                if !empty_projection {
+                    let start = if self.coordinate_system_zero_based {
+                        entry.start
+                    } else {
+                        entry.start + 1
+                    };
+                    // Only allocate the split-field view or the `rest` string when a
+                    // column actually consumes it; the other is left empty.
+                    let fields = if self.needs_split_fields {
+                        entry.rest.split('\t').map(ToString::to_string).collect()
+                    } else {
+                        Vec::new()
+                    };
+                    rows.push(BigBedRow {
+                        chrom: current.chrom.clone(),
+                        start,
+                        end: entry.end,
+                        rest: entry.rest,
+                        fields,
+                    });
+                }
+                if row_count >= self.batch_rows {
                     break;
                 }
             }
 
-            if rows.is_empty() {
+            if region_done {
+                self.current = None;
+            }
+
+            if row_count == 0 {
                 // Region fully drained; advance to the next one.
                 self.current = None;
                 continue;
             }
 
-            return Some(self.build_batch(&rows));
+            return Some(if empty_projection {
+                build_batch(self.schema.clone(), Vec::new(), row_count)
+            } else {
+                self.build_batch(&rows)
+            });
         }
     }
 }

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -24,7 +24,7 @@ use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
 use crate::common::{
-    BBI_BATCH_ROWS, BBI_EMPTY_PROJECTION_BATCH_ROWS, BbiBlockWork, BbiScanRegion, bbi_block_work,
+    BBI_BATCH_ROWS, BBI_EMPTY_PROJECTION_BATCH_ROWS, BbiBlockIndex, BbiScanRegion, bbi_block_index,
     build_batch, normalize_local_path, partition_estimated_bytes, plan_bbi_partitions,
     plan_bbi_scan_regions, project_schema, projected_indices, projection_display, region_display,
     to_external_error,
@@ -36,7 +36,7 @@ pub struct BigWigTableProvider {
     file_path: String,
     schema: SchemaRef,
     chroms: Vec<(String, u32)>,
-    block_work: Vec<BbiBlockWork>,
+    block_index: Option<BbiBlockIndex>,
     coordinate_system_zero_based: bool,
 }
 
@@ -49,8 +49,11 @@ impl BigWigTableProvider {
                 "Failed to open BigWig file '{file_path}': {error}"
             ))))
         })?;
-        let blocks = reader.data_blocks().map_err(to_external_error)?;
-        let block_work = bbi_block_work(reader.chroms(), &blocks);
+        let block_index = match reader.data_blocks() {
+            Ok(blocks) => Some(bbi_block_index(reader.chroms(), &blocks)),
+            Err(error) if error.is_data_block_traversal_limit_exceeded() => None,
+            Err(error) => return Err(to_external_error(error)),
+        };
         let chroms = reader
             .chroms()
             .iter()
@@ -61,7 +64,7 @@ impl BigWigTableProvider {
             file_path,
             schema,
             chroms,
-            block_work,
+            block_index,
             coordinate_system_zero_based,
         })
     }
@@ -109,23 +112,18 @@ impl TableProvider for BigWigTableProvider {
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = project_schema(&self.schema, projection);
-        // `widen_to_chromosome = true`: BigWigRead clips interval values to the
-        // query window, so we scan whole chromosomes and let DataFusion's Inexact
-        // re-filter drop surplus rows, rather than emitting clipped coordinates.
-        let scan_plan = plan_bbi_scan_regions(
-            filters,
-            &self.chroms,
-            self.coordinate_system_zero_based,
-            true,
-        );
+        // The unclipped BigTools interval path bounds index traversal while
+        // preserving original coordinates for values crossing query edges.
+        let scan_plan =
+            plan_bbi_scan_regions(filters, &self.chroms, self.coordinate_system_zero_based);
         let partitions = plan_bbi_partitions(
             scan_plan.regions,
             state.config().target_partitions(),
             !scan_plan.has_explicit_region,
-            true,
-            &self.block_work,
+            self.block_index.as_ref(),
         );
-        let partition_estimated_bytes = partition_estimated_bytes(&partitions, &self.block_work);
+        let partition_estimated_bytes =
+            partition_estimated_bytes(&partitions, self.block_index.as_ref());
         let partition_count = partitions.len();
         Ok(Arc::new(BigWigExec {
             file_path: self.file_path.clone(),
@@ -133,6 +131,7 @@ impl TableProvider for BigWigTableProvider {
             projection: projection.cloned(),
             partitions,
             partition_estimated_bytes,
+            block_layout_available: self.block_index.is_some(),
             coordinate_system_zero_based: self.coordinate_system_zero_based,
             cache: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(schema),
@@ -151,6 +150,7 @@ pub struct BigWigExec {
     projection: Option<Vec<usize>>,
     partitions: Vec<Vec<BbiScanRegion>>,
     partition_estimated_bytes: Vec<u64>,
+    block_layout_available: bool,
     coordinate_system_zero_based: bool,
     cache: Arc<PlanProperties>,
 }
@@ -167,9 +167,10 @@ impl DisplayAs for BigWigExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "BigWigExec: projection=[{}], partitions={}, estimated_data_bytes={:?}, regions=[{}]",
+            "BigWigExec: projection=[{}], partitions={}, block_layout_available={}, estimated_data_bytes={:?}, regions=[{}]",
             projection_display(&self.schema),
             self.partitions.len(),
+            self.block_layout_available,
             self.partition_estimated_bytes,
             self.partitions
                 .iter()
@@ -242,9 +243,6 @@ impl ExecutionPlan for BigWigExec {
 struct CurrentRegion {
     chrom: String,
     iter: BigWigIntervalIter<ReopenableFile, BigWigRead<ReopenableFile>>,
-    /// Exclusive upper bound on `start`; once an interval reaches it the
-    /// (start-sorted) region is done and we stop reading further blocks.
-    stop_at: Option<u32>,
     ownership_start: Option<u32>,
     ownership_end: Option<u32>,
 }
@@ -277,11 +275,10 @@ impl BigWigRegionStream {
                 ))));
             }
         };
-        match reader.get_interval_move(&region.chrom, region.start, region.end) {
+        match reader.get_interval_move_unclipped(&region.chrom, region.start, region.end) {
             Ok(iter) => Some(Ok(CurrentRegion {
                 chrom: region.chrom,
                 iter,
-                stop_at: region.stop_at,
                 ownership_start: region.ownership_start,
                 ownership_end: region.ownership_end,
             })),
@@ -328,7 +325,6 @@ impl Iterator for BigWigRegionStream {
             let current = self.current.as_mut().expect("current region is set");
             // Copied out before the loop so the loop only borrows `current.iter`,
             // leaving `self.current` free to clear on early termination.
-            let stop_at = current.stop_at;
             let ownership_start = current.ownership_start;
             let ownership_end = current.ownership_end;
             let chrom = current.chrom.clone();
@@ -345,14 +341,6 @@ impl Iterator for BigWigRegionStream {
                     Ok(value) => value,
                     Err(error) => return Some(Err(to_external_error(error))),
                 };
-                // Intervals stream in ascending `start`, so once one reaches the
-                // upper bound nothing further in this region can match: stop.
-                if let Some(stop_at) = stop_at
-                    && value.start >= stop_at
-                {
-                    region_done = true;
-                    break;
-                }
                 if let Some(ownership_end) = ownership_end
                     && value.start >= ownership_end
                 {

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -24,8 +24,10 @@ use datafusion_bio_format_core::genomic_filter::is_genomic_coordinate_filter;
 use datafusion_bio_format_core::record_filter::can_push_down_record_filter;
 
 use crate::common::{
-    BBI_BATCH_ROWS, BbiScanRegion, build_batch, normalize_local_path, plan_bbi_scan_regions,
-    project_schema, projected_indices, projection_display, region_display, to_external_error,
+    BBI_BATCH_ROWS, BBI_EMPTY_PROJECTION_BATCH_ROWS, BbiBlockWork, BbiScanRegion, bbi_block_work,
+    build_batch, normalize_local_path, partition_estimated_bytes, plan_bbi_partitions,
+    plan_bbi_scan_regions, project_schema, projected_indices, projection_display, region_display,
+    to_external_error,
 };
 
 /// Table provider for local BigWig files.
@@ -34,6 +36,7 @@ pub struct BigWigTableProvider {
     file_path: String,
     schema: SchemaRef,
     chroms: Vec<(String, u32)>,
+    block_work: Vec<BbiBlockWork>,
     coordinate_system_zero_based: bool,
 }
 
@@ -41,11 +44,13 @@ impl BigWigTableProvider {
     /// Create a BigWig provider for a local file path.
     pub fn new(file_path: String, coordinate_system_zero_based: bool) -> Result<Self> {
         let file_path = normalize_local_path(&file_path, "BigWig")?;
-        let reader = BigWigRead::open_file(&file_path).map_err(|error| {
+        let mut reader = BigWigRead::open_file(&file_path).map_err(|error| {
             DataFusionError::External(Box::new(std::io::Error::other(format!(
                 "Failed to open BigWig file '{file_path}': {error}"
             ))))
         })?;
+        let blocks = reader.data_blocks().map_err(to_external_error)?;
+        let block_work = bbi_block_work(reader.chroms(), &blocks);
         let chroms = reader
             .chroms()
             .iter()
@@ -56,6 +61,7 @@ impl BigWigTableProvider {
             file_path,
             schema,
             chroms,
+            block_work,
             coordinate_system_zero_based,
         })
     }
@@ -95,7 +101,7 @@ impl TableProvider for BigWigTableProvider {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         // `_limit` is intentionally ignored: BBI scans have no cheap row cap, so
@@ -112,15 +118,25 @@ impl TableProvider for BigWigTableProvider {
             self.coordinate_system_zero_based,
             true,
         );
+        let partitions = plan_bbi_partitions(
+            regions,
+            state.config().target_partitions(),
+            !filters.iter().any(is_genomic_coordinate_filter),
+            true,
+            &self.block_work,
+        );
+        let partition_estimated_bytes = partition_estimated_bytes(&partitions, &self.block_work);
+        let partition_count = partitions.len();
         Ok(Arc::new(BigWigExec {
             file_path: self.file_path.clone(),
             schema: schema.clone(),
             projection: projection.cloned(),
-            regions,
+            partitions,
+            partition_estimated_bytes,
             coordinate_system_zero_based: self.coordinate_system_zero_based,
             cache: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(schema),
-                Partitioning::UnknownPartitioning(1),
+                Partitioning::UnknownPartitioning(partition_count),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
             )),
@@ -133,7 +149,8 @@ pub struct BigWigExec {
     file_path: String,
     schema: SchemaRef,
     projection: Option<Vec<usize>>,
-    regions: Vec<BbiScanRegion>,
+    partitions: Vec<Vec<BbiScanRegion>>,
+    partition_estimated_bytes: Vec<u64>,
     coordinate_system_zero_based: bool,
     cache: Arc<PlanProperties>,
 }
@@ -150,9 +167,15 @@ impl DisplayAs for BigWigExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "BigWigExec: projection=[{}], regions=[{}]",
+            "BigWigExec: projection=[{}], partitions={}, estimated_compressed_bytes={:?}, regions=[{}]",
             projection_display(&self.schema),
-            region_display(&self.regions)
+            self.partitions.len(),
+            self.partition_estimated_bytes,
+            self.partitions
+                .iter()
+                .map(|regions| region_display(regions))
+                .collect::<Vec<_>>()
+                .join(" | ")
         )
     }
 }
@@ -183,17 +206,28 @@ impl ExecutionPlan for BigWigExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         // The stream opens a reader per region and pulls intervals in fixed-size
         // chunks, so peak memory stays bounded by one batch (never a whole
         // chromosome) and LIMIT/COUNT queries can stop early.
+        let regions = self.partitions.get(partition).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "BigWigExec partition {partition} is out of range for {} partitions",
+                self.partitions.len()
+            ))
+        })?;
         let stream = futures_util::stream::iter(BigWigRegionStream {
             file_path: self.file_path.clone(),
             schema: self.schema.clone(),
             projection: self.projection.clone(),
-            regions: self.regions.clone().into_iter(),
+            batch_rows: if self.schema.fields().is_empty() {
+                BBI_EMPTY_PROJECTION_BATCH_ROWS
+            } else {
+                BBI_BATCH_ROWS
+            },
+            regions: regions.clone().into_iter(),
             coordinate_system_zero_based: self.coordinate_system_zero_based,
             current: None,
         });
@@ -211,6 +245,8 @@ struct CurrentRegion {
     /// Exclusive upper bound on `start`; once an interval reaches it the
     /// (start-sorted) region is done and we stop reading further blocks.
     stop_at: Option<u32>,
+    ownership_start: Option<u32>,
+    ownership_end: Option<u32>,
 }
 
 /// Lazily yields fixed-size [`RecordBatch`]es across all scan regions, opening a
@@ -219,6 +255,7 @@ struct BigWigRegionStream {
     file_path: String,
     schema: SchemaRef,
     projection: Option<Vec<usize>>,
+    batch_rows: usize,
     regions: std::vec::IntoIter<BbiScanRegion>,
     coordinate_system_zero_based: bool,
     current: Option<CurrentRegion>,
@@ -245,6 +282,8 @@ impl BigWigRegionStream {
                 chrom: region.chrom,
                 iter,
                 stop_at: region.stop_at,
+                ownership_start: region.ownership_start,
+                ownership_end: region.ownership_end,
             })),
             Err(error) => Some(Err(to_external_error(error))),
         }
@@ -290,8 +329,16 @@ impl Iterator for BigWigRegionStream {
             // Copied out before the loop so the loop only borrows `current.iter`,
             // leaving `self.current` free to clear on early termination.
             let stop_at = current.stop_at;
+            let ownership_start = current.ownership_start;
+            let ownership_end = current.ownership_end;
             let chrom = current.chrom.clone();
-            let mut rows: Vec<(u32, u32, f32)> = Vec::with_capacity(BBI_BATCH_ROWS);
+            let empty_projection = self.schema.fields().is_empty();
+            let mut rows: Vec<(u32, u32, f32)> = if empty_projection {
+                Vec::new()
+            } else {
+                Vec::with_capacity(self.batch_rows)
+            };
+            let mut row_count = 0;
             let mut region_done = false;
             for value in current.iter.by_ref() {
                 let value = match value {
@@ -306,13 +353,27 @@ impl Iterator for BigWigRegionStream {
                     region_done = true;
                     break;
                 }
-                let start = if self.coordinate_system_zero_based {
-                    value.start
-                } else {
-                    value.start + 1
-                };
-                rows.push((start, value.end, value.value));
-                if rows.len() >= BBI_BATCH_ROWS {
+                if let Some(ownership_end) = ownership_end
+                    && value.start >= ownership_end
+                {
+                    region_done = true;
+                    break;
+                }
+                if let Some(ownership_start) = ownership_start
+                    && value.start < ownership_start
+                {
+                    continue;
+                }
+                row_count += 1;
+                if !empty_projection {
+                    let start = if self.coordinate_system_zero_based {
+                        value.start
+                    } else {
+                        value.start + 1
+                    };
+                    rows.push((start, value.end, value.value));
+                }
+                if row_count >= self.batch_rows {
                     break;
                 }
             }
@@ -322,13 +383,17 @@ impl Iterator for BigWigRegionStream {
                 self.current = None;
             }
 
-            if rows.is_empty() {
+            if row_count == 0 {
                 // Region drained (or stopped with nothing buffered); advance.
                 self.current = None;
                 continue;
             }
 
-            return Some(self.build_batch(&chrom, &rows));
+            return Some(if empty_projection {
+                build_batch(self.schema.clone(), Vec::new(), row_count)
+            } else {
+                self.build_batch(&chrom, &rows)
+            });
         }
     }
 }

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -112,16 +112,16 @@ impl TableProvider for BigWigTableProvider {
         // `widen_to_chromosome = true`: BigWigRead clips interval values to the
         // query window, so we scan whole chromosomes and let DataFusion's Inexact
         // re-filter drop surplus rows, rather than emitting clipped coordinates.
-        let regions = plan_bbi_scan_regions(
+        let scan_plan = plan_bbi_scan_regions(
             filters,
             &self.chroms,
             self.coordinate_system_zero_based,
             true,
         );
         let partitions = plan_bbi_partitions(
-            regions,
+            scan_plan.regions,
             state.config().target_partitions(),
-            !filters.iter().any(is_genomic_coordinate_filter),
+            !scan_plan.has_explicit_region,
             true,
             &self.block_work,
         );

--- a/datafusion/bio-format-bbi/src/bigwig.rs
+++ b/datafusion/bio-format-bbi/src/bigwig.rs
@@ -167,7 +167,7 @@ impl DisplayAs for BigWigExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "BigWigExec: projection=[{}], partitions={}, estimated_compressed_bytes={:?}, regions=[{}]",
+            "BigWigExec: projection=[{}], partitions={}, estimated_data_bytes={:?}, regions=[{}]",
             projection_display(&self.schema),
             self.partitions.len(),
             self.partition_estimated_bytes,

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -86,7 +86,7 @@ pub(crate) fn bbi_block_index(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> 
         }
         for chrom in &chroms_by_id[first..last] {
             let start = if chrom.id() == block.start_chrom_id {
-                block.start_base
+                block.start_base.min(chrom.length)
             } else {
                 0
             };
@@ -95,7 +95,9 @@ pub(crate) fn bbi_block_index(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> 
             } else {
                 chrom.length
             };
-            if start < end {
+            // A zero-width BigBed insertion can be the only record in a real
+            // encoded block. Retain it as work even though it has no span.
+            if start <= end {
                 by_chrom
                     .entry(chrom.name.clone())
                     .or_default()
@@ -270,10 +272,11 @@ struct BbiWorkSegment {
 /// Multi-region scans may always split a dominant chromosome so it does not
 /// monopolize one partition.
 ///
-/// The number of partitions is capped at the number of useful block-start
-/// segments. This avoids opening multiple readers that all decode the same
-/// indivisible block. A missing layout means traversal hit its safety limit, so
-/// the optimization falls back to one serial partition.
+/// The number of partitions is capped at the number of coordinate-overlap
+/// connected block components. This avoids opening multiple readers that all
+/// decode a long block spanning several later block starts. A missing layout
+/// means traversal hit its safety limit, so the optimization falls back to one
+/// serial partition.
 pub(crate) fn plan_bbi_partitions(
     regions: Vec<BbiScanRegion>,
     target_partitions: usize,
@@ -295,6 +298,9 @@ pub(crate) fn plan_bbi_partitions(
         .enumerate()
         .flat_map(|(region_index, region)| region_work_segments(region_index, region, block_index))
         .collect::<Vec<_>>();
+    if segments.is_empty() {
+        return vec![Vec::new()];
+    }
     let ranges = weighted_segment_ranges(&segments, target_partitions);
 
     ranges
@@ -312,9 +318,16 @@ fn candidate_blocks<'a>(
     };
     let upper = work
         .blocks
-        .partition_point(|block| block.start < region.end);
-    let lower = work.prefix_max_end[..upper].partition_point(|&end| end <= region.start);
+        .partition_point(|block| block.start <= region.end);
+    let lower = work.prefix_max_end[..upper].partition_point(|&end| end < region.start);
     &work.blocks[lower..upper]
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BbiBlockComponent {
+    start: u32,
+    maximum_end: u32,
+    estimated_bytes: u64,
 }
 
 fn region_work_segments(
@@ -322,41 +335,63 @@ fn region_work_segments(
     region: &BbiScanRegion,
     block_index: &BbiBlockIndex,
 ) -> Vec<BbiWorkSegment> {
-    let mut boundaries: Vec<(u32, u64)> = Vec::new();
+    let mut components: Vec<BbiBlockComponent> = Vec::new();
     for block in candidate_blocks(block_index, region)
         .iter()
-        .filter(|block| block.end > region.start)
+        .filter(|block| block.end >= region.start)
     {
-        let boundary = block.start.max(region.start);
-        if let Some((last_boundary, bytes)) = boundaries.last_mut()
-            && *last_boundary == boundary
+        let start = block.start.max(region.start).min(region.end);
+        let end = block.end.max(start).min(region.end);
+        if let Some(component) = components.last_mut()
+            && (component.start == start || start < component.maximum_end)
         {
-            *bytes = bytes.saturating_add(block.data_size);
+            component.maximum_end = component.maximum_end.max(end);
+            component.estimated_bytes = component.estimated_bytes.saturating_add(block.data_size);
         } else {
-            boundaries.push((boundary, block.data_size));
+            components.push(BbiBlockComponent {
+                start,
+                maximum_end: end,
+                estimated_bytes: block.data_size,
+            });
         }
     }
 
-    if boundaries.is_empty() {
-        boundaries.push((region.start, 0));
-    } else {
-        // Coordinates before the first block contain no independent work, so
-        // keep them with the first block instead of creating an empty shard.
-        boundaries[0].0 = region.start;
+    if components.is_empty() {
+        return Vec::new();
+    }
+    // Coordinates before the first block contain no independent work, so keep
+    // them with the first block instead of creating an empty shard.
+    components[0].start = region.start;
+
+    // A zero-width insertion at the region's inclusive lookup endpoint is read
+    // by the preceding query. Charge that work there because it cannot form a
+    // non-empty coordinate segment of its own.
+    if components.len() > 1
+        && components
+            .last()
+            .is_some_and(|component| component.start == region.end)
+    {
+        let endpoint = components.pop().expect("endpoint component is present");
+        let preceding = components
+            .last_mut()
+            .expect("preceding component is present");
+        preceding.estimated_bytes = preceding
+            .estimated_bytes
+            .saturating_add(endpoint.estimated_bytes);
     }
 
-    boundaries
+    components
         .iter()
         .enumerate()
-        .filter_map(|(index, &(start, estimated_bytes))| {
-            let end = boundaries
+        .filter_map(|(index, component)| {
+            let end = components
                 .get(index + 1)
-                .map_or(region.end, |&(next, _)| next);
-            (start < end).then_some(BbiWorkSegment {
+                .map_or(region.end, |next| next.start);
+            (component.start < end).then_some(BbiWorkSegment {
                 region_index,
-                start,
+                start: component.start,
                 end,
-                estimated_bytes,
+                estimated_bytes: component.estimated_bytes,
             })
         })
         .collect()
@@ -385,25 +420,32 @@ fn weighted_segment_ranges(
         }
 
         let latest_end = segments.len() - remaining_partitions;
-        let target = if total_bytes == 0 {
-            (segments.len() * (partition + 1) / partition_count) as u128
+        let end = if total_bytes == 0 {
+            (segments.len() * (partition + 1) / partition_count).clamp(start + 1, latest_end)
         } else {
-            total_bytes * (partition + 1) as u128 / partition_count as u128
+            let target = total_bytes * (partition + 1) as u128 / partition_count as u128;
+            closest_prefix_cut(&prefix_bytes, start + 1, latest_end, target)
         };
-        let end = (start + 1..=latest_end)
-            .min_by_key(|&candidate| {
-                let cumulative = if total_bytes == 0 {
-                    candidate as u128
-                } else {
-                    prefix_bytes[candidate]
-                };
-                cumulative.abs_diff(target)
-            })
-            .expect("a BBI partition must contain at least one work segment");
         ranges.push(start..end);
         start = end;
     }
     ranges
+}
+
+fn closest_prefix_cut(prefix: &[u128], lower: usize, upper: usize, target: u128) -> usize {
+    let candidates = &prefix[lower..=upper];
+    let offset = candidates.partition_point(|&value| value < target);
+    let upper_candidate = if offset < candidates.len() {
+        lower + offset
+    } else {
+        upper
+    };
+    let lower_candidate = upper_candidate.saturating_sub(1).max(lower);
+    if prefix[lower_candidate].abs_diff(target) <= prefix[upper_candidate].abs_diff(target) {
+        lower_candidate
+    } else {
+        upper_candidate
+    }
 }
 
 fn segments_to_regions(
@@ -433,7 +475,7 @@ fn segments_to_regions(
                 // query window but overlap it. Later shards discard that overlap
                 // because the preceding shard owns those record starts.
                 ownership_start: (shard_start != original.start).then_some(shard_start),
-                ownership_end: Some(shard_end),
+                ownership_end: (shard_end != original.end).then_some(shard_end),
             });
         }
         start = end;
@@ -460,7 +502,7 @@ pub(crate) fn partition_estimated_bytes(
                 .map(|region| {
                     candidate_blocks(block_index, region)
                         .iter()
-                        .filter(|block| block.end > region.start)
+                        .filter(|block| block.end >= region.start)
                         .map(|block| block.data_size)
                         .sum::<u64>()
                 })
@@ -574,7 +616,9 @@ mod partition_tests {
         assert_eq!((partitions[1][0].start, partitions[1][0].end), (200, 400));
         assert_eq!(
             partition_estimated_bytes(&partitions, Some(&index)),
-            vec![500, 500]
+            // BigTools' cir-tree lookup is inclusive at the coordinate
+            // boundary, so each shard also touches its neighbor's edge block.
+            vec![600, 600]
         );
     }
 
@@ -583,6 +627,46 @@ mod partition_tests {
         let index = block_index(&[(0, 400, 1_000)]);
         let partitions = plan_bbi_partitions(vec![region()], 8, true, Some(&index));
         assert_eq!(partitions, vec![vec![region()]]);
+    }
+
+    #[test]
+    fn overlapping_blocks_form_one_indivisible_component() {
+        let index = block_index(&[(0, 250, 100), (100, 300, 200), (200, 400, 300)]);
+
+        let partitions = plan_bbi_partitions(vec![region()], 8, true, Some(&index));
+
+        assert_eq!(partitions, vec![vec![region()]]);
+        assert_eq!(
+            partition_estimated_bytes(&partitions, Some(&index)),
+            vec![600]
+        );
+    }
+
+    #[test]
+    fn zero_width_block_contributes_real_work() {
+        let index = block_index(&[(100, 100, 50)]);
+
+        let partitions = plan_bbi_partitions(vec![region()], 8, true, Some(&index));
+
+        assert_eq!(partitions, vec![vec![region()]]);
+        assert_eq!(
+            partition_estimated_bytes(&partitions, Some(&index)),
+            vec![50]
+        );
+    }
+
+    #[test]
+    fn blockless_parallel_scan_uses_one_empty_partition() {
+        let partitions =
+            plan_bbi_partitions(vec![region()], 8, true, Some(&BbiBlockIndex::default()));
+        assert_eq!(partitions, vec![Vec::new()]);
+    }
+
+    #[test]
+    fn weighted_cut_binary_search_uses_lower_candidate_on_ties() {
+        let prefix = [0, 400, 500, 600, 1_000];
+        assert_eq!(closest_prefix_cut(&prefix, 1, 3, 550), 2);
+        assert_eq!(closest_prefix_cut(&prefix, 1, 3, 590), 3);
     }
 
     #[test]

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -4,7 +4,8 @@
 //! genomic-region planning, path validation) and are reused by both
 //! [`crate::bigwig`] and [`crate::bigbed`].
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::ops::Range;
 use std::sync::Arc;
 
 use bigtools::{BBIDataBlock, ChromInfo};
@@ -13,7 +14,6 @@ use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::logical_expr::Expr;
 use datafusion_bio_format_core::genomic_filter::{GenomicRegion, extract_genomic_regions};
-use datafusion_bio_format_core::partition_balancer::{RegionSizeEstimate, balance_partitions};
 
 /// Maximum number of rows emitted per [`RecordBatch`] while streaming a region.
 ///
@@ -33,14 +33,6 @@ pub(crate) struct BbiScanRegion {
     pub(crate) chrom: String,
     pub(crate) start: u32,
     pub(crate) end: u32,
-    /// Exclusive upper bound on interval `start` for early termination, in the
-    /// same 0-based coordinate space as the native interval `start`. `None`
-    /// means "no upper bound — drain the whole region".
-    ///
-    /// Used only by the BigWig provider: it scans whole chromosomes to avoid
-    /// coordinate clipping, but the streamed intervals are start-sorted, so it
-    /// can stop as soon as `start >= stop_at` rather than reading to the end.
-    pub(crate) stop_at: Option<u32>,
     /// Inclusive lower bound on the original interval start owned by this
     /// region. Partitioned queries can return an interval that overlaps the
     /// lower query boundary and is also returned by the preceding partition;
@@ -64,20 +56,35 @@ pub(crate) struct BbiScanPlan {
 /// reading the shared physical block.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BbiBlockWork {
-    chrom: String,
     start: u32,
     end: u32,
     data_size: u64,
 }
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BbiBlockIndex {
+    by_chrom: HashMap<String, BbiChromWork>,
+}
+
+#[derive(Clone, Debug)]
+struct BbiChromWork {
+    blocks: Vec<BbiBlockWork>,
+    prefix_max_end: Vec<u32>,
+}
+
 /// Convert BigTools' cir-tree leaf layout into chromosome-local work units.
-pub(crate) fn bbi_block_work(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> Vec<BbiBlockWork> {
-    let mut work = Vec::new();
+pub(crate) fn bbi_block_index(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> BbiBlockIndex {
+    let mut chroms_by_id = chroms.iter().collect::<Vec<_>>();
+    chroms_by_id.sort_unstable_by_key(|chrom| chrom.id());
+
+    let mut by_chrom: HashMap<String, Vec<BbiBlockWork>> = HashMap::new();
     for block in blocks {
-        for chrom in chroms
-            .iter()
-            .filter(|chrom| (block.start_chrom_id..=block.end_chrom_id).contains(&chrom.id()))
-        {
+        let first = chroms_by_id.partition_point(|chrom| chrom.id() < block.start_chrom_id);
+        let last = chroms_by_id.partition_point(|chrom| chrom.id() <= block.end_chrom_id);
+        if first >= last {
+            continue;
+        }
+        for chrom in &chroms_by_id[first..last] {
             let start = if chrom.id() == block.start_chrom_id {
                 block.start_base
             } else {
@@ -89,19 +96,40 @@ pub(crate) fn bbi_block_work(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> V
                 chrom.length
             };
             if start < end {
-                work.push(BbiBlockWork {
-                    chrom: chrom.name.clone(),
-                    start,
-                    end,
-                    data_size: block.data_size,
-                });
+                by_chrom
+                    .entry(chrom.name.clone())
+                    .or_default()
+                    .push(BbiBlockWork {
+                        start,
+                        end,
+                        data_size: block.data_size,
+                    });
             }
         }
     }
-    work.sort_unstable_by(|left, right| {
-        (&left.chrom, left.start, left.end).cmp(&(&right.chrom, right.start, right.end))
-    });
-    work
+
+    let by_chrom = by_chrom
+        .into_iter()
+        .map(|(chrom, mut blocks)| {
+            blocks.sort_unstable_by_key(|block| (block.start, block.end));
+            let mut maximum_end = 0;
+            let prefix_max_end = blocks
+                .iter()
+                .map(|block| {
+                    maximum_end = maximum_end.max(block.end);
+                    maximum_end
+                })
+                .collect();
+            (
+                chrom,
+                BbiChromWork {
+                    blocks,
+                    prefix_max_end,
+                },
+            )
+        })
+        .collect();
+    BbiBlockIndex { by_chrom }
 }
 
 pub(crate) fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
@@ -154,23 +182,12 @@ pub(crate) fn projection_display(schema: &SchemaRef) -> String {
 
 /// Plan the native interval-query regions for a BBI scan.
 ///
-/// `widen_to_chromosome` controls how a positional coordinate filter is turned
-/// into a query window:
-///
-/// * `false` (BigBed) — honor the filter's start/end bounds. `BigBedRead`
-///   returns full BED entries that *overlap* the window, so narrowing the window
-///   prunes work without altering the emitted coordinates.
-/// * `true` (BigWig) — ignore the positional bounds and scan each matched
-///   chromosome in full. `BigWigRead` *clips* interval values to the query
-///   window, so a sub-range would emit truncated start/end coordinates. Because
-///   coordinate filters are pushed down as `Inexact` (DataFusion re-applies
-///   them), scanning the whole chromosome is still correct — it only trades
-///   within-chromosome seek pruning for unclipped intervals.
+/// Both providers preserve original record coordinates for overlapping values,
+/// so extracted positional bounds can be passed directly to their index query.
 pub(crate) fn plan_bbi_scan_regions(
     filters: &[Expr],
     chroms: &[(String, u32)],
     coordinate_system_zero_based: bool,
-    widen_to_chromosome: bool,
 ) -> BbiScanPlan {
     let analysis = extract_genomic_regions(filters, coordinate_system_zero_based);
     let has_explicit_region = !analysis.regions.is_empty();
@@ -202,37 +219,6 @@ pub(crate) fn plan_bbi_scan_regions(
         .map(|(chrom, len)| (chrom.as_str(), *len))
         .collect();
 
-    if widen_to_chromosome {
-        // De-duplicate by chromosome so overlapping or OR'd ranges never scan the
-        // same chromosome twice (which would duplicate rows).
-        let mut seen = HashSet::new();
-        let regions = source_regions
-            .into_iter()
-            .filter(|region| seen.insert(region.chrom.clone()))
-            .filter_map(|region| {
-                let length = *chrom_lengths.get(region.chrom.as_str())?;
-                // Scan the whole chromosome (so intervals are never clipped) but
-                // remember the filter's upper bound: `region.end` is 1-based
-                // inclusive, which equals the 0-based exclusive bound on `start`,
-                // letting the start-sorted stream stop early. `None` (no upper
-                // bound) means drain the whole chromosome.
-                let stop_at = region.end.map(|end| end.min(length as u64) as u32);
-                (length > 0).then_some(BbiScanRegion {
-                    chrom: region.chrom,
-                    start: 0,
-                    end: length,
-                    stop_at,
-                    ownership_start: None,
-                    ownership_end: None,
-                })
-            })
-            .collect();
-        return BbiScanPlan {
-            regions,
-            has_explicit_region,
-        };
-    }
-
     let regions = source_regions
         .into_iter()
         .filter_map(|region| convert_genomic_region_to_bbi(region, &chrom_lengths))
@@ -257,20 +243,25 @@ fn convert_genomic_region_to_bbi(
         .map(|end| end.min(length as u64) as u32)
         .unwrap_or(length);
 
-    // The narrow (BigBed) path bounds the scan with the query window itself, so
-    // it needs no separate early-termination cursor.
     (start < end).then_some(BbiScanRegion {
         chrom: region.chrom,
         start,
         end,
-        stop_at: None,
         ownership_start: None,
         ownership_end: None,
     })
 }
 
-/// Balance BBI regions across DataFusion partitions using primary-data
-/// cir-tree block sizes and positions as the workload estimate.
+#[derive(Clone, Copy, Debug)]
+struct BbiWorkSegment {
+    region_index: usize,
+    start: u32,
+    end: u32,
+    estimated_bytes: u64,
+}
+
+/// Balance BBI regions across DataFusion partitions at primary-data block
+/// boundaries, using each block's encoded byte size as its weight.
 ///
 /// A single selected region deliberately remains serial unless
 /// `allow_single_region_split` is true: a narrow chromosome-filtered lookup
@@ -279,129 +270,175 @@ fn convert_genomic_region_to_bbi(
 /// Multi-region scans may always split a dominant chromosome so it does not
 /// monopolize one partition.
 ///
-/// When `clips_query_boundaries` is true (BigWig), a split query starts one base
-/// before its ownership boundary and extends to the original region end. This
-/// prevents `bigtools` from clipping the coordinates of the first/last owned
-/// interval. BigBed returns original coordinates, so each shard can query only
-/// its own coordinate window.
+/// The number of partitions is capped at the number of useful block-start
+/// segments. This avoids opening multiple readers that all decode the same
+/// indivisible block. A missing layout means traversal hit its safety limit, so
+/// the optimization falls back to one serial partition.
 pub(crate) fn plan_bbi_partitions(
     regions: Vec<BbiScanRegion>,
     target_partitions: usize,
     allow_single_region_split: bool,
-    clips_query_boundaries: bool,
-    block_work: &[BbiBlockWork],
+    block_index: Option<&BbiBlockIndex>,
 ) -> Vec<Vec<BbiScanRegion>> {
     if regions.is_empty() {
         return vec![Vec::new()];
     }
+    let Some(block_index) = block_index else {
+        return vec![regions];
+    };
     if target_partitions <= 1 || (regions.len() == 1 && !allow_single_region_split) {
         return vec![regions];
     }
 
-    let effective_ends = regions
+    let segments = regions
         .iter()
-        .map(|region| region.stop_at.unwrap_or(region.end).min(region.end))
-        .collect::<Vec<_>>();
-    let estimates = regions
-        .iter()
-        .zip(&effective_ends)
         .enumerate()
-        .map(|(index, (region, &effective_end))| {
-            let overlapping_blocks = block_work
-                .iter()
-                .filter(|block| {
-                    block.chrom == region.chrom
-                        && block.start < effective_end
-                        && block.end > region.start
-                })
-                .collect::<Vec<_>>();
-            let estimated_bytes = overlapping_blocks.iter().map(|block| block.data_size).sum();
-            let nonempty_block_positions = overlapping_blocks
-                .iter()
-                .map(|block| u64::from(block.start.max(region.start)) + 1)
-                .collect();
+        .flat_map(|(region_index, region)| region_work_segments(region_index, region, block_index))
+        .collect::<Vec<_>>();
+    let ranges = weighted_segment_ranges(&segments, target_partitions);
 
-            RegionSizeEstimate {
-                // The balancer treats coordinates as 1-based inclusive. Use the
-                // source index as an opaque key so multiple ranges on one
-                // chromosome still map back to the correct original query.
-                region: GenomicRegion {
-                    chrom: index.to_string(),
-                    start: Some(u64::from(region.start) + 1),
-                    end: Some(u64::from(effective_end)),
-                    unmapped_tail: false,
-                },
-                estimated_bytes,
-                contig_length: Some(u64::from(effective_end)),
-                unmapped_count: 0,
-                // Cir-tree blocks are variable-width rather than fixed genomic
-                // bins. A span of one makes the generic balancer place cuts at
-                // observed block positions; encoded data bytes supply the weight.
-                nonempty_bin_positions: nonempty_block_positions,
-                leaf_bin_span: 1,
-            }
-        })
-        .collect();
-
-    balance_partitions(estimates, target_partitions)
+    ranges
         .into_iter()
-        .map(|assignment| {
-            assignment
-                .regions
-                .into_iter()
-                .map(|balanced| {
-                    let index = balanced
-                        .chrom
-                        .parse::<usize>()
-                        .expect("BBI partition planner generated a non-numeric region key");
-                    let original = &regions[index];
-                    let effective_end = effective_ends[index];
-                    let ownership_start = balanced
-                        .start
-                        .map(|start| start.saturating_sub(1) as u32)
-                        .unwrap_or(original.start);
-                    let ownership_end = balanced.end.map(|end| end as u32).unwrap_or(effective_end);
+        .map(|range| segments_to_regions(&segments[range], &regions))
+        .collect()
+}
 
-                    if ownership_start == original.start && ownership_end == effective_end {
-                        return original.clone();
-                    }
+fn candidate_blocks<'a>(
+    block_index: &'a BbiBlockIndex,
+    region: &BbiScanRegion,
+) -> &'a [BbiBlockWork] {
+    let Some(work) = block_index.by_chrom.get(&region.chrom) else {
+        return &[];
+    };
+    let upper = work
+        .blocks
+        .partition_point(|block| block.start < region.end);
+    let lower = work.prefix_max_end[..upper].partition_point(|&end| end <= region.start);
+    &work.blocks[lower..upper]
+}
 
-                    let first_shard = ownership_start == original.start;
-                    if clips_query_boundaries {
-                        BbiScanRegion {
-                            chrom: original.chrom.clone(),
-                            start: if first_shard {
-                                original.start
-                            } else {
-                                ownership_start.saturating_sub(1)
-                            },
-                            // BigWig clips values at the query end, so retain the
-                            // original end and stop after the last owned start.
-                            end: original.end,
-                            stop_at: Some(ownership_end),
-                            ownership_start: Some(ownership_start),
-                            ownership_end: Some(ownership_end),
-                        }
-                    } else {
-                        BbiScanRegion {
-                            chrom: original.chrom.clone(),
-                            start: if first_shard {
-                                original.start
-                            } else {
-                                ownership_start
-                            },
-                            end: ownership_end,
-                            stop_at: None,
-                            // The first shard owns records that start before a
-                            // filtered query window but overlap that window.
-                            ownership_start: (!first_shard).then_some(ownership_start),
-                            ownership_end: Some(ownership_end),
-                        }
-                    }
-                })
-                .collect()
+fn region_work_segments(
+    region_index: usize,
+    region: &BbiScanRegion,
+    block_index: &BbiBlockIndex,
+) -> Vec<BbiWorkSegment> {
+    let mut boundaries: Vec<(u32, u64)> = Vec::new();
+    for block in candidate_blocks(block_index, region)
+        .iter()
+        .filter(|block| block.end > region.start)
+    {
+        let boundary = block.start.max(region.start);
+        if let Some((last_boundary, bytes)) = boundaries.last_mut()
+            && *last_boundary == boundary
+        {
+            *bytes = bytes.saturating_add(block.data_size);
+        } else {
+            boundaries.push((boundary, block.data_size));
+        }
+    }
+
+    if boundaries.is_empty() {
+        boundaries.push((region.start, 0));
+    } else {
+        // Coordinates before the first block contain no independent work, so
+        // keep them with the first block instead of creating an empty shard.
+        boundaries[0].0 = region.start;
+    }
+
+    boundaries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &(start, estimated_bytes))| {
+            let end = boundaries
+                .get(index + 1)
+                .map_or(region.end, |&(next, _)| next);
+            (start < end).then_some(BbiWorkSegment {
+                region_index,
+                start,
+                end,
+                estimated_bytes,
+            })
         })
         .collect()
+}
+
+fn weighted_segment_ranges(
+    segments: &[BbiWorkSegment],
+    target_partitions: usize,
+) -> Vec<Range<usize>> {
+    let partition_count = target_partitions.max(1).min(segments.len());
+    let mut prefix_bytes = Vec::with_capacity(segments.len() + 1);
+    prefix_bytes.push(0u128);
+    for segment in segments {
+        let next = prefix_bytes.last().copied().unwrap_or(0) + u128::from(segment.estimated_bytes);
+        prefix_bytes.push(next);
+    }
+    let total_bytes = *prefix_bytes.last().unwrap_or(&0);
+
+    let mut ranges = Vec::with_capacity(partition_count);
+    let mut start = 0;
+    for partition in 0..partition_count {
+        let remaining_partitions = partition_count - partition - 1;
+        if remaining_partitions == 0 {
+            ranges.push(start..segments.len());
+            break;
+        }
+
+        let latest_end = segments.len() - remaining_partitions;
+        let target = if total_bytes == 0 {
+            (segments.len() * (partition + 1) / partition_count) as u128
+        } else {
+            total_bytes * (partition + 1) as u128 / partition_count as u128
+        };
+        let end = (start + 1..=latest_end)
+            .min_by_key(|&candidate| {
+                let cumulative = if total_bytes == 0 {
+                    candidate as u128
+                } else {
+                    prefix_bytes[candidate]
+                };
+                cumulative.abs_diff(target)
+            })
+            .expect("a BBI partition must contain at least one work segment");
+        ranges.push(start..end);
+        start = end;
+    }
+    ranges
+}
+
+fn segments_to_regions(
+    segments: &[BbiWorkSegment],
+    originals: &[BbiScanRegion],
+) -> Vec<BbiScanRegion> {
+    let mut regions = Vec::new();
+    let mut start = 0;
+    while start < segments.len() {
+        let region_index = segments[start].region_index;
+        let mut end = start + 1;
+        while end < segments.len() && segments[end].region_index == region_index {
+            end += 1;
+        }
+
+        let original = &originals[region_index];
+        let shard_start = segments[start].start;
+        let shard_end = segments[end - 1].end;
+        if shard_start == original.start && shard_end == original.end {
+            regions.push(original.clone());
+        } else {
+            regions.push(BbiScanRegion {
+                chrom: original.chrom.clone(),
+                start: shard_start,
+                end: shard_end,
+                // The first shard keeps records that begin before a filtered
+                // query window but overlap it. Later shards discard that overlap
+                // because the preceding shard owns those record starts.
+                ownership_start: (shard_start != original.start).then_some(shard_start),
+                ownership_end: Some(shard_end),
+            });
+        }
+        start = end;
+    }
+    regions
 }
 
 /// Estimate on-disk data bytes read by each planned partition. Boundary blocks
@@ -410,26 +447,20 @@ pub(crate) fn plan_bbi_partitions(
 /// closer to actual I/O than an ownership-only estimate.
 pub(crate) fn partition_estimated_bytes(
     partitions: &[Vec<BbiScanRegion>],
-    block_work: &[BbiBlockWork],
+    block_index: Option<&BbiBlockIndex>,
 ) -> Vec<u64> {
+    let Some(block_index) = block_index else {
+        return vec![0; partitions.len()];
+    };
     partitions
         .iter()
         .map(|regions| {
             regions
                 .iter()
                 .map(|region| {
-                    let effective_end = region
-                        .ownership_end
-                        .or(region.stop_at)
-                        .unwrap_or(region.end)
-                        .min(region.end);
-                    block_work
+                    candidate_blocks(block_index, region)
                         .iter()
-                        .filter(|block| {
-                            block.chrom == region.chrom
-                                && block.start < effective_end
-                                && block.end > region.start
-                        })
+                        .filter(|block| block.end > region.start)
                         .map(|block| block.data_size)
                         .sum::<u64>()
                 })
@@ -483,4 +514,81 @@ fn remote_host_error(format_name: &str) -> DataFusionError {
     DataFusionError::NotImplemented(format!(
         "{format_name} does not support remote file:// URIs with a host authority"
     ))
+}
+
+#[cfg(test)]
+mod partition_tests {
+    use super::*;
+
+    fn region() -> BbiScanRegion {
+        BbiScanRegion {
+            chrom: "chr1".into(),
+            start: 0,
+            end: 400,
+            ownership_start: None,
+            ownership_end: None,
+        }
+    }
+
+    fn block_index(blocks: &[(u32, u32, u64)]) -> BbiBlockIndex {
+        let blocks = blocks
+            .iter()
+            .map(|&(start, end, data_size)| BbiBlockWork {
+                start,
+                end,
+                data_size,
+            })
+            .collect::<Vec<_>>();
+        let mut maximum_end = 0;
+        let prefix_max_end = blocks
+            .iter()
+            .map(|block| {
+                maximum_end = maximum_end.max(block.end);
+                maximum_end
+            })
+            .collect();
+        BbiBlockIndex {
+            by_chrom: HashMap::from([(
+                "chr1".into(),
+                BbiChromWork {
+                    blocks,
+                    prefix_max_end,
+                },
+            )]),
+        }
+    }
+
+    #[test]
+    fn weighted_split_uses_cumulative_encoded_bytes() {
+        let index = block_index(&[
+            (0, 100, 400),
+            (100, 200, 100),
+            (200, 300, 100),
+            (300, 400, 400),
+        ]);
+
+        let partitions = plan_bbi_partitions(vec![region()], 2, true, Some(&index));
+
+        assert_eq!(partitions.len(), 2);
+        assert_eq!((partitions[0][0].start, partitions[0][0].end), (0, 200));
+        assert_eq!((partitions[1][0].start, partitions[1][0].end), (200, 400));
+        assert_eq!(
+            partition_estimated_bytes(&partitions, Some(&index)),
+            vec![500, 500]
+        );
+    }
+
+    #[test]
+    fn partition_count_does_not_exceed_block_granularity() {
+        let index = block_index(&[(0, 400, 1_000)]);
+        let partitions = plan_bbi_partitions(vec![region()], 8, true, Some(&index));
+        assert_eq!(partitions, vec![vec![region()]]);
+    }
+
+    #[test]
+    fn unavailable_layout_falls_back_to_serial_scan() {
+        let partitions = plan_bbi_partitions(vec![region()], 8, true, None);
+        assert_eq!(partitions, vec![vec![region()]]);
+        assert_eq!(partition_estimated_bytes(&partitions, None), vec![0]);
+    }
 }

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -52,6 +52,12 @@ pub(crate) struct BbiScanRegion {
     pub(crate) ownership_end: Option<u32>,
 }
 
+/// Native regions plus whether they came from an indexable genomic selection.
+pub(crate) struct BbiScanPlan {
+    pub(crate) regions: Vec<BbiScanRegion>,
+    pub(crate) has_explicit_region: bool,
+}
+
 /// Index-derived work estimate for one primary BBI data block on one
 /// chromosome. Blocks that span a chromosome boundary produce one estimate per
 /// covered chromosome; this is rare and reflects that either query can require
@@ -165,10 +171,14 @@ pub(crate) fn plan_bbi_scan_regions(
     chroms: &[(String, u32)],
     coordinate_system_zero_based: bool,
     widen_to_chromosome: bool,
-) -> Vec<BbiScanRegion> {
+) -> BbiScanPlan {
     let analysis = extract_genomic_regions(filters, coordinate_system_zero_based);
+    let has_explicit_region = !analysis.regions.is_empty();
     if analysis.unsatisfiable {
-        return Vec::new();
+        return BbiScanPlan {
+            regions: Vec::new(),
+            has_explicit_region,
+        };
     }
 
     let source_regions = if analysis.regions.is_empty() {
@@ -196,7 +206,7 @@ pub(crate) fn plan_bbi_scan_regions(
         // De-duplicate by chromosome so overlapping or OR'd ranges never scan the
         // same chromosome twice (which would duplicate rows).
         let mut seen = HashSet::new();
-        return source_regions
+        let regions = source_regions
             .into_iter()
             .filter(|region| seen.insert(region.chrom.clone()))
             .filter_map(|region| {
@@ -217,12 +227,20 @@ pub(crate) fn plan_bbi_scan_regions(
                 })
             })
             .collect();
+        return BbiScanPlan {
+            regions,
+            has_explicit_region,
+        };
     }
 
-    source_regions
+    let regions = source_regions
         .into_iter()
         .filter_map(|region| convert_genomic_region_to_bbi(region, &chrom_lengths))
-        .collect()
+        .collect();
+    BbiScanPlan {
+        regions,
+        has_explicit_region,
+    }
 }
 
 fn convert_genomic_region_to_bbi(

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -25,7 +25,7 @@ pub(crate) const BBI_BATCH_ROWS: usize = 8192;
 /// Empty projections carry only a logical row count, so substantially larger
 /// batches reduce scheduler and bridge overhead without allocating Arrow value
 /// buffers. This is the common `count(*)` path.
-pub(crate) const BBI_EMPTY_PROJECTION_BATCH_ROWS: usize = 4_194_304;
+pub(crate) const BBI_EMPTY_PROJECTION_BATCH_ROWS: usize = 262_144;
 
 /// Native BBI interval query region in 0-based half-open coordinates.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -299,7 +299,9 @@ pub(crate) fn plan_bbi_partitions(
         .flat_map(|(region_index, region)| region_work_segments(region_index, region, block_index))
         .collect::<Vec<_>>();
     if segments.is_empty() {
-        return vec![Vec::new()];
+        // Treat the layout as an optimization hint: an unexpectedly empty
+        // mapping must not turn a non-empty logical scan into zero rows.
+        return vec![regions];
     }
     let ranges = weighted_segment_ranges(&segments, target_partitions);
 
@@ -656,10 +658,10 @@ mod partition_tests {
     }
 
     #[test]
-    fn blockless_parallel_scan_uses_one_empty_partition() {
+    fn blockless_layout_falls_back_to_serial_scan() {
         let partitions =
             plan_bbi_partitions(vec![region()], 8, true, Some(&BbiBlockIndex::default()));
-        assert_eq!(partitions, vec![Vec::new()]);
+        assert_eq!(partitions, vec![vec![region()]]);
     }
 
     #[test]

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -7,11 +7,13 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use bigtools::{BBIDataBlock, ChromInfo};
 use datafusion::arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::logical_expr::Expr;
 use datafusion_bio_format_core::genomic_filter::{GenomicRegion, extract_genomic_regions};
+use datafusion_bio_format_core::partition_balancer::{RegionSizeEstimate, balance_partitions};
 
 /// Maximum number of rows emitted per [`RecordBatch`] while streaming a region.
 ///
@@ -19,6 +21,11 @@ use datafusion_bio_format_core::genomic_filter::{GenomicRegion, extract_genomic_
 /// bounded (a whole chromosome is never buffered) and `LIMIT`/`COUNT` queries
 /// can stop early instead of reading the entire region.
 pub(crate) const BBI_BATCH_ROWS: usize = 8192;
+
+/// Empty projections carry only a logical row count, so substantially larger
+/// batches reduce scheduler and bridge overhead without allocating Arrow value
+/// buffers. This is the common `count(*)` path.
+pub(crate) const BBI_EMPTY_PROJECTION_BATCH_ROWS: usize = 4_194_304;
 
 /// Native BBI interval query region in 0-based half-open coordinates.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -34,6 +41,61 @@ pub(crate) struct BbiScanRegion {
     /// coordinate clipping, but the streamed intervals are start-sorted, so it
     /// can stop as soon as `start >= stop_at` rather than reading to the end.
     pub(crate) stop_at: Option<u32>,
+    /// Inclusive lower bound on the original interval start owned by this
+    /// region. Partitioned queries can return an interval that overlaps the
+    /// lower query boundary and is also returned by the preceding partition;
+    /// ownership filtering keeps it in exactly one partition.
+    pub(crate) ownership_start: Option<u32>,
+    /// Exclusive upper bound on the original interval start owned by this
+    /// region. This also permits early termination because BBI interval streams
+    /// are ordered by start position.
+    pub(crate) ownership_end: Option<u32>,
+}
+
+/// Index-derived work estimate for one primary BBI data block on one
+/// chromosome. Blocks that span a chromosome boundary produce one estimate per
+/// covered chromosome; this is rare and reflects that either query can require
+/// reading the shared physical block.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BbiBlockWork {
+    chrom: String,
+    start: u32,
+    end: u32,
+    compressed_size: u64,
+}
+
+/// Convert BigTools' cir-tree leaf layout into chromosome-local work units.
+pub(crate) fn bbi_block_work(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> Vec<BbiBlockWork> {
+    let mut work = Vec::new();
+    for block in blocks {
+        for chrom in chroms
+            .iter()
+            .filter(|chrom| (block.start_chrom_id..=block.end_chrom_id).contains(&chrom.id()))
+        {
+            let start = if chrom.id() == block.start_chrom_id {
+                block.start_base
+            } else {
+                0
+            };
+            let end = if chrom.id() == block.end_chrom_id {
+                block.end_base.min(chrom.length)
+            } else {
+                chrom.length
+            };
+            if start < end {
+                work.push(BbiBlockWork {
+                    chrom: chrom.name.clone(),
+                    start,
+                    end,
+                    compressed_size: block.compressed_size,
+                });
+            }
+        }
+    }
+    work.sort_unstable_by(|left, right| {
+        (&left.chrom, left.start, left.end).cmp(&(&right.chrom, right.start, right.end))
+    });
+    work
 }
 
 pub(crate) fn project_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> SchemaRef {
@@ -150,6 +212,8 @@ pub(crate) fn plan_bbi_scan_regions(
                     start: 0,
                     end: length,
                     stop_at,
+                    ownership_start: None,
+                    ownership_end: None,
                 })
             })
             .collect();
@@ -182,7 +246,181 @@ fn convert_genomic_region_to_bbi(
         start,
         end,
         stop_at: None,
+        ownership_start: None,
+        ownership_end: None,
     })
+}
+
+/// Balance BBI regions across DataFusion partitions using primary-data
+/// cir-tree block sizes and positions as the workload estimate.
+///
+/// A single selected region deliberately remains serial unless
+/// `allow_single_region_split` is true: a narrow chromosome-filtered lookup
+/// should not fan out into several independent file opens, while an unfiltered
+/// one-chromosome file must still be able to use the requested parallelism.
+/// Multi-region scans may always split a dominant chromosome so it does not
+/// monopolize one partition.
+///
+/// When `clips_query_boundaries` is true (BigWig), a split query starts one base
+/// before its ownership boundary and extends to the original region end. This
+/// prevents `bigtools` from clipping the coordinates of the first/last owned
+/// interval. BigBed returns original coordinates, so each shard can query only
+/// its own coordinate window.
+pub(crate) fn plan_bbi_partitions(
+    regions: Vec<BbiScanRegion>,
+    target_partitions: usize,
+    allow_single_region_split: bool,
+    clips_query_boundaries: bool,
+    block_work: &[BbiBlockWork],
+) -> Vec<Vec<BbiScanRegion>> {
+    if regions.is_empty() {
+        return vec![Vec::new()];
+    }
+    if target_partitions <= 1 || (regions.len() == 1 && !allow_single_region_split) {
+        return vec![regions];
+    }
+
+    let effective_ends = regions
+        .iter()
+        .map(|region| region.stop_at.unwrap_or(region.end).min(region.end))
+        .collect::<Vec<_>>();
+    let estimates = regions
+        .iter()
+        .zip(&effective_ends)
+        .enumerate()
+        .map(|(index, (region, &effective_end))| {
+            let overlapping_blocks = block_work
+                .iter()
+                .filter(|block| {
+                    block.chrom == region.chrom
+                        && block.start < effective_end
+                        && block.end > region.start
+                })
+                .collect::<Vec<_>>();
+            let estimated_bytes = overlapping_blocks
+                .iter()
+                .map(|block| block.compressed_size)
+                .sum();
+            let nonempty_block_positions = overlapping_blocks
+                .iter()
+                .map(|block| u64::from(block.start.max(region.start)) + 1)
+                .collect();
+
+            RegionSizeEstimate {
+                // The balancer treats coordinates as 1-based inclusive. Use the
+                // source index as an opaque key so multiple ranges on one
+                // chromosome still map back to the correct original query.
+                region: GenomicRegion {
+                    chrom: index.to_string(),
+                    start: Some(u64::from(region.start) + 1),
+                    end: Some(u64::from(effective_end)),
+                    unmapped_tail: false,
+                },
+                estimated_bytes,
+                contig_length: Some(u64::from(effective_end)),
+                unmapped_count: 0,
+                // Cir-tree blocks are variable-width rather than fixed genomic
+                // bins. A span of one makes the generic balancer place cuts at
+                // observed block positions; compressed bytes supply the weight.
+                nonempty_bin_positions: nonempty_block_positions,
+                leaf_bin_span: 1,
+            }
+        })
+        .collect();
+
+    balance_partitions(estimates, target_partitions)
+        .into_iter()
+        .map(|assignment| {
+            assignment
+                .regions
+                .into_iter()
+                .map(|balanced| {
+                    let index = balanced
+                        .chrom
+                        .parse::<usize>()
+                        .expect("BBI partition planner generated a non-numeric region key");
+                    let original = &regions[index];
+                    let effective_end = effective_ends[index];
+                    let ownership_start = balanced
+                        .start
+                        .map(|start| start.saturating_sub(1) as u32)
+                        .unwrap_or(original.start);
+                    let ownership_end = balanced.end.map(|end| end as u32).unwrap_or(effective_end);
+
+                    if ownership_start == original.start && ownership_end == effective_end {
+                        return original.clone();
+                    }
+
+                    let first_shard = ownership_start == original.start;
+                    if clips_query_boundaries {
+                        BbiScanRegion {
+                            chrom: original.chrom.clone(),
+                            start: if first_shard {
+                                original.start
+                            } else {
+                                ownership_start.saturating_sub(1)
+                            },
+                            // BigWig clips values at the query end, so retain the
+                            // original end and stop after the last owned start.
+                            end: original.end,
+                            stop_at: Some(ownership_end),
+                            ownership_start: Some(ownership_start),
+                            ownership_end: Some(ownership_end),
+                        }
+                    } else {
+                        BbiScanRegion {
+                            chrom: original.chrom.clone(),
+                            start: if first_shard {
+                                original.start
+                            } else {
+                                ownership_start
+                            },
+                            end: ownership_end,
+                            stop_at: None,
+                            // The first shard owns records that start before a
+                            // filtered query window but overlap that window.
+                            ownership_start: (!first_shard).then_some(ownership_start),
+                            ownership_end: Some(ownership_end),
+                        }
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Estimate compressed bytes read by each planned partition. Boundary blocks
+/// can appear in two partitions because both independent index queries may
+/// legitimately read them; retaining that duplication makes the diagnostic
+/// closer to actual I/O than an ownership-only estimate.
+pub(crate) fn partition_estimated_bytes(
+    partitions: &[Vec<BbiScanRegion>],
+    block_work: &[BbiBlockWork],
+) -> Vec<u64> {
+    partitions
+        .iter()
+        .map(|regions| {
+            regions
+                .iter()
+                .map(|region| {
+                    let effective_end = region
+                        .ownership_end
+                        .or(region.stop_at)
+                        .unwrap_or(region.end)
+                        .min(region.end);
+                    block_work
+                        .iter()
+                        .filter(|block| {
+                            block.chrom == region.chrom
+                                && block.start < effective_end
+                                && block.end > region.start
+                        })
+                        .map(|block| block.compressed_size)
+                        .sum::<u64>()
+                })
+                .sum()
+        })
+        .collect()
 }
 
 pub(crate) fn region_display(regions: &[BbiScanRegion]) -> String {

--- a/datafusion/bio-format-bbi/src/common.rs
+++ b/datafusion/bio-format-bbi/src/common.rs
@@ -61,7 +61,7 @@ pub(crate) struct BbiBlockWork {
     chrom: String,
     start: u32,
     end: u32,
-    compressed_size: u64,
+    data_size: u64,
 }
 
 /// Convert BigTools' cir-tree leaf layout into chromosome-local work units.
@@ -87,7 +87,7 @@ pub(crate) fn bbi_block_work(chroms: &[ChromInfo], blocks: &[BBIDataBlock]) -> V
                     chrom: chrom.name.clone(),
                     start,
                     end,
-                    compressed_size: block.compressed_size,
+                    data_size: block.data_size,
                 });
             }
         }
@@ -297,10 +297,7 @@ pub(crate) fn plan_bbi_partitions(
                         && block.end > region.start
                 })
                 .collect::<Vec<_>>();
-            let estimated_bytes = overlapping_blocks
-                .iter()
-                .map(|block| block.compressed_size)
-                .sum();
+            let estimated_bytes = overlapping_blocks.iter().map(|block| block.data_size).sum();
             let nonempty_block_positions = overlapping_blocks
                 .iter()
                 .map(|block| u64::from(block.start.max(region.start)) + 1)
@@ -321,7 +318,7 @@ pub(crate) fn plan_bbi_partitions(
                 unmapped_count: 0,
                 // Cir-tree blocks are variable-width rather than fixed genomic
                 // bins. A span of one makes the generic balancer place cuts at
-                // observed block positions; compressed bytes supply the weight.
+                // observed block positions; encoded data bytes supply the weight.
                 nonempty_bin_positions: nonempty_block_positions,
                 leaf_bin_span: 1,
             }
@@ -389,7 +386,7 @@ pub(crate) fn plan_bbi_partitions(
         .collect()
 }
 
-/// Estimate compressed bytes read by each planned partition. Boundary blocks
+/// Estimate on-disk data bytes read by each planned partition. Boundary blocks
 /// can appear in two partitions because both independent index queries may
 /// legitimately read them; retaining that duplication makes the diagnostic
 /// closer to actual I/O than an ownership-only estimate.
@@ -415,7 +412,7 @@ pub(crate) fn partition_estimated_bytes(
                                 && block.start < effective_end
                                 && block.end > region.start
                         })
-                        .map(|block| block.compressed_size)
+                        .map(|block| block.data_size)
                         .sum::<u64>()
                 })
                 .sum()

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -804,7 +804,7 @@ async fn bigwig_full_scan_uses_target_partitions_without_boundary_corruption() -
         "BBI source partitions should make a round-robin repartition unnecessary:\n{count_plan_text}"
     );
     assert!(
-        count_plan_text.contains("estimated_compressed_bytes=["),
+        count_plan_text.contains("estimated_data_bytes=["),
         "BigWig plan should expose index-derived partition work:\n{count_plan_text}"
     );
 
@@ -877,7 +877,7 @@ async fn bigbed_full_scan_uses_target_partitions_without_duplicates() -> TestRes
         "BBI source partitions should make a round-robin repartition unnecessary:\n{count_plan_text}"
     );
     assert!(
-        count_plan_text.contains("estimated_compressed_bytes=["),
+        count_plan_text.contains("estimated_data_bytes=["),
         "BigBed plan should expose index-derived partition work:\n{count_plan_text}"
     );
 

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -32,7 +32,7 @@ fn chrom_sizes() -> HashMap<String, u32> {
 }
 
 fn skewed_chrom_sizes() -> HashMap<String, u32> {
-    HashMap::from([("chr1".to_string(), 900), ("chr2".to_string(), 100)])
+    HashMap::from([("chr1".to_string(), 900), ("chr2".to_string(), 300)])
 }
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -844,6 +844,56 @@ async fn bigwig_full_scan_uses_block_bounded_partitions_without_boundary_corrupt
             .partition_count(),
         1,
         "a single selected chromosome should not fan out"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn bigwig_filtered_multiregion_split_preserves_boundary_overlap() -> TestResult<()> {
+    let fixture = write_partition_bigwig_fixture()?;
+    let path = fixture.path().to_string_lossy().to_string();
+    let filter = col("chrom")
+        .in_list(vec![lit("chr1"), lit("chr2")], false)
+        .and(col("start").gt_eq(lit(250u32)));
+
+    let serial = context_with_partitions(1);
+    let serial_table = BigWigTableProvider::new(path.clone(), true)?;
+    let serial_plan = serial_table
+        .scan(&serial.state(), None, std::slice::from_ref(&filter), None)
+        .await?;
+    let expected = collect(serial_plan.execute(0, serial.task_ctx())?).await?;
+    let starts = expected[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .expect("BigWig start column");
+    assert_eq!(
+        starts.value(0),
+        240,
+        "the source keeps the lower-bound overlap"
+    );
+
+    let parallel = context_with_partitions(4);
+    let parallel_table = BigWigTableProvider::new(path, true)?;
+    let parallel_plan = parallel_table
+        .scan(&parallel.state(), None, &[filter], None)
+        .await?;
+    let partition_count = parallel_plan
+        .properties()
+        .output_partitioning()
+        .partition_count();
+    assert_eq!(
+        partition_count, 3,
+        "the selected regions should split by blocks"
+    );
+    let mut actual = Vec::new();
+    for partition in 0..partition_count {
+        actual.extend(collect(parallel_plan.execute(partition, parallel.task_ctx())?).await?);
+    }
+
+    assert_eq!(
+        pretty_format_batches(&actual)?.to_string(),
+        pretty_format_batches(&expected)?.to_string()
     );
     Ok(())
 }

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -90,8 +90,6 @@ fn write_bigbed_fixture_inner() -> TestResult<NamedTempFile> {
 fn write_partition_bigwig_fixture() -> TestResult<NamedTempFile> {
     std::thread::spawn(|| -> TestResult<NamedTempFile> {
         let mut bedgraph = NamedTempFile::new()?;
-        // target_partitions=4 places chr1 ownership boundaries at 250, 500,
-        // and 750. These intervals cross all three boundaries.
         writeln!(bedgraph, "chr1\t240\t260\t1.0")?;
         writeln!(bedgraph, "chr1\t490\t510\t2.0")?;
         writeln!(bedgraph, "chr1\t740\t760\t3.0")?;
@@ -99,7 +97,10 @@ fn write_partition_bigwig_fixture() -> TestResult<NamedTempFile> {
         bedgraph.flush()?;
 
         let bigwig = NamedTempFile::new()?;
-        let out = BigWigWrite::create_file(bigwig.path(), skewed_chrom_sizes())?;
+        let mut out = BigWigWrite::create_file(bigwig.path(), skewed_chrom_sizes())?;
+        // Force distinct same-chromosome primary blocks so tests exercise real
+        // index-derived cuts rather than inferred coordinate quartiles.
+        out.options.items_per_slot = 1;
         let input = File::open(bedgraph.path())?;
         let data = BedParserStreamingIterator::from_bedgraph_file(input, false);
         out.write(data, runtime())?;
@@ -113,6 +114,7 @@ fn write_partition_bigbed_fixture() -> TestResult<NamedTempFile> {
     std::thread::spawn(|| -> TestResult<NamedTempFile> {
         let mut bed = NamedTempFile::new()?;
         writeln!(bed, "chr1\t240\t260\tfeature1\t1")?;
+        writeln!(bed, "chr1\t490\t490\tboundary\t0")?;
         writeln!(bed, "chr1\t490\t510\tfeature2\t2")?;
         writeln!(bed, "chr1\t740\t760\tfeature3\t3")?;
         writeln!(bed, "chr2\t10\t20\tfeature4\t4")?;
@@ -128,6 +130,7 @@ fn write_partition_bigbed_fixture() -> TestResult<NamedTempFile> {
         };
         out.autosql = Some(bigtools::bed::autosql::bed_autosql(&first_rest));
         out.options.compress = false;
+        out.options.items_per_slot = 1;
         let input = File::open(bed.path())?;
         let data = BedParserStreamingIterator::from_bed_file(input, false);
         out.write(data, runtime())?;
@@ -805,13 +808,17 @@ async fn bigwig_full_scan_uses_block_bounded_partitions_without_boundary_corrupt
     let count_plan = count.create_physical_plan().await?;
     let leaf = find_leaf_exec(&count_plan);
     assert_eq!(leaf.name(), "BigWigExec");
-    assert_eq!(leaf.properties().output_partitioning().partition_count(), 2);
+    assert_eq!(leaf.properties().output_partitioning().partition_count(), 4);
     let count_plan_text = DisplayableExecutionPlan::new(count_plan.as_ref())
         .indent(false)
         .to_string();
     assert!(
         count_plan_text.contains("estimated_data_bytes=["),
         "BigWig plan should expose index-derived partition work:\n{count_plan_text}"
+    );
+    assert!(
+        count_plan_text.contains("chr1:0-490") && count_plan_text.contains("chr1:490-740"),
+        "BigWig plan should use observed same-chromosome block cuts:\n{count_plan_text}"
     );
 
     let actual = parallel
@@ -856,7 +863,10 @@ async fn bigbed_full_scan_uses_block_bounded_partitions_without_duplicates() -> 
         )?),
     )?;
     let expected = serial
-        .sql("SELECT chrom, start, \"end\", name, score FROM bb ORDER BY chrom, start")
+        .sql(
+            "SELECT chrom, start, \"end\", name, score FROM bb \
+             ORDER BY chrom, start, \"end\", name",
+        )
         .await?
         .collect()
         .await?;
@@ -874,7 +884,7 @@ async fn bigbed_full_scan_uses_block_bounded_partitions_without_duplicates() -> 
     let count_plan = count.create_physical_plan().await?;
     let leaf = find_leaf_exec(&count_plan);
     assert_eq!(leaf.name(), "BigBedExec");
-    assert_eq!(leaf.properties().output_partitioning().partition_count(), 2);
+    assert_eq!(leaf.properties().output_partitioning().partition_count(), 4);
     let count_plan_text = DisplayableExecutionPlan::new(count_plan.as_ref())
         .indent(false)
         .to_string();
@@ -882,9 +892,16 @@ async fn bigbed_full_scan_uses_block_bounded_partitions_without_duplicates() -> 
         count_plan_text.contains("estimated_data_bytes=["),
         "BigBed plan should expose index-derived partition work:\n{count_plan_text}"
     );
+    assert!(
+        count_plan_text.contains("chr1:0-490") && count_plan_text.contains("chr1:490-740"),
+        "BigBed plan should use observed same-chromosome block cuts:\n{count_plan_text}"
+    );
 
     let actual = parallel
-        .sql("SELECT chrom, start, \"end\", name, score FROM bb ORDER BY chrom, start")
+        .sql(
+            "SELECT chrom, start, \"end\", name, score FROM bb \
+             ORDER BY chrom, start, \"end\", name",
+        )
         .await?
         .collect()
         .await?;
@@ -892,7 +909,7 @@ async fn bigbed_full_scan_uses_block_bounded_partitions_without_duplicates() -> 
         pretty_format_batches(&actual)?.to_string(),
         pretty_format_batches(&expected)?.to_string()
     );
-    assert_eq!(actual.iter().map(RecordBatch::num_rows).sum::<usize>(), 4);
+    assert_eq!(actual.iter().map(RecordBatch::num_rows).sum::<usize>(), 5);
 
     let filtered_plan = parallel
         .sql("SELECT count(*) FROM bb WHERE chrom = 'chr1'")
@@ -941,7 +958,7 @@ async fn bbi_full_scan_partition_count_tracks_every_target_from_one_to_eight() -
                 .await?;
             let leaf = find_leaf_exec(&plan);
             let source_partitions = leaf.properties().output_partitioning().partition_count();
-            assert_eq!(source_partitions, target.min(2));
+            assert_eq!(source_partitions, target.min(4));
             let plan_text = DisplayableExecutionPlan::new(plan.as_ref())
                 .indent(false)
                 .to_string();
@@ -957,7 +974,8 @@ async fn bbi_full_scan_partition_count_tracks_every_target_from_one_to_eight() -
                 .await?
                 .collect()
                 .await?;
-            assert_eq!(count_star_value(&batches[0]), 4);
+            let expected_rows = if table == "bb" { 5 } else { 4 };
+            assert_eq!(count_star_value(&batches[0]), expected_rows);
         }
     }
     Ok(())

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -234,13 +234,12 @@ async fn pushes_bigwig_genomic_filter_into_scan_regions() -> TestResult<()> {
         plan_text.contains("BigWigExec"),
         "expected BigWigExec in plan:\n{plan_text}"
     );
-    // BigWig prunes by chromosome but scans it in full: BigWigRead clips interval
-    // values to the query window, so a positional sub-range (e.g. chr2:0-10)
-    // would emit truncated coordinates. The Inexact pushdown lets DataFusion
-    // re-apply `start < 10` after the unclipped scan.
+    // The bounded BigTools query preserves original coordinates for intervals
+    // overlapping the query edge, so BigWig can prune positionally as well as by
+    // chromosome without clipping emitted values.
     assert!(
-        plan_text.contains("regions=[chr2:0-100]"),
-        "expected chr2 to be scanned in full:\n{plan_text}"
+        plan_text.contains("regions=[chr2:0-10]"),
+        "expected chr2 to use the extracted upper bound:\n{plan_text}"
     );
 
     Ok(())
@@ -628,11 +627,9 @@ async fn bigwig_early_termination_spans_multiple_batches() -> TestResult<()> {
 }
 
 #[tokio::test]
-async fn bigwig_lower_bound_only_scans_whole_chromosome() -> TestResult<()> {
-    // A lower bound alone (`start > 100`) has no upper bound to stop at, and a
-    // safe left seek isn't possible (it would clip the straddling interval), so
-    // the scan must read the whole chromosome and let DataFusion filter. Guards
-    // against accidentally deriving a stop cursor from the lower bound.
+async fn bigwig_lower_bound_uses_bounded_unclipped_query() -> TestResult<()> {
+    // The unclipped query can seek to a lower bound without changing a
+    // boundary-overlapping interval's original coordinates.
     let intervals = 20_000u32;
     let fixture = write_large_bigwig_fixture(intervals)?;
     let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
@@ -648,8 +645,8 @@ async fn bigwig_lower_bound_only_scans_whole_chromosome() -> TestResult<()> {
 
     let total: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(
-        total, intervals as usize,
-        "lower-bound-only filters must not early-terminate"
+        total, 19_949,
+        "the source should seek to the lower bound without scanning earlier rows"
     );
 
     Ok(())
@@ -786,7 +783,8 @@ async fn count_star_bigbed() -> TestResult<()> {
 }
 
 #[tokio::test]
-async fn bigwig_full_scan_uses_target_partitions_without_boundary_corruption() -> TestResult<()> {
+async fn bigwig_full_scan_uses_block_bounded_partitions_without_boundary_corruption()
+-> TestResult<()> {
     let fixture = write_partition_bigwig_fixture()?;
     let path = fixture.path().to_string_lossy().to_string();
 
@@ -807,14 +805,10 @@ async fn bigwig_full_scan_uses_target_partitions_without_boundary_corruption() -
     let count_plan = count.create_physical_plan().await?;
     let leaf = find_leaf_exec(&count_plan);
     assert_eq!(leaf.name(), "BigWigExec");
-    assert_eq!(leaf.properties().output_partitioning().partition_count(), 4);
+    assert_eq!(leaf.properties().output_partitioning().partition_count(), 2);
     let count_plan_text = DisplayableExecutionPlan::new(count_plan.as_ref())
         .indent(false)
         .to_string();
-    assert!(
-        !count_plan_text.contains("RepartitionExec"),
-        "BBI source partitions should make a round-robin repartition unnecessary:\n{count_plan_text}"
-    );
     assert!(
         count_plan_text.contains("estimated_data_bytes=["),
         "BigWig plan should expose index-derived partition work:\n{count_plan_text}"
@@ -848,7 +842,7 @@ async fn bigwig_full_scan_uses_target_partitions_without_boundary_corruption() -
 }
 
 #[tokio::test]
-async fn bigbed_full_scan_uses_target_partitions_without_duplicates() -> TestResult<()> {
+async fn bigbed_full_scan_uses_block_bounded_partitions_without_duplicates() -> TestResult<()> {
     let fixture = write_partition_bigbed_fixture()?;
     let path = fixture.path().to_string_lossy().to_string();
 
@@ -880,14 +874,10 @@ async fn bigbed_full_scan_uses_target_partitions_without_duplicates() -> TestRes
     let count_plan = count.create_physical_plan().await?;
     let leaf = find_leaf_exec(&count_plan);
     assert_eq!(leaf.name(), "BigBedExec");
-    assert_eq!(leaf.properties().output_partitioning().partition_count(), 4);
+    assert_eq!(leaf.properties().output_partitioning().partition_count(), 2);
     let count_plan_text = DisplayableExecutionPlan::new(count_plan.as_ref())
         .indent(false)
         .to_string();
-    assert!(
-        !count_plan_text.contains("RepartitionExec"),
-        "BBI source partitions should make a round-robin repartition unnecessary:\n{count_plan_text}"
-    );
     assert!(
         count_plan_text.contains("estimated_data_bytes=["),
         "BigBed plan should expose index-derived partition work:\n{count_plan_text}"
@@ -950,18 +940,24 @@ async fn bbi_full_scan_partition_count_tracks_every_target_from_one_to_eight() -
                 .create_physical_plan()
                 .await?;
             let leaf = find_leaf_exec(&plan);
-            assert_eq!(
-                leaf.properties().output_partitioning().partition_count(),
-                target,
-                "{table} did not honor target_partitions={target}"
-            );
+            let source_partitions = leaf.properties().output_partitioning().partition_count();
+            assert_eq!(source_partitions, target.min(2));
             let plan_text = DisplayableExecutionPlan::new(plan.as_ref())
                 .indent(false)
                 .to_string();
-            assert!(
-                !plan_text.contains("RepartitionExec"),
-                "{table} target_partitions={target} unexpectedly repartitioned:\n{plan_text}"
-            );
+            if source_partitions == target {
+                assert!(
+                    !plan_text.contains("RepartitionExec"),
+                    "{table} target_partitions={target} unexpectedly repartitioned:\n{plan_text}"
+                );
+            }
+
+            let batches = context
+                .sql(&format!("SELECT count(*) AS c FROM {table}"))
+                .await?
+                .collect()
+                .await?;
+            assert_eq!(count_star_value(&batches[0]), 4);
         }
     }
     Ok(())

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -8,13 +8,15 @@ use bigtools::beddata::BedParserStreamingIterator;
 use bigtools::{BigBedWrite, BigWigWrite};
 use datafusion::arrow::array::{Float32Array, Int64Array, StringArray, UInt32Array, UInt64Array};
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::catalog::TableProvider;
+use datafusion::execution::context::SessionConfig;
 use datafusion::physical_plan::common::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::*;
 use datafusion_bio_format_bbi::bigbed::{BigBedSchemaMode, BigBedTableProvider};
 use datafusion_bio_format_bbi::bigwig::BigWigTableProvider;
-use datafusion_bio_format_core::test_utils::assert_plan_projection;
+use datafusion_bio_format_core::test_utils::{assert_plan_projection, find_leaf_exec};
 use tempfile::NamedTempFile;
 use tokio::runtime;
 
@@ -27,6 +29,10 @@ fn runtime() -> runtime::Runtime {
 
 fn chrom_sizes() -> HashMap<String, u32> {
     HashMap::from([("chr1".to_string(), 100), ("chr2".to_string(), 100)])
+}
+
+fn skewed_chrom_sizes() -> HashMap<String, u32> {
+    HashMap::from([("chr1".to_string(), 900), ("chr2".to_string(), 100)])
 }
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -79,6 +85,60 @@ fn write_bigbed_fixture_inner() -> TestResult<NamedTempFile> {
     let data = BedParserStreamingIterator::from_bed_file(input, false);
     out.write(data, runtime())?;
     Ok(bigbed)
+}
+
+fn write_partition_bigwig_fixture() -> TestResult<NamedTempFile> {
+    std::thread::spawn(|| -> TestResult<NamedTempFile> {
+        let mut bedgraph = NamedTempFile::new()?;
+        // target_partitions=4 places chr1 ownership boundaries at 250, 500,
+        // and 750. These intervals cross all three boundaries.
+        writeln!(bedgraph, "chr1\t240\t260\t1.0")?;
+        writeln!(bedgraph, "chr1\t490\t510\t2.0")?;
+        writeln!(bedgraph, "chr1\t740\t760\t3.0")?;
+        writeln!(bedgraph, "chr2\t10\t20\t4.0")?;
+        bedgraph.flush()?;
+
+        let bigwig = NamedTempFile::new()?;
+        let out = BigWigWrite::create_file(bigwig.path(), skewed_chrom_sizes())?;
+        let input = File::open(bedgraph.path())?;
+        let data = BedParserStreamingIterator::from_bedgraph_file(input, false);
+        out.write(data, runtime())?;
+        Ok(bigwig)
+    })
+    .join()
+    .unwrap()
+}
+
+fn write_partition_bigbed_fixture() -> TestResult<NamedTempFile> {
+    std::thread::spawn(|| -> TestResult<NamedTempFile> {
+        let mut bed = NamedTempFile::new()?;
+        writeln!(bed, "chr1\t240\t260\tfeature1\t1")?;
+        writeln!(bed, "chr1\t490\t510\tfeature2\t2")?;
+        writeln!(bed, "chr1\t740\t760\tfeature3\t3")?;
+        writeln!(bed, "chr2\t10\t20\tfeature4\t4")?;
+        bed.flush()?;
+
+        let bigbed = NamedTempFile::new()?;
+        let mut out = BigBedWrite::create_file(bigbed.path(), skewed_chrom_sizes())?;
+        let first_rest = {
+            use bigtools::bed::bedparser::StreamingBedValues;
+            let input = File::open(bed.path())?;
+            let mut vals = BedFileStream::from_bed_file(input);
+            vals.next().unwrap()?.1.rest
+        };
+        out.autosql = Some(bigtools::bed::autosql::bed_autosql(&first_rest));
+        out.options.compress = false;
+        let input = File::open(bed.path())?;
+        let data = BedParserStreamingIterator::from_bed_file(input, false);
+        out.write(data, runtime())?;
+        Ok(bigbed)
+    })
+    .join()
+    .unwrap()
+}
+
+fn context_with_partitions(partitions: usize) -> SessionContext {
+    SessionContext::new_with_config(SessionConfig::new().with_target_partitions(partitions))
 }
 
 #[tokio::test]
@@ -411,7 +471,7 @@ async fn streams_large_region_in_fixed_size_batches() -> TestResult<()> {
     let fixture = write_large_bigwig_fixture(intervals)?;
     let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
 
-    let ctx = SessionContext::new();
+    let ctx = context_with_partitions(1);
     let state = ctx.state();
     let plan = table.scan(&state, None, &[], None).await?;
     let stream = plan.execute(0, ctx.task_ctx())?;
@@ -429,6 +489,62 @@ async fn streams_large_region_in_fixed_size_batches() -> TestResult<()> {
         "no batch should exceed the chunk size"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn empty_projection_uses_large_logical_batches_without_arrays() -> TestResult<()> {
+    let intervals = 20_000u32;
+    let fixture = write_large_bigwig_fixture(intervals)?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+
+    let ctx = context_with_partitions(1);
+    let projection = Vec::new();
+    let plan = table
+        .scan(&ctx.state(), Some(&projection), &[], None)
+        .await?;
+    let batches = collect(plan.execute(0, ctx.task_ctx())?).await?;
+
+    assert_eq!(batches.len(), 1, "empty projections use a larger batch cap");
+    assert_eq!(batches[0].num_rows(), intervals as usize);
+    assert_eq!(batches[0].num_columns(), 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn unfiltered_single_chromosome_scan_can_split_but_filtered_scan_stays_serial()
+-> TestResult<()> {
+    let fixture = write_large_bigwig_fixture(20_000)?;
+    let table = BigWigTableProvider::new(fixture.path().to_string_lossy().to_string(), true)?;
+    let ctx = context_with_partitions(4);
+
+    let full_plan = table.scan(&ctx.state(), None, &[], None).await?;
+    assert_eq!(
+        full_plan
+            .properties()
+            .output_partitioning()
+            .partition_count(),
+        4,
+        "an unfiltered one-chromosome file should use target_partitions"
+    );
+    let mut total = 0;
+    for partition in 0..4 {
+        let batches = collect(full_plan.execute(partition, ctx.task_ctx())?).await?;
+        total += batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+    }
+    assert_eq!(total, 20_000);
+
+    let filtered_plan = table
+        .scan(&ctx.state(), None, &[col("chrom").eq(lit("chr1"))], None)
+        .await?;
+    assert_eq!(
+        filtered_plan
+            .properties()
+            .output_partitioning()
+            .partition_count(),
+        1,
+        "an explicitly selected chromosome should not fan out"
+    );
     Ok(())
 }
 
@@ -654,5 +770,187 @@ async fn count_star_bigbed() -> TestResult<()> {
         .await?;
     assert_eq!(batches.len(), 1);
     assert_eq!(count_star_value(&batches[0]), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn bigwig_full_scan_uses_target_partitions_without_boundary_corruption() -> TestResult<()> {
+    let fixture = write_partition_bigwig_fixture()?;
+    let path = fixture.path().to_string_lossy().to_string();
+
+    let serial = context_with_partitions(1);
+    serial.register_table(
+        "bw",
+        Arc::new(BigWigTableProvider::new(path.clone(), true)?),
+    )?;
+    let expected = serial
+        .sql("SELECT chrom, start, \"end\", value FROM bw ORDER BY chrom, start")
+        .await?
+        .collect()
+        .await?;
+
+    let parallel = context_with_partitions(4);
+    parallel.register_table("bw", Arc::new(BigWigTableProvider::new(path, true)?))?;
+    let count = parallel.sql("SELECT count(*) FROM bw").await?;
+    let count_plan = count.create_physical_plan().await?;
+    let leaf = find_leaf_exec(&count_plan);
+    assert_eq!(leaf.name(), "BigWigExec");
+    assert_eq!(leaf.properties().output_partitioning().partition_count(), 4);
+    let count_plan_text = DisplayableExecutionPlan::new(count_plan.as_ref())
+        .indent(false)
+        .to_string();
+    assert!(
+        !count_plan_text.contains("RepartitionExec"),
+        "BBI source partitions should make a round-robin repartition unnecessary:\n{count_plan_text}"
+    );
+    assert!(
+        count_plan_text.contains("estimated_compressed_bytes=["),
+        "BigWig plan should expose index-derived partition work:\n{count_plan_text}"
+    );
+
+    let actual = parallel
+        .sql("SELECT chrom, start, \"end\", value FROM bw ORDER BY chrom, start")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        pretty_format_batches(&actual)?.to_string(),
+        pretty_format_batches(&expected)?.to_string()
+    );
+    assert_eq!(actual.iter().map(RecordBatch::num_rows).sum::<usize>(), 4);
+
+    let filtered_plan = parallel
+        .sql("SELECT count(*) FROM bw WHERE chrom = 'chr1'")
+        .await?
+        .create_physical_plan()
+        .await?;
+    assert_eq!(
+        find_leaf_exec(&filtered_plan)
+            .properties()
+            .output_partitioning()
+            .partition_count(),
+        1,
+        "a single selected chromosome should not fan out"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn bigbed_full_scan_uses_target_partitions_without_duplicates() -> TestResult<()> {
+    let fixture = write_partition_bigbed_fixture()?;
+    let path = fixture.path().to_string_lossy().to_string();
+
+    let serial = context_with_partitions(1);
+    serial.register_table(
+        "bb",
+        Arc::new(BigBedTableProvider::new(
+            path.clone(),
+            true,
+            BigBedSchemaMode::Auto,
+        )?),
+    )?;
+    let expected = serial
+        .sql("SELECT chrom, start, \"end\", name, score FROM bb ORDER BY chrom, start")
+        .await?
+        .collect()
+        .await?;
+
+    let parallel = context_with_partitions(4);
+    parallel.register_table(
+        "bb",
+        Arc::new(BigBedTableProvider::new(
+            path,
+            true,
+            BigBedSchemaMode::Auto,
+        )?),
+    )?;
+    let count = parallel.sql("SELECT count(*) FROM bb").await?;
+    let count_plan = count.create_physical_plan().await?;
+    let leaf = find_leaf_exec(&count_plan);
+    assert_eq!(leaf.name(), "BigBedExec");
+    assert_eq!(leaf.properties().output_partitioning().partition_count(), 4);
+    let count_plan_text = DisplayableExecutionPlan::new(count_plan.as_ref())
+        .indent(false)
+        .to_string();
+    assert!(
+        !count_plan_text.contains("RepartitionExec"),
+        "BBI source partitions should make a round-robin repartition unnecessary:\n{count_plan_text}"
+    );
+    assert!(
+        count_plan_text.contains("estimated_compressed_bytes=["),
+        "BigBed plan should expose index-derived partition work:\n{count_plan_text}"
+    );
+
+    let actual = parallel
+        .sql("SELECT chrom, start, \"end\", name, score FROM bb ORDER BY chrom, start")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        pretty_format_batches(&actual)?.to_string(),
+        pretty_format_batches(&expected)?.to_string()
+    );
+    assert_eq!(actual.iter().map(RecordBatch::num_rows).sum::<usize>(), 4);
+
+    let filtered_plan = parallel
+        .sql("SELECT count(*) FROM bb WHERE chrom = 'chr1'")
+        .await?
+        .create_physical_plan()
+        .await?;
+    assert_eq!(
+        find_leaf_exec(&filtered_plan)
+            .properties()
+            .output_partitioning()
+            .partition_count(),
+        1,
+        "a single selected chromosome should not fan out"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn bbi_full_scan_partition_count_tracks_every_target_from_one_to_eight() -> TestResult<()> {
+    let bigwig = write_partition_bigwig_fixture()?;
+    let bigbed = write_partition_bigbed_fixture()?;
+
+    for target in 1..=8 {
+        let context = context_with_partitions(target);
+        context.register_table(
+            "bw",
+            Arc::new(BigWigTableProvider::new(
+                bigwig.path().to_string_lossy().to_string(),
+                true,
+            )?),
+        )?;
+        context.register_table(
+            "bb",
+            Arc::new(BigBedTableProvider::new(
+                bigbed.path().to_string_lossy().to_string(),
+                true,
+                BigBedSchemaMode::Auto,
+            )?),
+        )?;
+
+        for table in ["bw", "bb"] {
+            let plan = context
+                .sql(&format!("SELECT count(*) FROM {table}"))
+                .await?
+                .create_physical_plan()
+                .await?;
+            let leaf = find_leaf_exec(&plan);
+            assert_eq!(
+                leaf.properties().output_partitioning().partition_count(),
+                target,
+                "{table} did not honor target_partitions={target}"
+            );
+            let plan_text = DisplayableExecutionPlan::new(plan.as_ref())
+                .indent(false)
+                .to_string();
+            assert!(
+                !plan_text.contains("RepartitionExec"),
+                "{table} target_partitions={target} unexpectedly repartitioned:\n{plan_text}"
+            );
+        }
+    }
     Ok(())
 }

--- a/datafusion/bio-format-bbi/tests/provider_test.rs
+++ b/datafusion/bio-format-bbi/tests/provider_test.rs
@@ -545,6 +545,18 @@ async fn unfiltered_single_chromosome_scan_can_split_but_filtered_scan_stays_ser
         1,
         "an explicitly selected chromosome should not fan out"
     );
+
+    let residual_plan = table
+        .scan(&ctx.state(), None, &[col("end").gt(lit(0u32))], None)
+        .await?;
+    assert_eq!(
+        residual_plan
+            .properties()
+            .output_partitioning()
+            .partition_count(),
+        4,
+        "a residual coordinate predicate should not disable full-file parallelism"
+    );
     Ok(())
 }
 

--- a/openspec/changes/add-parallel-bbi-scans/design.md
+++ b/openspec/changes/add-parallel-bbi-scans/design.md
@@ -1,0 +1,91 @@
+## Context
+
+The BBI providers already enumerate genomic regions and use the file's embedded
+chromosome and cir-tree indexes. Their execution plans nevertheless report one
+partition and ignore the partition passed to `execute`. Whole-genome BigWig
+files are commonly dominated by one or two chromosomes, so assigning whole
+chromosomes by length leaves large stragglers.
+
+BigTools can traverse the primary cir-tree without reading or decompressing
+payload blocks. Its block coordinates and compressed sizes provide a cheap,
+format-native estimate of actual scan work.
+
+## Goals / Non-Goals
+
+- Goals:
+  - expose up to the requested number of source partitions for whole-file BBI
+    scans;
+  - balance compressed work, including files with one dominant chromosome;
+  - preserve identical rows and coordinates at every partition count;
+  - retain streaming, bounded-memory execution and projection pushdown.
+- Non-Goals:
+  - guarantee output ordering across partitions;
+  - parallelize a deliberately narrow single-region lookup;
+  - optimize the downstream DataFusion-to-Polars Python bridge.
+
+## Decisions
+
+### Read block layout during provider construction
+
+The provider reads the primary cir-tree leaf layout once and stores normalized
+chromosome-local work units. This adds bounded index I/O to construction but no
+payload reads or decompression, and it avoids reparsing the layout for every
+scan.
+
+### Balance using compressed block work
+
+The existing core partition balancer receives each selected region's compressed
+byte total plus observed block positions. It may split a dominant region at
+block-informed coordinate boundaries, then assigns the resulting regions to the
+requested partitions.
+
+### Separate query windows from row ownership
+
+Adjacent independent interval queries can both return a boundary-overlapping
+record. Each shard therefore carries an inclusive ownership start and exclusive
+ownership end for original record starts.
+
+BigBed returns original record coordinates, so shards query their coordinate
+window directly. BigWig clips intervals to query boundaries, so non-first
+shards query one base earlier and retain the original upper query bound while
+ownership filters remove overlap. This preserves original coordinates and
+prevents duplicates.
+
+### Avoid fan-out for narrow lookups
+
+A scan selecting one explicit genomic region remains one partition. Whole-file
+scans may split even when the file contains only one chromosome; multi-region
+scans may also split a dominant chromosome.
+
+### Keep decoded batches bounded
+
+Decoded projections retain the existing 8,192-row batch bound. Empty projections
+carry only a logical row count and use a larger bound to reduce scheduler
+overhead without allocating value buffers.
+
+## Risks / Trade-offs
+
+- Boundary ownership mistakes could duplicate, omit, or clip rows. Tests compare
+  complete sorted content and row counts across partition counts and filtered
+  scans.
+- Independent shards can read a compressed block on both sides of a boundary.
+  Plan diagnostics retain this conservative duplication in per-partition byte
+  estimates.
+- Provider construction performs extra cir-tree index I/O. The layout is cached
+  on the provider, and the benchmark records end-to-end construction separately
+  from source execution.
+- Downstream consumers may still scale below the provider because Python batch
+  conversion, aggregation, or full DataFrame materialization is outside this
+  change.
+
+## Migration Plan
+
+1. Merge and release the BigTools block-layout API.
+2. Replace the temporary git revision with the released crate version.
+3. Merge the provider change and release datafusion-bio-formats.
+4. Bump polars-bio and update its BBI parallel-scan capability documentation.
+
+## Open Questions
+
+- Whether decoded BBI batch size should become adaptive belongs to a separate
+  downstream/materialization optimization.

--- a/openspec/changes/add-parallel-bbi-scans/design.md
+++ b/openspec/changes/add-parallel-bbi-scans/design.md
@@ -53,9 +53,10 @@ prevents duplicates.
 
 ### Avoid fan-out for narrow lookups
 
-A scan selecting one explicit genomic region remains one partition. Whole-file
-scans may split even when the file contains only one chromosome; multi-region
-scans may also split a dominant chromosome.
+A scan selecting one explicit index region remains one partition. Residual
+coordinate-column predicates that do not produce an index region retain
+whole-file partitioning. Whole-file scans may split even when the file contains
+only one chromosome; multi-region scans may also split a dominant chromosome.
 
 ### Keep decoded batches bounded
 

--- a/openspec/changes/add-parallel-bbi-scans/design.md
+++ b/openspec/changes/add-parallel-bbi-scans/design.md
@@ -35,10 +35,13 @@ provider construction succeeds and scanning falls back to one source partition.
 
 ### Balance using encoded block work
 
-A BBI-specific linear partitioner groups blocks by start coordinate and places
-cuts using cumulative encoded byte weights. It never cuts below an observed
-block boundary, so the useful source-partition count may be lower than the
-requested target when a file contains fewer independently readable blocks.
+A BBI-specific partitioner groups coordinate-overlapping blocks into indivisible
+components and places cuts between components using cumulative encoded byte
+weights. Prefix construction is linear in the selected blocks and each cut uses
+a binary search. A long block therefore cannot be reread by several shards just
+because later blocks start inside it, and the useful source-partition count may
+be lower than requested when a file contains fewer independently readable
+components.
 
 ### Separate query windows from row ownership
 
@@ -70,9 +73,9 @@ overhead without allocating value buffers.
 - Boundary ownership mistakes could duplicate, omit, or clip rows. Tests compare
   complete sorted content and row counts across partition counts and filtered
   scans.
-- Independent shards can read a payload block on both sides of a boundary.
-  Plan diagnostics retain this conservative duplication in per-partition byte
-  estimates.
+- BigTools' inclusive cir-tree lookup can read the touching edge block on both
+  sides of a component boundary. This duplication is limited to neighboring
+  shards; plan diagnostics retain it in per-partition byte estimates.
 - Provider construction performs extra cir-tree index I/O. The layout is cached
   on the provider, the benchmark includes construction in end-to-end timing,
   and limit exhaustion falls back to the pre-existing serial scan path.

--- a/openspec/changes/add-parallel-bbi-scans/design.md
+++ b/openspec/changes/add-parallel-bbi-scans/design.md
@@ -27,17 +27,18 @@ format-native estimate of actual scan work.
 
 ### Read block layout during provider construction
 
-The provider reads the primary cir-tree leaf layout once and stores normalized
-chromosome-local work units. This adds bounded index I/O to construction but no
-payload reads or decompression, and it avoids reparsing the layout for every
-scan.
+The provider reads the primary cir-tree leaf layout once and stores normalized,
+chromosome-indexed work units. This adds bounded index I/O to construction but
+no payload reads or decompression, and it avoids reparsing the layout for every
+scan. If a valid file exceeds BigTools' safety limits for complete traversal,
+provider construction succeeds and scanning falls back to one source partition.
 
 ### Balance using encoded block work
 
-The existing core partition balancer receives each selected region's encoded
-byte total plus observed block positions. It may split a dominant region at
-block-informed coordinate boundaries, then assigns the resulting regions to the
-requested partitions.
+A BBI-specific linear partitioner groups blocks by start coordinate and places
+cuts using cumulative encoded byte weights. It never cuts below an observed
+block boundary, so the useful source-partition count may be lower than the
+requested target when a file contains fewer independently readable blocks.
 
 ### Separate query windows from row ownership
 
@@ -45,11 +46,11 @@ Adjacent independent interval queries can both return a boundary-overlapping
 record. Each shard therefore carries an inclusive ownership start and exclusive
 ownership end for original record starts.
 
-BigBed returns original record coordinates, so shards query their coordinate
-window directly. BigWig clips intervals to query boundaries, so non-first
-shards query one base earlier and retain the original upper query bound while
-ownership filters remove overlap. This preserves original coordinates and
-prevents duplicates.
+BigBed returns original record coordinates. BigWig uses BigTools' bounded
+unclipped interval API. Both therefore query only their shard coordinate window;
+ownership filters remove overlap returned at a non-first shard's lower edge.
+This preserves original coordinates, prevents duplicates, and avoids building a
+suffix block list for every BigWig shard.
 
 ### Avoid fan-out for narrow lookups
 
@@ -73,8 +74,8 @@ overhead without allocating value buffers.
   Plan diagnostics retain this conservative duplication in per-partition byte
   estimates.
 - Provider construction performs extra cir-tree index I/O. The layout is cached
-  on the provider, and the benchmark records end-to-end construction separately
-  from source execution.
+  on the provider, the benchmark includes construction in end-to-end timing,
+  and limit exhaustion falls back to the pre-existing serial scan path.
 - Downstream consumers may still scale below the provider because Python batch
   conversion, aggregation, or full DataFrame materialization is outside this
   change.

--- a/openspec/changes/add-parallel-bbi-scans/design.md
+++ b/openspec/changes/add-parallel-bbi-scans/design.md
@@ -7,7 +7,7 @@ files are commonly dominated by one or two chromosomes, so assigning whole
 chromosomes by length leaves large stragglers.
 
 BigTools can traverse the primary cir-tree without reading or decompressing
-payload blocks. Its block coordinates and compressed sizes provide a cheap,
+payload blocks. Its block coordinates and encoded on-disk sizes provide a cheap,
 format-native estimate of actual scan work.
 
 ## Goals / Non-Goals
@@ -32,9 +32,9 @@ chromosome-local work units. This adds bounded index I/O to construction but no
 payload reads or decompression, and it avoids reparsing the layout for every
 scan.
 
-### Balance using compressed block work
+### Balance using encoded block work
 
-The existing core partition balancer receives each selected region's compressed
+The existing core partition balancer receives each selected region's encoded
 byte total plus observed block positions. It may split a dominant region at
 block-informed coordinate boundaries, then assigns the resulting regions to the
 requested partitions.
@@ -68,7 +68,7 @@ overhead without allocating value buffers.
 - Boundary ownership mistakes could duplicate, omit, or clip rows. Tests compare
   complete sorted content and row counts across partition counts and filtered
   scans.
-- Independent shards can read a compressed block on both sides of a boundary.
+- Independent shards can read a payload block on both sides of a boundary.
   Plan diagnostics retain this conservative duplication in per-partition byte
   estimates.
 - Provider construction performs extra cir-tree index I/O. The layout is cached

--- a/openspec/changes/add-parallel-bbi-scans/design.md
+++ b/openspec/changes/add-parallel-bbi-scans/design.md
@@ -15,7 +15,7 @@ format-native estimate of actual scan work.
 - Goals:
   - expose up to the requested number of source partitions for whole-file BBI
     scans;
-  - balance compressed work, including files with one dominant chromosome;
+  - balance encoded on-disk work, including files with one dominant chromosome;
   - preserve identical rows and coordinates at every partition count;
   - retain streaming, bounded-memory execution and projection pushdown.
 - Non-Goals:

--- a/openspec/changes/add-parallel-bbi-scans/proposal.md
+++ b/openspec/changes/add-parallel-bbi-scans/proposal.md
@@ -9,7 +9,7 @@ parallelize index traversal, decompression, or decoding at the source.
 - Partition whole-file BigWig and BigBed scans according to the configured
   DataFusion target partition count.
 - Weight and split scan regions using primary cir-tree block coordinates and
-  compressed sizes rather than chromosome length alone.
+  encoded on-disk sizes rather than chromosome length alone.
 - Preserve exact row ownership across independently queried shard boundaries,
   including BigWig's coordinate-clipping behavior.
 - Keep narrow single-region queries serial while allowing unfiltered

--- a/openspec/changes/add-parallel-bbi-scans/proposal.md
+++ b/openspec/changes/add-parallel-bbi-scans/proposal.md
@@ -10,8 +10,8 @@ parallelize index traversal, decompression, or decoding at the source.
   DataFusion target partition count.
 - Weight and split scan regions using primary cir-tree block coordinates and
   encoded on-disk sizes rather than chromosome length alone.
-- Preserve exact row ownership across independently queried shard boundaries,
-  including BigWig's coordinate-clipping behavior.
+- Preserve exact row ownership and original coordinates across independently
+  queried shard boundaries with bounded, unclipped BigWig reads.
 - Keep narrow single-region queries serial while allowing unfiltered
   single-chromosome files to use multiple partitions.
 - Add plan diagnostics, correctness coverage, and a source-partition profiling

--- a/openspec/changes/add-parallel-bbi-scans/proposal.md
+++ b/openspec/changes/add-parallel-bbi-scans/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+BigWig and BigBed are the only indexed format providers that always advertise a
+single physical partition. DataFusion can redistribute their output but cannot
+parallelize index traversal, decompression, or decoding at the source.
+
+## What Changes
+
+- Partition whole-file BigWig and BigBed scans according to the configured
+  DataFusion target partition count.
+- Weight and split scan regions using primary cir-tree block coordinates and
+  compressed sizes rather than chromosome length alone.
+- Preserve exact row ownership across independently queried shard boundaries,
+  including BigWig's coordinate-clipping behavior.
+- Keep narrow single-region queries serial while allowing unfiltered
+  single-chromosome files to use multiple partitions.
+- Add plan diagnostics, correctness coverage, and a source-partition profiling
+  example for count and decoded-column workloads.
+
+## Impact
+
+- Affected specs: `bbi-parallel-scan` (new)
+- Affected code: `datafusion/bio-format-bbi`
+- Dependency: a pinned BigTools revision exposes read-only primary cir-tree
+  block layout metadata; replace the revision with a released version after
+  upstream publication.

--- a/openspec/changes/add-parallel-bbi-scans/proposal.md
+++ b/openspec/changes/add-parallel-bbi-scans/proposal.md
@@ -19,7 +19,7 @@ parallelize index traversal, decompression, or decoding at the source.
 
 ## Impact
 
-- Affected specs: `bbi-parallel-scan` (new)
+- Affected specs: `bbi-parallel-scan` (new), `dependencies` (modified)
 - Affected code: `datafusion/bio-format-bbi`
 - Dependency: a pinned BigTools revision exposes read-only primary cir-tree
   block layout metadata; replace the revision with a released version after

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -21,6 +21,21 @@ cir-tree layout.
 - **AND** assignments are balanced by estimated on-disk data bytes rather than by
   region count alone
 
+#### Scenario: Fewer useful blocks than requested partitions
+
+- **WHEN** a scan requests more partitions than there are distinct primary-data
+  block-start segments
+- **THEN** the source reports fewer than the requested partitions
+- **AND** no two partitions are created solely to decode the same indivisible
+  block
+
+#### Scenario: Layout traversal reaches its safety limit
+
+- **WHEN** a valid BBI file exceeds the configured complete-index traversal
+  safety limit
+- **THEN** provider construction succeeds
+- **AND** the scan falls back to one source partition
+
 #### Scenario: Narrow filtered scan
 
 - **WHEN** a scan explicitly selects one genomic region

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -27,6 +27,13 @@ cir-tree layout.
 - **THEN** the provider uses one source partition instead of opening multiple
   independent readers for the narrow lookup
 
+#### Scenario: Residual coordinate predicate
+
+- **WHEN** a coordinate-column predicate cannot be converted into an explicit
+  indexed region
+- **THEN** the predicate does not disable source parallelism for the remaining
+  whole-file scan
+
 ### Requirement: Partition-invariant BBI content
 
 Parallel BBI scans MUST emit the same records and original coordinates as the

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -14,7 +14,7 @@ cir-tree layout.
 
 #### Scenario: One chromosome dominates encoded work
 
-- **WHEN** a whole-file scan contains one region whose compressed block work
+- **WHEN** a whole-file scan contains one region whose encoded block work
   dominates the other selected regions
 - **THEN** the planner MAY split that region at block-informed coordinate
   boundaries

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -18,7 +18,7 @@ cir-tree layout.
   dominates the other selected regions
 - **THEN** the planner MAY split that region at block-informed coordinate
   boundaries
-- **AND** assignments are balanced by estimated compressed bytes rather than by
+- **AND** assignments are balanced by estimated on-disk data bytes rather than by
   region count alone
 
 #### Scenario: Narrow filtered scan
@@ -70,4 +70,4 @@ without reading result batches.
 
 - **WHEN** a caller inspects a BigWig or BigBed execution plan
 - **THEN** the plan reports its source partition count
-- **AND** it reports the estimated compressed bytes assigned to each partition
+- **AND** it reports the estimated data bytes assigned to each partition

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -76,6 +76,8 @@ batch construction.
 
 - **WHEN** DataFusion requests an empty BBI projection for `count(*)`
 - **THEN** batches represent logical row counts without allocating value arrays
+- **AND** batch row counts remain bounded independently of chromosome size so
+  consumers can cancel or satisfy a limit without decoding the entire region
 
 #### Scenario: Decoded projection
 

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -21,13 +21,13 @@ cir-tree layout.
 - **AND** assignments are balanced by estimated on-disk data bytes rather than by
   region count alone
 
-#### Scenario: Fewer useful blocks than requested partitions
+#### Scenario: Fewer independently readable components than requested partitions
 
-- **WHEN** a scan requests more partitions than there are distinct primary-data
-  block-start segments
+- **WHEN** a scan requests more partitions than there are coordinate-overlap
+  connected primary-data block components
 - **THEN** the source reports fewer than the requested partitions
-- **AND** no two partitions are created solely to decode the same indivisible
-  block
+- **AND** no cut is placed through a component solely to reach the requested
+  count
 
 #### Scenario: Layout traversal reaches its safety limit
 

--- a/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/bbi-parallel-scan/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Partitioned whole-file BBI scans
+
+The BigWig and BigBed providers SHALL expose source partitions derived from the
+configured DataFusion target partition count and the file's embedded primary
+cir-tree layout.
+
+#### Scenario: Whole-file scan requests parallelism
+
+- **WHEN** an unfiltered BigWig or BigBed scan requests `N` target partitions
+- **THEN** the physical BBI source reports up to `N` non-empty partitions
+- **AND** each execution partition reads only its assigned regions
+
+#### Scenario: One chromosome dominates encoded work
+
+- **WHEN** a whole-file scan contains one region whose compressed block work
+  dominates the other selected regions
+- **THEN** the planner MAY split that region at block-informed coordinate
+  boundaries
+- **AND** assignments are balanced by estimated compressed bytes rather than by
+  region count alone
+
+#### Scenario: Narrow filtered scan
+
+- **WHEN** a scan explicitly selects one genomic region
+- **THEN** the provider uses one source partition instead of opening multiple
+  independent readers for the narrow lookup
+
+### Requirement: Partition-invariant BBI content
+
+Parallel BBI scans MUST emit the same records and original coordinates as the
+equivalent one-partition scan, independent of cross-partition ordering.
+
+#### Scenario: Record overlaps an internal shard boundary
+
+- **WHEN** independent shard queries both encounter a record overlapping their
+  shared coordinate boundary
+- **THEN** exactly one shard emits that record according to start-coordinate
+  ownership
+- **AND** its start and end coordinates equal the one-partition result
+
+#### Scenario: Empty selection
+
+- **WHEN** pushed-down genomic filters select no valid BBI regions
+- **THEN** the scan completes with zero rows and a valid physical execution plan
+
+### Requirement: Bounded streaming projections
+
+Partitioned BBI execution MUST preserve projection pushdown and bounded streaming
+batch construction.
+
+#### Scenario: Empty projection count
+
+- **WHEN** DataFusion requests an empty BBI projection for `count(*)`
+- **THEN** batches represent logical row counts without allocating value arrays
+
+#### Scenario: Decoded projection
+
+- **WHEN** DataFusion requests one or more BBI columns
+- **THEN** every emitted record batch contains only the projected fields
+- **AND** no execution partition buffers an entire chromosome
+
+### Requirement: Partition diagnostics
+
+The physical BBI plan SHALL expose enough metadata to verify partition planning
+without reading result batches.
+
+#### Scenario: Inspect physical plan
+
+- **WHEN** a caller inspects a BigWig or BigBed execution plan
+- **THEN** the plan reports its source partition count
+- **AND** it reports the estimated compressed bytes assigned to each partition

--- a/openspec/changes/add-parallel-bbi-scans/specs/dependencies/spec.md
+++ b/openspec/changes/add-parallel-bbi-scans/specs/dependencies/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Git Dependency Documentation
+
+The project MUST document all git-based dependencies for transparency and user guidance.
+
+#### Scenario: Noodles fork dependencies
+
+- **WHEN** examining workspace dependencies
+- **THEN** noodles-cram, noodles-sam, and noodles-fasta use git = "https://github.com/biodatageeks/noodles.git"
+- **AND** the rationale for using the fork MUST be documented in affected crate READMEs
+- **AND** the documentation MUST explain what functionality the fork provides
+- **AND** the documentation SHOULD mention the specific git revision being used
+
+#### Scenario: BigTools fork dependency
+
+- **WHEN** examining the `datafusion-bio-format-bbi` dependencies
+- **THEN** BigTools uses git = "https://github.com/biodatageeks/bigtools.git"
+- **AND** the BBI crate README MUST document the block-layout and bounded-query functionality supplied by the fork
+- **AND** the documentation MUST identify the pinned revision and the upstream migration path
+
+#### Scenario: User transparency
+
+- **WHEN** users install crates with git dependencies
+- **THEN** Cargo will automatically fetch the git dependencies during build
+- **AND** users MUST have git installed and network access
+- **AND** this is standard behavior in the Rust ecosystem
+- **AND** the README MUST note this requirement

--- a/openspec/changes/add-parallel-bbi-scans/tasks.md
+++ b/openspec/changes/add-parallel-bbi-scans/tasks.md
@@ -1,0 +1,23 @@
+## 1. Upstream metadata API
+
+- [x] 1.1 Expose chromosome IDs and primary cir-tree block layout from BigTools.
+- [x] 1.2 Cover BigWig and BigBed layout metadata with fixture tests.
+
+## 2. Partition planning
+
+- [x] 2.1 Normalize cir-tree blocks into chromosome-local compressed-work units.
+- [x] 2.2 Balance selected regions using target partitions and block positions.
+- [x] 2.3 Preserve boundary row ownership and unclipped coordinates.
+- [x] 2.4 Advertise and execute the planned source partitions.
+
+## 3. Correctness and diagnostics
+
+- [x] 3.1 Verify row counts and complete content across partition counts.
+- [x] 3.2 Verify filtered, empty, one-chromosome, and skewed-region behavior.
+- [x] 3.3 Report partition count and estimated compressed bytes in physical plans.
+- [x] 3.4 Add a source-stage partition profiling example.
+
+## 4. Verification
+
+- [x] 4.1 Run formatting, crate tests, clippy, and strict OpenSpec validation.
+- [ ] 4.2 Record whole-file t=1 through t=8 benchmark evidence downstream.

--- a/openspec/changes/add-parallel-bbi-scans/tasks.md
+++ b/openspec/changes/add-parallel-bbi-scans/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Partition planning
 
-- [x] 2.1 Normalize cir-tree blocks into chromosome-local compressed-work units.
+- [x] 2.1 Normalize cir-tree blocks into chromosome-local encoded-work units.
 - [x] 2.2 Balance selected regions using target partitions and block positions.
 - [x] 2.3 Preserve boundary row ownership and unclipped coordinates.
 - [x] 2.4 Advertise and execute the planned source partitions.
@@ -14,7 +14,7 @@
 
 - [x] 3.1 Verify row counts and complete content across partition counts.
 - [x] 3.2 Verify filtered, empty, one-chromosome, and skewed-region behavior.
-- [x] 3.3 Report partition count and estimated compressed bytes in physical plans.
+- [x] 3.3 Report partition count and estimated data bytes in physical plans.
 - [x] 3.4 Add a source-stage partition profiling example.
 
 ## 4. Verification

--- a/openspec/changes/add-parallel-bbi-scans/tasks.md
+++ b/openspec/changes/add-parallel-bbi-scans/tasks.md
@@ -20,4 +20,5 @@
 ## 4. Verification
 
 - [x] 4.1 Run formatting, crate tests, clippy, and strict OpenSpec validation.
-- [ ] 4.2 Record whole-file t=1 through t=8 benchmark evidence downstream.
+- [x] 4.2 Record whole-file t=1 through t=8 benchmark evidence downstream
+  (`bioformats-benchmark/results/bbi_scaling_full_scan.json`).


### PR DESCRIPTION
## Summary

- plan BigWig and BigBed source partitions from primary cir-tree block positions and encoded on-disk sizes
- enforce boundary ownership so independent readers return every row exactly once without clipping coordinates
- advertise physical partition counts and estimated encoded data bytes in execution plans
- add correctness, skew, filtering, empty-scan, plan-diagnostic, and partition-profiling coverage

## Scalability

The downstream five-round t=1–8 sweep consumes all columns and verifies identical content at every partition count.

- BigWig Arrow all-column stream: 2.7302 s at t=1 to 0.4073 s at t=8, 6.70x
- BigBed Arrow all-column stream: 0.0824 s at t=1 to 0.0111 s at t=8, 7.45x
- literal Polars all-column collect is measured separately: 2.08x at t=8 for BigWig and 4.11x for BigBed; retained chunk amplification explains the downstream plateau

## Stack

- benchmark and raw evidence: biodatageeks/bioformats-benchmark#5
- upstream block-layout API: jackh726/bigtools#106

Cargo is pinned to the reviewed BigTools fork commit until the upstream change is merged.

## Verification

- cargo test --locked -p datafusion-bio-format-bbi
- cargo clippy --locked -p datafusion-bio-format-bbi --all-targets -- -D warnings
- cargo fmt --all -- --check
- openspec validate add-parallel-bbi-scans --strict
- downstream five-round t=1–8 content and physical-partition verification

Closes #238